### PR TITLE
Fixed 10 Tests (out of 16 Failing)

### DIFF
--- a/ICSharpCode.SharpZipLib.Tests/GZip/GZipTests.cs
+++ b/ICSharpCode.SharpZipLib.Tests/GZip/GZipTests.cs
@@ -100,13 +100,18 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 		{
 			var gzi = new GZipInputStream(new MemoryStream());
 			bool exception = false;
-			try {
-				gzi.ReadByte();
-			} catch {
+			int retval = int.MinValue;
+			try
+			{
+				retval = gzi.ReadByte();
+			}
+			catch
+			{
 				exception = true;
 			}
 
-			Assert.IsTrue(exception, "reading from an empty stream should cause an exception");
+			Assert.IsFalse(exception, "reading from an empty stream should not cause an exception");
+			Assert.That(retval, Is.EqualTo(-1), "should yield -1 byte value");
 		}
 
 		[Test]

--- a/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
+++ b/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
@@ -283,7 +283,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 			h2.LinkName = h1.LinkName;
 			Assert.IsTrue(h1.Equals(h2));
 
-			h1.Magic = "ustar";
+			h1.Magic = "other";
 			Assert.IsFalse(h1.Equals(h2));
 			h2.Magic = h1.Magic;
 			Assert.IsTrue(h1.Equals(h2));

--- a/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
+++ b/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
@@ -1127,7 +1127,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			TestDirectory(wnt, "d", "d");
 			TestDirectory(wnt, "absolute/file2", @"absolute\file2");
 
-			string BaseDir1 = Path.Combine("C:", "Dir");
+			string BaseDir1 = Path.Combine("C:\\", "Dir");
 			wnt.BaseDirectory = BaseDir1;
 
 			TestDirectory(wnt, "talofa", Path.Combine(BaseDir1, "talofa"));

--- a/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
+++ b/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
@@ -2734,7 +2734,6 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 		[Test]
 		[Category("Zip")]
-		//[ExpectedException(typeof(FileNotFoundException))]
 		public void ExtractExceptions()
 		{
 			var fastZip = new FastZip();
@@ -2743,7 +2742,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			string addFile = Path.Combine(tempFilePath, "test.zip");
 			try {
-				fastZip.ExtractZip(addFile, @"z:\doesnt exist", null);
+				Assert.Throws<FileNotFoundException>(() => fastZip.ExtractZip(addFile, @"z:\doesnt exist", null));
 			} finally {
 				File.Delete(addFile);
 			}

--- a/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
+++ b/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
@@ -1350,7 +1350,6 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		/// </summary>
 		[Test]
 		[Category("Zip")]
-		//[ExpectedException(typeof(ZipException))]
 		public void InvalidPasswordSeekable()
 		{
 			byte[] originalData = null;
@@ -1367,13 +1366,16 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			ZipEntry entry2 = inStream.GetNextEntry();
 
-			while (true) {
-				int numRead = inStream.Read(buf2, pos, buf2.Length);
-				if (numRead <= 0) {
-					break;
+			Assert.Throws<ZipException>(() => 
+			{
+				while (true) {
+					int numRead = inStream.Read(buf2, pos, buf2.Length);
+					if (numRead <= 0) {
+						break;
+					}
+					pos += numRead;
 				}
-				pos += numRead;
-			}
+			});
 		}
 
 		/// <summary>
@@ -1413,7 +1415,6 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		/// </summary>
 		[Test]
 		[Category("Zip")]
-		//[ExpectedException(typeof(ZipException))]
 		public void InvalidPasswordNonSeekable()
 		{
 			byte[] originalData = null;
@@ -1430,13 +1431,16 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			ZipEntry entry2 = inStream.GetNextEntry();
 
-			while (true) {
-				int numRead = inStream.Read(buf2, pos, buf2.Length);
-				if (numRead <= 0) {
-					break;
+			Assert.Throws<ZipException>(() => 
+			{
+				while (true) {
+					int numRead = inStream.Read(buf2, pos, buf2.Length);
+					if (numRead <= 0) {
+						break;
+					}
+					pos += numRead;
 				}
-				pos += numRead;
-			}
+			});
 		}
 
 		/// <summary>
@@ -2680,19 +2684,21 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 		[Test]
 		[Category("Zip")]
-		//[ExpectedException(typeof(DirectoryNotFoundException))]
 		public void CreateExceptions()
 		{
 			var fastZip = new FastZip();
 			string tempFilePath = GetTempFilePath();
 			Assert.IsNotNull(tempFilePath, "No permission to execute this test?");
 
-			string addFile = Path.Combine(tempFilePath, "test.zip");
-			try {
-				fastZip.CreateZip(addFile, @"z:\doesnt exist", false, null);
-			} finally {
-				File.Delete(addFile);
-			}
+			Assert.Throws<DirectoryNotFoundException>(() => 
+			{
+				string addFile = Path.Combine(tempFilePath, "test.zip");
+				try {
+					fastZip.CreateZip(addFile, @"z:\doesnt exist", false, null);
+				} finally {
+					File.Delete(addFile);
+				}
+			});
 		}
 
 		[Test]

--- a/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
@@ -225,9 +225,9 @@ namespace ICSharpCode.SharpZipLib.Tar
 		public const byte LF_GNU_VOLHDR = (byte)'V';
 
 		/// <summary>
-		/// The magic tag representing a POSIX tar archive.  (includes trailing NULL)
+		/// The magic tag representing a POSIX tar archive.  (would be written with a trailing NULL)
 		/// </summary>
-		public const string TMAGIC = "ustar ";
+		public const string TMAGIC = "ustar";
 
 		/// <summary>
 		/// The magic tag representing an old GNU tar archive where version is included in magic and overwrites it
@@ -899,9 +899,13 @@ namespace ICSharpCode.SharpZipLib.Tar
 				throw new ArgumentNullException(nameof(buffer));
 			}
 
-			for (int i = 0; i < length && nameOffset + i < toAdd.Length; ++i) {
+			int i;
+			for (i = 0; i < length && nameOffset + i < toAdd.Length; ++i) {
 				buffer[bufferOffset + i] = (byte)toAdd[nameOffset + i];
 			}
+			// If length is beyond the toAdd string length (which is OK by the prev loop condition), eg if a field has fixed length and the string is shorter, make sure all of the extra chars are written as NULLs, so that the reader func would ignore them and get back the original string
+			for (; i < length; ++i)
+				buffer[bufferOffset + i] = 0;
 			return bufferOffset + length;
 		}
 

--- a/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -238,9 +238,9 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 				int nameCharIndex = 0;
 
-				while (nameCharIndex < entry.TarHeader.Name.Length) {
+				while (nameCharIndex < entry.TarHeader.Name.Length + 1 /* we've allocated one for the null char, now we must make sure it gets written out */) {
 					Array.Clear(blockBuffer, 0, blockBuffer.Length);
-					TarHeader.GetAsciiBytes(entry.TarHeader.Name, nameCharIndex, this.blockBuffer, 0, TarBuffer.BlockSize);
+					TarHeader.GetAsciiBytes(entry.TarHeader.Name, nameCharIndex, this.blockBuffer, 0, TarBuffer.BlockSize); // This func handles OK the extra char out of string length
 					nameCharIndex += TarBuffer.BlockSize;
 					buffer.WriteBlock(blockBuffer);
 				}

--- a/ICSharpCode.SharpZipLib/Zip/WindowsNameTransform.cs
+++ b/ICSharpCode.SharpZipLib/Zip/WindowsNameTransform.cs
@@ -158,7 +158,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			int index = name.IndexOf(string.Format("{0}{0}", Path.DirectorySeparatorChar), StringComparison.Ordinal);
 			while (index >= 0) {
 				name = name.Remove(index, 1);
-				index = name.IndexOf(Path.DirectorySeparatorChar);
+				index = name.IndexOf(string.Format("{0}{0}", Path.DirectorySeparatorChar), StringComparison.Ordinal);
 			}
 
 			// Convert any invalid characters using the replacement one.


### PR DESCRIPTION
Would like to try optimizations on stream read virtual calls, for which I need to check the changes with tests. Turned out that 16 of them were failing out of the box. Fixed 10 which had more or less obvious technical issues. The idea of the remaining tests is not so straightforward.
This applies to WinNT platform.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
