### PR TITLE
Ignore link entries in the default Tar extractor

### DIFF
--- a/src/Tar/TarArchive.cs
+++ b/src/Tar/TarArchive.cs
@@ -537,6 +537,9 @@ namespace ICSharpCode.SharpZipLib.Tar
 				if (entry == null) {
 					break;
 				}
+
+				if (entry.TarHeader.TypeFlag == TarHeader.LF_LINK)
+					continue;
 				
 				ExtractEntry(destinationDirectory, entry);
 			}


### PR DESCRIPTION
Related to #70 and #71.
