### PR TITLE
Update ZipFile.cs to correct the zip specification version.

### DIFF
--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -1023,7 +1023,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					throw new ZipException(string.Format("Wrong local header signature @{0:X}", offsetOfFirstEntry + entry.Offset));
 				}
 
-				short extractVersion = ( short )ReadLEUshort() & 0x00ff;
+				short extractVersion = ( short ) (ReadLEUshort() & 0x00ff);
 				short localFlags = ( short )ReadLEUshort();
 				short compressionMethod = ( short )ReadLEUshort();
 				short fileTime = ( short )ReadLEUshort();

--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -1023,7 +1023,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					throw new ZipException(string.Format("Wrong local header signature @{0:X}", offsetOfFirstEntry + entry.Offset));
 				}
 
-				short extractVersion = ( short )ReadLEUshort();
+				short extractVersion = ( short )ReadLEUshort() & 0x00ff;
 				short localFlags = ( short )ReadLEUshort();
 				short compressionMethod = ( short )ReadLEUshort();
 				short fileTime = ( short )ReadLEUshort();


### PR DESCRIPTION
Correct the zip specification version by only checking the lower bits; otherwise it will fail to unzip some zipped files via FastZip.ExtractZip.