### PR TITLE
Closes #41 - Do not fail when local header compressed size equals to 0

### DIFF
--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -1258,7 +1258,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 					}
 
 					if (compressedSize != entry.CompressedSize &&
-						compressedSize != 0xFFFFFFFF && compressedSize != -1) {
+						compressedSize != 0xFFFFFFFF && compressedSize != -1 &&
+						compressedSize != 0) {
 						throw new ZipException(
 							string.Format("Compressed size mismatch between central header({0}) and local header({1})",
 							entry.CompressedSize, compressedSize));


### PR DESCRIPTION
As extracting some "valid" ZIP files was not possible...

Example ZIP file failing before the fix:
http://www.cmake.org/files/v3.2/cmake-3.2.2-win32-x86.zip

Also related to:
* https://github.com/icsharpcode/SharpZipLib/issues/41
* http://community.sharpdevelop.net/forums/t/12404.aspx