### PR TITLE
Don't ignore Link entry type.

### DIFF
--- a/src/Tar/TarInputStream.cs
+++ b/src/Tar/TarInputStream.cs
@@ -493,7 +493,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 						headerBuf = this.tarBuffer.ReadBlock();
 					} else if (header.TypeFlag != TarHeader.LF_NORMAL && 
 							   header.TypeFlag != TarHeader.LF_OLDNORM &&
-							   header.TypeFlag != TarHeader.LF_DIR) {
+							   header.TypeFlag != TarHeader.LF_DIR &&
+							   header.TypeFlag != TarHeader.LFLINK) {
 						// Ignore things we dont understand completely for now
 						SkipToNextEntry();
 						headerBuf = tarBuffer.ReadBlock();


### PR DESCRIPTION
There is no reason to ignore this kind of entry as TarHeader.LinkName is correctly filled. It's up to the user to handle it correctly.
