### PR TITLE
PendingBuffer ToByteArray() to return all bytes

### DIFF
--- a/ICSharpCode.SharpZipLib/Zip/Compression/PendingBuffer.cs
+++ b/ICSharpCode.SharpZipLib/Zip/Compression/PendingBuffer.cs
@@ -245,6 +245,8 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 		/// </returns>
 		public byte[] ToByteArray()
 		{
+			AlignToByte();
+			
 			byte[] result = new byte[end - start];
 			System.Array.Copy(buffer_, start, result, 0, result.Length);
 			start = 0;


### PR DESCRIPTION
<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

If AlignToByte() (or a procedure similar to that in Flush()) is not done within ToByteArray(), the bits variable may contain up to 15 bits not present in buffer_ which could result in data truncation. I have added AlignToByte() on the assumption that ToByteArray() will only be called when all output to PendingBuffer is complete.