### PR TITLE
Allow the project file to be added to a VS 2013 solution

### DIFF
--- a/src/ICSharpCode.SharpZLib.csproj
+++ b/src/ICSharpCode.SharpZLib.csproj
@@ -1,4 +1,4 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" xmlns:Conversion="urn:Conversion">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" xmlns:Conversion="urn:Conversion" ToolsVersion="2.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>


### PR DESCRIPTION
When attempting to use ICSharpCode.SharpZLib.csproj as part of a VS 2013 solution, an error occurs informing you that a one-way upgrade is required for compatibility.  Adding the ToolsVersion property to the project file allows the project to be added to more recent VS solutions in a way that shouldn't break existing builds or solutions.