### PR TITLE
Added a CompressionLevel enum to Deflater to allow FastZip users to s…

### DIFF
--- a/ICSharpCode.SharpZipLib/Zip/Compression/Deflater.cs
+++ b/ICSharpCode.SharpZipLib/Zip/Compression/Deflater.cs
@@ -77,9 +77,45 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 		/// There is no need to use this constant at all.
 		/// </summary>
 		public const int DEFLATED = 8;
-		#endregion
-		#region Local Constants
-		private const int IS_SETDICT = 0x01;
+        #endregion
+        #region Public Enum
+
+        /// <summary>
+        /// Compression Level as an enum for safer use
+        /// </summary>
+        public enum CompressionLevel
+        {
+            /// <summary>
+            /// The best and slowest compression level.  This tries to find very
+            /// long and distant string repetitions.
+            /// </summary>
+            BEST_COMPRESSION = Deflater.BEST_COMPRESSION,
+
+            /// <summary>
+            /// The worst but fastest compression level.
+            /// </summary>
+            BEST_SPEED = Deflater.BEST_SPEED,
+
+            /// <summary>
+            /// The default compression level.
+            /// </summary>
+            DEFAULT_COMPRESSION = Deflater.DEFAULT_COMPRESSION,
+
+            /// <summary>
+            /// This level won't compress at all but output uncompressed blocks.
+            /// </summary>
+            NO_COMPRESSION = Deflater.NO_COMPRESSION,
+
+            /// <summary>
+            /// The compression method.  This is the only method supported so far.
+            /// There is no need to use this constant at all.
+            /// </summary>
+            DEFLATED = Deflater.DEFLATED
+        }
+
+        #endregion
+        #region Local Constants
+        private const int IS_SETDICT = 0x01;
 		private const int IS_FLUSHING = 0x04;
 		private const int IS_FINISHING = 0x08;
 

--- a/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.Zip.Compression;
+using static ICSharpCode.SharpZipLib.Zip.Compression.Deflater;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -170,6 +172,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// </summary>
 			Always
 		}
+
 		#endregion
 
 		#region Constructors
@@ -263,13 +266,22 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get/set a value indicating wether file attributes should
+		/// Get/set a value indicating whether file attributes should
 		/// be restored during extract operations
 		/// </summary>
 		public bool RestoreAttributesOnExtract {
 			get { return restoreAttributesOnExtract_; }
 			set { restoreAttributesOnExtract_ = value; }
 		}
+
+        /// <summary>
+        /// Get/set the Compression Level that will be used
+        /// when creating the zip
+        /// </summary>
+        public Deflater.CompressionLevel CompressionLevel{
+            get { return compressionLevel_; }
+            set { compressionLevel_ = value; }
+        }
 		#endregion
 
 		#region Delegates
@@ -321,6 +333,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 			sourceDirectory_ = sourceDirectory;
 
 			using (outputStream_ = new ZipOutputStream(outputStream)) {
+
+                outputStream_.SetLevel((int)CompressionLevel);
 
 				if (password_ != null) {
 					outputStream_.Password = password_;
@@ -640,8 +654,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		IEntryFactory entryFactory_ = new ZipEntryFactory();
 		INameTransform extractNameTransform_;
 		UseZip64 useZip64_ = UseZip64.Dynamic;
+        CompressionLevel compressionLevel_ = CompressionLevel.DEFAULT_COMPRESSION;
 
-		string password_;
+        string password_;
 
 		#endregion
 	}


### PR DESCRIPTION
I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License.

I came across this feature need in the forum because I also needed it.
[http://community.sharpdevelop.net/forums/p/6835/19472.aspx](http://community.sharpdevelop.net/forums/p/6835/19472.aspx)

I recently switched from DotNetZip because it was not functioning well with my project when unzipping it in OSX. SharpZipLib did not have the same problem, but I did miss the compression level feature. I followed the practices I saw in the library, and I added the enum to Deflater because that is where the const int definitions were. I personally think it would have been cleaner to add my enum directly to the ICSharpCode.SharpZipLib.Zip.Compression namespace, but I leave that up to you.
