### PR TITLE
Update ZipFile.cs

### DIFF
--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -1542,6 +1542,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 			contentsEdited_ = true;
 
 			int index = FindExistingUpdate(update.Entry.Name);
+			
+			// FindExistingUpdate returns One based index, so adjusting it by decrementing one so that index can work with Generic List updates_
+			if (index != 0) index--;
 
 			if (index >= 0) {
 				if ( updates_[index] == null ) {


### PR DESCRIPTION
AddUpdate method previously had index which was adjusted by -1 so, that it could with with updates_ generic list.
For some reason, -1 adjustment was removed in the latest code which was causing index out of bound error.

FindExistingUpdate method returns the one based index whereas updates_ generic list is zero based, so adjusting "index" by -1 is necessary.
