### PR TITLE
Copyright & Licensing

### DIFF
--- a/doc/COPYING.txt
+++ b/doc/COPYING.txt
@@ -2,7 +2,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -305,7 +305,7 @@ the "copyright" line and a pointer to where the full notice is found.
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 Also add information on how to contact you by electronic and paper mail.

--- a/samples/DIME/DimeDataSetService/AssemblyInfo.cs
+++ b/samples/DIME/DimeDataSetService/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]		
 

--- a/samples/DIME/DimeDataSetServiceConsumer/AssemblyInfo.cs
+++ b/samples/DIME/DimeDataSetServiceConsumer/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]		
 

--- a/samples/HttpCompressionModule/src/AssemblyInfo.cs
+++ b/samples/HttpCompressionModule/src/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Reflection;
 // Set the CompanyName, LegalCopyright, and LegalTrademark fields
 // You shouldn't have to mess with these
 [assembly: AssemblyCompany("blowery.org")]
-[assembly: AssemblyCopyright("Copyright (c) 2002 Ben Lowery")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 
 #endregion
 

--- a/samples/cs/CreateZipFile/AssemblyInfo.cs
+++ b/samples/cs/CreateZipFile/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("A SharpDevelop sample")]
-[assembly: AssemblyCopyright("Mike Krueger 2000")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/samples/cs/CreateZipFile/Main.cs
+++ b/samples/cs/CreateZipFile/Main.cs
@@ -1,5 +1,5 @@
 // SharpZipLibrary samples
-// Copyright (c) 2007, AlphaSierraPapa
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/cs/FastZip/AssemblyInfo.cs
+++ b/samples/cs/FastZip/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("Copyright 2005 John Reilly")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/samples/cs/FastZip/Main.cs
+++ b/samples/cs/FastZip/Main.cs
@@ -1,5 +1,5 @@
 // SharpZipLibrary samples
-// Copyright (c) 2007, AlphaSierraPapa
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/cs/minibzip2/AssemblyInfo.cs
+++ b/samples/cs/minibzip2/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SharpDevelop")]
-[assembly: AssemblyCopyright("Mike Krueger 2000")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/samples/cs/minibzip2/Main.cs
+++ b/samples/cs/minibzip2/Main.cs
@@ -1,5 +1,5 @@
 // SharpZipLibrary samples
-// Copyright (c) 2007, AlphaSierraPapa
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/cs/minigzip/AssemblyInfo.cs
+++ b/samples/cs/minigzip/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SharpDevelop")]
-[assembly: AssemblyCopyright("Mike Krueger 2000")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/samples/cs/minigzip/Main.cs
+++ b/samples/cs/minigzip/Main.cs
@@ -1,5 +1,5 @@
 // SharpZipLibrary samples
-// Copyright (c) 2007, AlphaSierraPapa
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/cs/sz/AssemblyInfo.cs
+++ b/samples/cs/sz/AssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("#ZipLibrary")]
-[assembly: AssemblyCopyright("")]
-[assembly: AssemblyTrademark("Copyright 2004 John Reilly")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
+[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // The assembly version has following format :

--- a/samples/cs/sz/sz.cs
+++ b/samples/cs/sz/sz.cs
@@ -3,7 +3,7 @@
 // $Id$
 // $URL$
 //
-// Copyright (c) 2007, AlphaSierraPapa
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -520,7 +520,8 @@ namespace ICSharpCode.SharpZipLib.Samples.SZ
         /// </summary>		
         void ShowVersion() {
             seenHelp = true;
-            Console.WriteLine("SharpZip Archiver v0.37   Copyright 2004 John Reilly");
+            Console.WriteLine("SharpZip Archiver v0.37");
+            Console.WriteLine("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team");
 #if !NETCF			
             Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 

--- a/samples/cs/tar/AssemblyInfo.cs
+++ b/samples/cs/tar/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("#ZipLibrary")]
-[assembly: AssemblyCopyright("Copyright 2003 ICSharpCode.NET")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/samples/cs/tar/Main.cs
+++ b/samples/cs/tar/Main.cs
@@ -1,5 +1,5 @@
 // SharpZipLibrary samples
-// Copyright (c) 2007, AlphaSierraPapa
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -590,8 +590,7 @@ public class Tar
 		Console.Error.WriteLine( "tar 2.0.6.2" );
 		Console.Error.WriteLine( "" );
 		Console.Error.WriteLine( "{0}", SharpZipVersion() );
-		Console.Error.WriteLine( "Copyright (c) 2002 by Mike Krueger" );
-		Console.Error.WriteLine( "Copyright (c) 1998,1999 by Tim Endres (Java version)" );
+		Console.Error.WriteLine( "Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team" );
 		Console.Error.WriteLine( "" );
 		Console.Error.WriteLine( "This program is free software licensed to you under the" );
 		Console.Error.WriteLine( "GNU General Public License. See the accompanying LICENSE" );

--- a/samples/cs/unzipfile/UnZipFile.cs
+++ b/samples/cs/unzipfile/UnZipFile.cs
@@ -1,5 +1,5 @@
 // SharpZipLibrary samples
-// Copyright (c) 2007, AlphaSierraPapa
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/cs/zf/AssemblyInfo.cs
+++ b/samples/cs/zf/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("Copyright 2006 John Reilly")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]		
 

--- a/samples/cs/zf/zf.cs
+++ b/samples/cs/zf/zf.cs
@@ -3,7 +3,7 @@
 // zf - A command line archiver using the ZipFile class from SharpZipLib
 // for compression
 //
-// Copyright 2006, 2010 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 //------------------------------------------------------------------------------
 // Version History
@@ -403,7 +403,8 @@ namespace ICSharpCode.SharpZipLib.Samples.CS.ZF
 		void ShowVersion() 
 		{
 			seenHelp_ = true;
-			Console.Out.WriteLine("ZipFile Archiver v0.3   Copyright 2006 John Reilly");
+			Console.Out.WriteLine("ZipFile Archiver v0.3");
+			Console.Out.WriteLine("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team");
 			
 			Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 

--- a/samples/cs/zipfiletest/ZipFileTest.cs
+++ b/samples/cs/zipfiletest/ZipFileTest.cs
@@ -1,5 +1,5 @@
 // SharpZipLibrary samples
-// Copyright (c) 2007, AlphaSierraPapa
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/vb/CreateZipFile/AssemblyInfo.vb
+++ b/samples/vb/CreateZipFile/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.CompilerServices
 <assembly: AssemblyConfiguration("")>
 <assembly: AssemblyCompany("ICSharpCode.NET")>
 <assembly: AssemblyProduct("")>
-<assembly: AssemblyCopyright("")>
+<Assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")>
 <assembly: AssemblyTrademark("")>
 <assembly: AssemblyCulture("")>
 

--- a/samples/vb/CreateZipFile/MainForm.vb
+++ b/samples/vb/CreateZipFile/MainForm.vb
@@ -1,5 +1,5 @@
 ' SharpZipLibrary samples
-' Copyright (c) 2007, AlphaSierraPapa
+' Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 ' All rights reserved.
 '
 ' Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/vb/minibzip2/AssemblyInfo.vb
+++ b/samples/vb/minibzip2/AssemblyInfo.vb
@@ -11,7 +11,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("SharpZipLib MiniBZip2 Sample")> 
 <Assembly: AssemblyCompany("")> 
 <Assembly: AssemblyProduct("")> 
-<Assembly: AssemblyCopyright("")> 
+<Assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")> 
 <Assembly: AssemblyTrademark("")> 
 
 'The following GUID is for the ID of the typelib if this project is exposed to COM

--- a/samples/vb/minibzip2/Main.vb
+++ b/samples/vb/minibzip2/Main.vb
@@ -1,5 +1,5 @@
 ' SharpZipLibrary samples
-' Copyright (c) 2007, AlphaSierraPapa
+' Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 ' All rights reserved.
 '
 ' Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/vb/viewzipfile/AssemblyInfo.vb
+++ b/samples/vb/viewzipfile/AssemblyInfo.vb
@@ -11,7 +11,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")> 
 <Assembly: AssemblyCompany("")> 
 <Assembly: AssemblyProduct("")> 
-<Assembly: AssemblyCopyright("")> 
+<Assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")> 
 <Assembly: AssemblyTrademark("")> 
 
 'The following GUID is for the ID of the typelib if this project is exposed to COM

--- a/samples/vb/viewzipfile/Main.vb
+++ b/samples/vb/viewzipfile/Main.vb
@@ -1,5 +1,5 @@
 ' SharpZipLibrary samples
-' Copyright (c) 2007, AlphaSierraPapa
+' Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 ' All rights reserved.
 '
 ' Redistribution and use in source and binary forms, with or without modification, are

--- a/samples/vb/zipfiletest/AssemblyInfo.vb
+++ b/samples/vb/zipfiletest/AssemblyInfo.vb
@@ -11,7 +11,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")> 
 <Assembly: AssemblyCompany("")> 
 <Assembly: AssemblyProduct("")> 
-<Assembly: AssemblyCopyright("")> 
+<Assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")> 
 <Assembly: AssemblyTrademark("")> 
 
 ' Version information for an assembly consists of the following four values:

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 // AssemblyInfo.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and
@@ -60,11 +59,11 @@ using System.Runtime.InteropServices;
 #elif (MONO_2_0)
 [assembly: AssemblyTitle("SharpZipLib for Mono 2.0")]
 #else
-[assembly: AssemblyTitle("SharpZipLibrary unlabelled version")]
+[assembly: AssemblyTitle("SharpZipLib unlabelled version")]
 #endif
 
 [assembly: AssemblyDescription("A free C# compression library")]
-[assembly: AssemblyProduct("#ZipLibrary")]
+[assembly: AssemblyProduct("#ZipLib")]
 [assembly: AssemblyDefaultAlias("SharpZipLib")]
 [assembly: AssemblyCulture("")]
 
@@ -75,9 +74,9 @@ using System.Runtime.InteropServices;
 #endif
 
 
-[assembly: AssemblyCompany("ICSharpCode.net")]
-[assembly: AssemblyCopyright("Copyright 2001-2010 Mike Krueger, John Reilly")]
-[assembly: AssemblyTrademark("Copyright 2001-2010 Mike Krueger, John Reilly")]
+[assembly: AssemblyCompany("AlphaSierraPapa")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
+[assembly: AssemblyTrademark("")]
 
 [assembly: AssemblyVersion("0.86.0.518")]
 [assembly: AssemblyInformationalVersionAttribute("0.86.0")]

--- a/src/BZip2/BZip2.cs
+++ b/src/BZip2/BZip2.cs
@@ -1,6 +1,6 @@
 // BZip2.cs
 //
-// Copyright (C) 2010 David Pierson
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/BZip2/BZip2Constants.cs
+++ b/src/BZip2/BZip2Constants.cs
@@ -1,5 +1,5 @@
 // BZip2Constants.cs
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/BZip2/BZip2Exception.cs
+++ b/src/BZip2/BZip2Exception.cs
@@ -1,6 +1,6 @@
 // BZip2.cs
 //
-// Copyright 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/BZip2/BZip2InputStream.cs
+++ b/src/BZip2/BZip2InputStream.cs
@@ -1,6 +1,6 @@
 // BZip2InputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/BZip2/BZip2OutputStream.cs
+++ b/src/BZip2/BZip2OutputStream.cs
@@ -1,6 +1,6 @@
 // BZip2OutputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Checksums/Adler32.cs
+++ b/src/Checksums/Adler32.cs
@@ -1,5 +1,5 @@
 // Adler32.cs - Computes Adler32 data checksum of a data stream
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 1999, 2000, 2001 Free Software Foundation, Inc.
@@ -16,7 +16,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Checksums/Crc32.cs
+++ b/src/Checksums/Crc32.cs
@@ -1,5 +1,5 @@
 // CRC32.cs - Computes CRC32 data checksum of a data stream
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 1999, 2000, 2001 Free Software Foundation, Inc.
@@ -16,7 +16,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Checksums/IChecksum.cs
+++ b/src/Checksums/IChecksum.cs
@@ -1,5 +1,5 @@
 // IChecksum.cs - Interface to compute a data checksum
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 1999, 2000, 2001 Free Software Foundation, Inc.
@@ -16,7 +16,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Checksums/StrangeCrc.cs
+++ b/src/Checksums/StrangeCrc.cs
@@ -1,6 +1,6 @@
 // StrangeCRC.cs - computes a crc used in the bziplib
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 1999, 2000, 2001 Free Software Foundation, Inc.
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Core/FileSystemScanner.cs
+++ b/src/Core/FileSystemScanner.cs
@@ -1,6 +1,6 @@
 // FileSystemScanner.cs
 //
-// Copyright 2005 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Core/INameTransform.cs
+++ b/src/Core/INameTransform.cs
@@ -1,6 +1,6 @@
 // INameTransform.cs
 //
-// Copyright 2005 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Core/IScanFilter.cs
+++ b/src/Core/IScanFilter.cs
@@ -1,6 +1,6 @@
 ﻿// IScanFilter.cs
 //
-// Copyright 2006 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Core/NameFilter.cs
+++ b/src/Core/NameFilter.cs
@@ -1,6 +1,6 @@
 // NameFilter.cs
 //
-// Copyright 2005 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Core/PathFilter.cs
+++ b/src/Core/PathFilter.cs
@@ -1,6 +1,6 @@
 // PathFilter.cs
 //
-// Copyright 2005 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Core/StreamUtils.cs
+++ b/src/Core/StreamUtils.cs
@@ -1,6 +1,6 @@
 // StreamUtils.cs
 //
-// Copyright 2005 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Core/WindowsPathUtils.cs
+++ b/src/Core/WindowsPathUtils.cs
@@ -1,6 +1,6 @@
 // WindowsPathUtils.cs
 //
-// Copyright 2007 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Encryption/PkzipClassic.cs
+++ b/src/Encryption/PkzipClassic.cs
@@ -1,7 +1,7 @@
 //
 // PkzipClassic encryption
 //
-// Copyright 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Encryption/ZipAESStream.cs
+++ b/src/Encryption/ZipAESStream.cs
@@ -1,7 +1,7 @@
 //
 // ZipAESStream.cs
 //
-// Copyright 2009 David Pierson
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Encryption/ZipAESTransform.cs
+++ b/src/Encryption/ZipAESTransform.cs
@@ -1,7 +1,7 @@
 //
 // ZipAESTransform.cs
 //
-// Copyright 2009 David Pierson
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/GZip/GZipConstants.cs
+++ b/src/GZip/GZipConstants.cs
@@ -1,6 +1,6 @@
 // GZipConstants.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/GZip/GZipException.cs
+++ b/src/GZip/GZipException.cs
@@ -1,6 +1,6 @@
 // GZipException.cs
 //
-// Copyright 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/GZip/GzipInputStream.cs
+++ b/src/GZip/GzipInputStream.cs
@@ -1,6 +1,6 @@
 // GzipInputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/GZip/GzipOutputStream.cs
+++ b/src/GZip/GzipOutputStream.cs
@@ -1,6 +1,6 @@
 // GZipOutputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Lzw/LzwConstants.cs
+++ b/src/Lzw/LzwConstants.cs
@@ -1,6 +1,6 @@
 // LzwConstants.cs
 //
-// Copyright (C) 2009 Gabriel Burca
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Lzw/LzwException.cs
+++ b/src/Lzw/LzwException.cs
@@ -1,6 +1,6 @@
 ﻿// LzwException.cs
 //
-// Copyright (C) 2009 Gabriel Burca
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Lzw/LzwInputStream.cs
+++ b/src/Lzw/LzwInputStream.cs
@@ -1,6 +1,6 @@
 ﻿﻿// LzwInputStream.cs
 //
-// Copyright (C) 2009 Gabriel Burca
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -1,6 +1,6 @@
 // Main.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/SharpZipBaseException.cs
+++ b/src/SharpZipBaseException.cs
@@ -1,6 +1,6 @@
 // SharpZipBaseException.cs
 //
-// Copyright 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Tar/InvalidHeaderException.cs
+++ b/src/Tar/InvalidHeaderException.cs
@@ -1,6 +1,6 @@
 // InvalidHeaderException.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Tar/TarArchive.cs
+++ b/src/Tar/TarArchive.cs
@@ -1,6 +1,6 @@
 // TarArchive.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Tar/TarBuffer.cs
+++ b/src/Tar/TarBuffer.cs
@@ -1,5 +1,5 @@
 // TarBuffer.cs
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Tar/TarEntry.cs
+++ b/src/Tar/TarEntry.cs
@@ -1,6 +1,6 @@
 // TarEntry.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Tar/TarException.cs
+++ b/src/Tar/TarException.cs
@@ -1,6 +1,6 @@
 // TarException.cs
 //
-// Copyright 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Tar/TarHeader.cs
+++ b/src/Tar/TarHeader.cs
@@ -1,6 +1,6 @@
 // TarHeader.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Tar/TarInputStream.cs
+++ b/src/Tar/TarInputStream.cs
@@ -1,6 +1,6 @@
 // TarInputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Tar/TarOutputStream.cs
+++ b/src/Tar/TarOutputStream.cs
@@ -1,7 +1,6 @@
 // TarOutputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright 2005 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/Deflater.cs
+++ b/src/Zip/Compression/Deflater.cs
@@ -1,7 +1,6 @@
 // Deflater.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/DeflaterConstants.cs
+++ b/src/Zip/Compression/DeflaterConstants.cs
@@ -1,7 +1,6 @@
 // DeflaterConstants.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/DeflaterEngine.cs
+++ b/src/Zip/Compression/DeflaterEngine.cs
@@ -1,7 +1,6 @@
 // DeflaterEngine.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/DeflaterHuffman.cs
+++ b/src/Zip/Compression/DeflaterHuffman.cs
@@ -1,7 +1,6 @@
 // DeflaterHuffman.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/DeflaterPending.cs
+++ b/src/Zip/Compression/DeflaterPending.cs
@@ -1,7 +1,6 @@
 // DeflaterPending.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/Inflater.cs
+++ b/src/Zip/Compression/Inflater.cs
@@ -1,7 +1,6 @@
 // Inflater.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/InflaterDynHeader.cs
+++ b/src/Zip/Compression/InflaterDynHeader.cs
@@ -1,5 +1,5 @@
 // InflaterDynHeader.cs
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -16,7 +16,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/InflaterHuffmanTree.cs
+++ b/src/Zip/Compression/InflaterHuffmanTree.cs
@@ -1,5 +1,5 @@
 // InflaterHuffmanTree.cs
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -16,7 +16,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/PendingBuffer.cs
+++ b/src/Zip/Compression/PendingBuffer.cs
@@ -1,7 +1,6 @@
 // PendingBuffer.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -1,6 +1,6 @@
 // DeflaterOutputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/src/Zip/Compression/Streams/InflaterInputStream.cs
@@ -1,7 +1,6 @@
 // InflaterInputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/Streams/OutputWindow.cs
+++ b/src/Zip/Compression/Streams/OutputWindow.cs
@@ -1,6 +1,6 @@
 // OutputWindow.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/Compression/Streams/StreamManipulator.cs
+++ b/src/Zip/Compression/Streams/StreamManipulator.cs
@@ -1,6 +1,6 @@
 // StreamManipulator.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/FastZip.cs
+++ b/src/Zip/FastZip.cs
@@ -1,6 +1,6 @@
 // FastZip.cs
 //
-// Copyright 2005 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/IEntryFactory.cs
+++ b/src/Zip/IEntryFactory.cs
@@ -1,7 +1,8 @@
 // IEntryFactory.cs
 //
-// Copyright 2006 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
+// This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
 //
 // This program is free software; you can redistribute it and/or
@@ -16,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/WindowsNameTransform.cs
+++ b/src/Zip/WindowsNameTransform.cs
@@ -1,6 +1,6 @@
 // WindowsNameTransform.cs
 //
-// Copyright 2007 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipConstants.cs
+++ b/src/Zip/ZipConstants.cs
@@ -1,7 +1,6 @@
 // ZipConstants.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipEntry.cs
+++ b/src/Zip/ZipEntry.cs
@@ -1,7 +1,6 @@
 // ZipEntry.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipEntryFactory.cs
+++ b/src/Zip/ZipEntryFactory.cs
@@ -1,7 +1,8 @@
 // ZipEntryFactory.cs
 //
-// Copyright 2006 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
+// This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
 //
 // This program is free software; you can redistribute it and/or
@@ -16,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipException.cs
+++ b/src/Zip/ZipException.cs
@@ -1,9 +1,9 @@
 // ZipException.cs
 //
-// Copyright (C) 2001 Mike Krueger
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
-// Copyright (C) 1998, 1999, 2000, 2001 Free Software Foundation, Inc.
+// Copyright (C) 2001 Free Software Foundation, Inc.
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipExtraData.cs
+++ b/src/Zip/ZipExtraData.cs
@@ -1,7 +1,7 @@
 //
 // ZipExtraData.cs
 //
-// Copyright 2004-2007 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -1,7 +1,6 @@
 // ZipFile.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipHelperStream.cs
+++ b/src/Zip/ZipHelperStream.cs
@@ -1,6 +1,6 @@
 // ZipHelperStream.cs
 //
-// Copyright 2006, 2007 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipInputStream.cs
+++ b/src/Zip/ZipInputStream.cs
@@ -1,7 +1,6 @@
 // ZipInputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipNameTransform.cs
+++ b/src/Zip/ZipNameTransform.cs
@@ -1,6 +1,6 @@
 // ZipNameTransform.cs
 //
-// Copyright 2005 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/src/Zip/ZipOutputStream.cs
+++ b/src/Zip/ZipOutputStream.cs
@@ -1,7 +1,6 @@
 // ZipOutputStream.cs
 //
-// Copyright (C) 2001 Mike Krueger
-// Copyright (C) 2004 John Reilly
+// Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team
 //
 // This file was translated from java, it was part of the GNU Classpath
 // Copyright (C) 2001 Free Software Foundation, Inc.
@@ -18,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 //
 // Linking this library statically or dynamically with other modules is
 // making a combined work based on this library.  Thus, the terms and

--- a/tests/AssemblyInfo.cs
+++ b/tests/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ICSharpCode.net")]
 [assembly: AssemblyProduct("#ZipLibrary")]
-[assembly: AssemblyCopyright("Copyright 2001-2007 Mike Krueger, John Reilly")]
+[assembly: AssemblyCopyright("Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
* Update address of Free Software Foundation, which closes icsharpcode/SharpZipLib#91
* All of the various copyright statements have been consolidated to the following:
Copyright © 2000-2016 AlphaSierraPapa for the SharpZipLib Team