### PR TITLE
Fix tar long names

### DIFF
--- a/src/Tar/TarHeader.cs
+++ b/src/Tar/TarHeader.cs
@@ -896,7 +896,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			int i;
 			
-			for (i = 0 ; i < length - 1 && nameOffset + i < name.Length; ++i) {
+			for (i = 0 ; i < length && nameOffset + i < name.Length; ++i) {
 				buffer[bufferOffset + i] = (byte)name[nameOffset + i];
 			}
 			

--- a/src/Tar/TarOutputStream.cs
+++ b/src/Tar/TarOutputStream.cs
@@ -278,7 +278,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				throw new ArgumentNullException("entry");
 			}
 
-			if (entry.TarHeader.Name.Length >= TarHeader.NAMELEN) {
+			if (entry.TarHeader.Name.Length > TarHeader.NAMELEN) {
 				TarHeader longHeader = new TarHeader();
 				longHeader.TypeFlag = TarHeader.LF_GNU_LONGNAME;
 				longHeader.Name = longHeader.Name + "././@LongLink";

--- a/src/Tar/TarOutputStream.cs
+++ b/src/Tar/TarOutputStream.cs
@@ -282,10 +282,11 @@ namespace ICSharpCode.SharpZipLib.Tar
 				TarHeader longHeader = new TarHeader();
 				longHeader.TypeFlag = TarHeader.LF_GNU_LONGNAME;
 				longHeader.Name = longHeader.Name + "././@LongLink";
-				longHeader.UserId = 0;
-				longHeader.GroupId = 0;
-				longHeader.GroupName = "";
-				longHeader.UserName = "";
+				longHeader.Mode = 420;//644 by default
+				longHeader.UserId = entry.UserId;
+				longHeader.GroupId = entry.GroupId;
+				longHeader.GroupName = entry.GroupName;
+				longHeader.UserName = entry.UserName;
 				longHeader.LinkName = "";
                 longHeader.Size = entry.TarHeader.Name.Length + 1;	// Plus one to avoid dropping last char
 


### PR DESCRIPTION
Was using the library to generate debian packages which use Tar inside. Files with names longer than 100 symbols were preventing the package from installing - dpkg couldn't copy the files with the long names. Looking at the specification and Tars generated on Linux with default tools I found several bugs:
- Ustar format supports names up to 100 symbols. That is, if a name is exactly 100 symbols you don't need to write terminating symbol. SharpZipLib truncates names to 99 symbols
- "@LongLink" should have default 644 mode. SharpZipLib doesn't specify it
- "@LongLink" should have user ID, user name, group ID and group name from the entry it belongs to. SharpZipLib doesn't specify them