### PR TITLE
Implemented NETStandard1.3 lib and made changes get lib compiling

### DIFF
--- a/ICSharpCode.SharpZipLib.sln
+++ b/ICSharpCode.SharpZipLib.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICSharpCode.SharpZipLib", "ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.csproj", "{0E7413FF-EB9E-4714-ACF2-BE3A6A7B2FFD}"
 EndProject
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Configuration", "S
 		.gitignore = .gitignore
 		Rebracer.xml = Rebracer.xml
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICSharpCode.SharpZipLib.NetStandard", "ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.NetStandard.csproj", "{BF51C1EA-5CED-4A08-A57D-FDF2E425DB70}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,6 +31,10 @@ Global
 		{82211166-9C45-4603-8E3A-2CA2EFFCBC26}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82211166-9C45-4603-8E3A-2CA2EFFCBC26}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82211166-9C45-4603-8E3A-2CA2EFFCBC26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF51C1EA-5CED-4A08-A57D-FDF2E425DB70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF51C1EA-5CED-4A08-A57D-FDF2E425DB70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF51C1EA-5CED-4A08-A57D-FDF2E425DB70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF51C1EA-5CED-4A08-A57D-FDF2E425DB70}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ICSharpCode.SharpZipLib/BZip2/BZip2.cs
+++ b/ICSharpCode.SharpZipLib/BZip2/BZip2.cs
@@ -29,7 +29,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 			} finally {
 				if (isStreamOwner) {
 					// inStream is closed by the BZip2InputStream if stream owner
-					outStream.Close();
+					outStream.Dispose();
 				}
 			}
 		}
@@ -57,7 +57,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 			} finally {
 				if (isStreamOwner) {
 					// outStream is closed by the BZip2OutputStream if stream owner
-					inStream.Close();
+					inStream.Dispose();
 				}
 			}
 		}

--- a/ICSharpCode.SharpZipLib/BZip2/BZip2Exception.cs
+++ b/ICSharpCode.SharpZipLib/BZip2/BZip2Exception.cs
@@ -6,19 +6,8 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// <summary>
 	/// BZip2Exception represents exceptions specific to BZip2 classes and code.
 	/// </summary>
-	[Serializable]
 	public class BZip2Exception : SharpZipBaseException
 	{
-		/// <summary>
-		/// Deserialization constructor 
-		/// </summary>
-		/// <param name="info"><see cref="SerializationInfo"/> for this constructor</param>
-		/// <param name="context"><see cref="StreamingContext"/> for this constructor</param>
-		protected BZip2Exception(SerializationInfo info, StreamingContext context)
-			: base(info, context)
-		{
-		}
-
 		/// <summary>
 		/// Initialise a new instance of <see cref="BZip2Exception" />.
 		/// </summary>

--- a/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
+++ b/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
@@ -188,10 +188,10 @@ namespace ICSharpCode.SharpZipLib.BZip2
 		/// <summary>
 		/// Closes the stream, releasing any associated resources.
 		/// </summary>
-		public override void Close()
+		protected override void Dispose(bool disposing)
 		{
-			if (IsStreamOwner && (baseStream != null)) {
-				baseStream.Close();
+			if (disposing && IsStreamOwner && (baseStream != null)) {
+				baseStream.Dispose();
 			}
 		}
 		/// <summary>

--- a/ICSharpCode.SharpZipLib/BZip2/BZip2OutputStream.cs
+++ b/ICSharpCode.SharpZipLib/BZip2/BZip2OutputStream.cs
@@ -259,16 +259,6 @@ namespace ICSharpCode.SharpZipLib.BZip2
 			}
 		}
 
-		/// <summary>
-		/// End the current block and end compression.
-		/// Close the stream and free any resources
-		/// </summary>
-		public override void Close()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
 		#endregion
 		void MakeMaps()
 		{
@@ -365,7 +355,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 				} finally {
 					if (disposing) {
 						if (IsStreamOwner) {
-							baseStream.Close();
+							baseStream.Dispose();
 						}
 					}
 				}

--- a/ICSharpCode.SharpZipLib/GZip/GZip.cs
+++ b/ICSharpCode.SharpZipLib/GZip/GZip.cs
@@ -29,7 +29,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 			} finally {
 				if (isStreamOwner) {
 					// inStream is closed by the GZipInputStream if stream owner
-					outStream.Close();
+					outStream.Dispose();
 				}
 			}
 		}
@@ -57,7 +57,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 			} finally {
 				if (isStreamOwner) {
 					// outStream is closed by the GZipOutputStream if stream owner
-					inStream.Close();
+					inStream.Dispose();
 				}
 			}
 		}

--- a/ICSharpCode.SharpZipLib/GZip/GZipException.cs
+++ b/ICSharpCode.SharpZipLib/GZip/GZipException.cs
@@ -6,19 +6,8 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// <summary>
 	/// GZipException represents exceptions specific to GZip classes and code.
 	/// </summary>
-	[Serializable]
 	public class GZipException : SharpZipBaseException
 	{
-		/// <summary>
-		/// Deserialization constructor 
-		/// </summary>
-		/// <param name="info"><see cref="SerializationInfo"/> for this constructor</param>
-		/// <param name="context"><see cref="StreamingContext"/> for this constructor</param>
-		protected GZipException(SerializationInfo info, StreamingContext context)
-			: base(info, context)
-		{
-		}
-
 		/// <summary>
 		/// Initialise a new instance of <see cref="GZipException" />.
 		/// </summary>

--- a/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -131,7 +131,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// Writes remaining compressed output data to the output stream
 		/// and closes it.
 		/// </summary>
-		public override void Close()
+		protected override void Dispose(bool disposing)
 		{
 			try {
 				Finish();
@@ -139,7 +139,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 				if (state_ != OutputState.Closed) {
 					state_ = OutputState.Closed;
 					if (IsStreamOwner) {
-						baseOutputStream_.Close();
+						baseOutputStream_.Dispose();
 					}
 				}
 			}

--- a/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.NetStandard.csproj
+++ b/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.NetStandard.csproj
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BF51C1EA-5CED-4A08-A57D-FDF2E425DB70}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ICSharpCode.SharpZipLib</RootNamespace>
+    <AssemblyName>ICSharpCode.SharpZipLib</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="BZip2\BZip2.cs" />
+    <Compile Include="BZip2\BZip2Constants.cs" />
+    <Compile Include="BZip2\BZip2Exception.cs" />
+    <Compile Include="BZip2\BZip2InputStream.cs" />
+    <Compile Include="BZip2\BZip2OutputStream.cs" />
+    <Compile Include="Checksum\Adler32.cs" />
+    <Compile Include="Checksum\BZip2Crc.cs" />
+    <Compile Include="Checksum\Crc32.cs" />
+    <Compile Include="Checksum\IChecksum.cs" />
+    <Compile Include="Core\FileSystemScanner.cs" />
+    <Compile Include="Core\INameTransform.cs" />
+    <Compile Include="Core\IScanFilter.cs" />
+    <Compile Include="Core\NameFilter.cs" />
+    <Compile Include="Core\PathFilter.cs" />
+    <Compile Include="Core\StreamUtils.cs" />
+    <Compile Include="Core\WindowsPathUtils.cs" />
+    <Compile Include="Encryption\PkzipClassic.cs" />
+    <Compile Include="Encryption\ZipAESStream.cs" />
+    <Compile Include="Encryption\ZipAESTransform.cs" />
+    <Compile Include="GZip\GZip.cs" />
+    <Compile Include="GZip\GZipConstants.cs" />
+    <Compile Include="GZip\GZipException.cs" />
+    <Compile Include="GZip\GzipInputStream.cs" />
+    <Compile Include="GZip\GzipOutputStream.cs" />
+    <Compile Include="Lzw\LzwConstants.cs" />
+    <Compile Include="Lzw\LzwException.cs" />
+    <Compile Include="Lzw\LzwInputStream.cs" />
+    <Compile Include="SharpZipBaseException.cs" />
+    <Compile Include="Tar\InvalidHeaderException.cs" />
+    <Compile Include="Tar\TarArchive.cs" />
+    <Compile Include="Tar\TarBuffer.cs" />
+    <Compile Include="Tar\TarEntry.cs" />
+    <Compile Include="Tar\TarException.cs" />
+    <Compile Include="Tar\TarHeader.cs" />
+    <Compile Include="Tar\TarInputStream.cs" />
+    <Compile Include="Tar\TarOutputStream.cs" />
+    <Compile Include="Zip\Compression\Deflater.cs" />
+    <Compile Include="Zip\Compression\DeflaterConstants.cs" />
+    <Compile Include="Zip\Compression\DeflaterEngine.cs" />
+    <Compile Include="Zip\Compression\DeflaterHuffman.cs" />
+    <Compile Include="Zip\Compression\DeflaterPending.cs" />
+    <Compile Include="Zip\Compression\Inflater.cs" />
+    <Compile Include="Zip\Compression\InflaterDynHeader.cs" />
+    <Compile Include="Zip\Compression\InflaterHuffmanTree.cs" />
+    <Compile Include="Zip\Compression\PendingBuffer.cs" />
+    <Compile Include="Zip\Compression\Streams\DeflaterOutputStream.cs" />
+    <Compile Include="Zip\Compression\Streams\InflaterInputStream.cs" />
+    <Compile Include="Zip\Compression\Streams\OutputWindow.cs" />
+    <Compile Include="Zip\Compression\Streams\StreamManipulator.cs" />
+    <Compile Include="Zip\FastZip.cs" />
+    <Compile Include="Zip\IEntryFactory.cs" />
+    <Compile Include="Zip\WindowsNameTransform.cs" />
+    <Compile Include="Zip\ZipConstants.cs" />
+    <Compile Include="Zip\ZipEntry.cs" />
+    <Compile Include="Zip\ZipEntryFactory.cs" />
+    <Compile Include="Zip\ZipException.cs" />
+    <Compile Include="Zip\ZipExtraData.cs" />
+    <Compile Include="Zip\ZipFile.cs" />
+    <Compile Include="Zip\ZipHelperStream.cs" />
+    <Compile Include="Zip\ZipInputStream.cs" />
+    <Compile Include="Zip\ZipNameTransform.cs" />
+    <Compile Include="Zip\ZipOutputStream.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ICSharpCode.SharpZipLib/Lzw/LzwException.cs
+++ b/ICSharpCode.SharpZipLib/Lzw/LzwException.cs
@@ -6,19 +6,8 @@ namespace ICSharpCode.SharpZipLib.Lzw
 	/// <summary>
 	/// LzwException represents exceptions specific to LZW classes and code.
 	/// </summary>
-	[Serializable]
 	public class LzwException : SharpZipBaseException
 	{
-		/// <summary>
-		/// Deserialization constructor 
-		/// </summary>
-		/// <param name="info"><see cref="SerializationInfo"/> for this constructor</param>
-		/// <param name="context"><see cref="StreamingContext"/> for this constructor</param>
-		protected LzwException(SerializationInfo info, StreamingContext context)
-			: base(info, context)
-		{
-		}
-
 		/// <summary>
 		/// Initialise a new instance of <see cref="LzwException" />.
 		/// </summary>

--- a/ICSharpCode.SharpZipLib/Lzw/LzwInputStream.cs
+++ b/ICSharpCode.SharpZipLib/Lzw/LzwInputStream.cs
@@ -478,30 +478,15 @@ namespace ICSharpCode.SharpZipLib.Lzw
 		}
 
 		/// <summary>
-		/// Entry point to begin an asynchronous write.  Always throws a NotSupportedException.
-		/// </summary>
-		/// <param name="buffer">The buffer to write data from</param>
-		/// <param name="offset">Offset of first byte to write</param>
-		/// <param name="count">The maximum number of bytes to write</param>
-		/// <param name="callback">The method to be called when the asynchronous write operation is completed</param>
-		/// <param name="state">A user-provided object that distinguishes this particular asynchronous write request from other requests</param>
-		/// <returns>An <see cref="System.IAsyncResult">IAsyncResult</see> that references the asynchronous write</returns>
-		/// <exception cref="NotSupportedException">Any access</exception>
-		public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-		{
-			throw new NotSupportedException("InflaterInputStream BeginWrite not supported");
-		}
-
-		/// <summary>
 		/// Closes the input stream.  When <see cref="IsStreamOwner"></see>
 		/// is true the underlying stream is also closed.
 		/// </summary>
-		public override void Close()
+		protected override void Dispose(bool disposing)
 		{
 			if (!isClosed) {
 				isClosed = true;
 				if (isStreamOwner) {
-					baseInputStream.Close();
+					baseInputStream.Dispose();
 				}
 			}
 		}

--- a/ICSharpCode.SharpZipLib/SharpZipBaseException.cs
+++ b/ICSharpCode.SharpZipLib/SharpZipBaseException.cs
@@ -3,25 +3,14 @@ using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib
 {
-	/// <summary>
-	/// SharpZipBaseException is the base exception class for SharpZipLib.
-	/// All library exceptions are derived from this.
-	/// </summary>
-	/// <remarks>NOTE: Not all exceptions thrown will be derived from this class.
-	/// A variety of other exceptions are possible for example <see cref="ArgumentNullException"></see></remarks>
-	[Serializable]
+    /// <summary>
+    /// SharpZipBaseException is the base exception class for SharpZipLib.
+    /// All library exceptions are derived from this.
+    /// </summary>
+    /// <remarks>NOTE: Not all exceptions thrown will be derived from this class.
+    /// A variety of other exceptions are possible for example <see cref="ArgumentNullException"></see></remarks>
 	public class SharpZipBaseException : Exception
 	{
-		/// <summary>
-		/// Deserialization constructor 
-		/// </summary>
-		/// <param name="info"><see cref="System.Runtime.Serialization.SerializationInfo"/> for this constructor</param>
-		/// <param name="context"><see cref="StreamingContext"/> for this constructor</param>
-		protected SharpZipBaseException(SerializationInfo info, StreamingContext context)
-			: base(info, context)
-		{
-		}
-
 		/// <summary>
 		/// Initializes a new instance of the SharpZipBaseException class.
 		/// </summary>

--- a/ICSharpCode.SharpZipLib/Tar/InvalidHeaderException.cs
+++ b/ICSharpCode.SharpZipLib/Tar/InvalidHeaderException.cs
@@ -7,21 +7,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// This exception is used to indicate that there is a problem
 	/// with a TAR archive header.
 	/// </summary>
-	[Serializable]
 	public class InvalidHeaderException : TarException
 	{
-
-		/// <summary>
-		/// Deserialization constructor 
-		/// </summary>
-		/// <param name="information"><see cref="SerializationInfo"/> for this constructor</param>
-		/// <param name="context"><see cref="StreamingContext"/> for this constructor</param>
-		protected InvalidHeaderException(SerializationInfo information, StreamingContext context)
-			: base(information, context)
-
-		{
-		}
-
 		/// <summary>
 		/// Initialise a new instance of the InvalidHeaderException class.
 		/// </summary>

--- a/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
@@ -580,9 +580,9 @@ namespace ICSharpCode.SharpZipLib.Tar
 					}
 
 					if (asciiTrans) {
-						outw.Close();
+						outw.Dispose();
 					} else {
-						outputStream.Close();
+						outputStream.Dispose();
 					}
 				}
 			}
@@ -748,11 +748,11 @@ namespace ICSharpCode.SharpZipLib.Tar
 				if (disposing) {
 					if (tarOut != null) {
 						tarOut.Flush();
-						tarOut.Close();
+						tarOut.Dispose();
 					}
 
 					if (tarIn != null) {
-						tarIn.Close();
+						tarIn.Dispose();
 					}
 				}
 			}

--- a/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -524,12 +524,12 @@ namespace ICSharpCode.SharpZipLib.Tar
 				WriteFinalRecord();
 
 				if (isStreamOwner_) {
-					outputStream.Close();
+					outputStream.Dispose();
 				}
 				outputStream = null;
 			} else if (inputStream != null) {
 				if (isStreamOwner_) {
-					inputStream.Close();
+					inputStream.Dispose();
 				}
 				inputStream = null;
 			}

--- a/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
@@ -30,7 +30,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// defaults and the File is set to null.</p>
 	/// <see cref="TarHeader"/>
 	/// </summary>
-	public class TarEntry : ICloneable
+	public class TarEntry
 	{
 		#region Constructors
 		/// <summary>
@@ -340,8 +340,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 			string name = file;
 
 			// 23-Jan-2004 GnuTar allows device names in path where the name is not local to the current directory
-			if (name.IndexOf(Environment.CurrentDirectory, StringComparison.Ordinal) == 0) {
-				name = name.Substring(Environment.CurrentDirectory.Length);
+			if (name.IndexOf(Directory.GetCurrentDirectory(), StringComparison.Ordinal) == 0) {
+				name = name.Substring(Directory.GetCurrentDirectory().Length);
 			}
 
 			/*

--- a/ICSharpCode.SharpZipLib/Tar/TarException.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarException.cs
@@ -6,18 +6,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// <summary>
 	/// TarException represents exceptions specific to Tar classes and code.
 	/// </summary>
-	[Serializable]
 	public class TarException : SharpZipBaseException
 	{
-		/// <summary>
-		/// Deserialization constructor 
-		/// </summary>
-		/// <param name="info"><see cref="SerializationInfo"/> for this constructor</param>
-		/// <param name="context"><see cref="StreamingContext"/> for this constructor</param>
-		protected TarException(SerializationInfo info, StreamingContext context)
-			: base(info, context)
-		{
-		}
 
 		/// <summary>
 		/// Initialise a new instance of <see cref="TarException" />.

--- a/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
@@ -38,7 +38,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// 	char t_mfill[12];          // 500 Filler up to 512
 	/// };
 	/// </remarks>
-	public class TarHeader : ICloneable
+	public class TarHeader
 	{
 		#region Constants
 		/// <summary>
@@ -435,7 +435,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				if (value != null) {
 					userName = value.Substring(0, Math.Min(UNAMELEN, value.Length));
 				} else {
-					string currentUser = Environment.UserName;
+					string currentUser = "user";
 					if (currentUser.Length > UNAMELEN) {
 						currentUser = currentUser.Substring(0, UNAMELEN);
 					}
@@ -489,7 +489,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <returns>A new <see cref="Object"/> that is a copy of the current instance.</returns>
 		public object Clone()
 		{
-			return MemberwiseClone();
+			return this.MemberwiseClone();
 		}
 		#endregion
 

--- a/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -254,9 +254,12 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// Closes this stream. Calls the TarBuffer's close() method.
 		/// The underlying stream is closed by the TarBuffer.
 		/// </summary>
-		public override void Close()
+		protected override void Dispose(bool disposing)
 		{
-			tarBuffer.Close();
+			if (disposing)
+			{
+				tarBuffer.Close();
+			}
 		}
 
 		#endregion

--- a/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -167,7 +167,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		/// <remarks>This means that Finish() is called followed by calling the
 		/// TarBuffer's Close().</remarks>
-		public override void Close()
+		protected override void Dispose(bool disposing)
 		{
 			if (!isClosed) {
 				isClosed = true;

--- a/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -208,7 +208,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 			salt = new byte[entry.AESSaltLen];
 			// Salt needs to be cryptographically random, and unique per file
 			if (_aesRnd == null)
-				_aesRnd = new RNGCryptoServiceProvider();
+				_aesRnd = RandomNumberGenerator.Create();
 			_aesRnd.GetBytes(salt);
 			int blockSize = entry.AESKeySize / 8;   // bits to bytes
 
@@ -342,36 +342,6 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		}
 
 		/// <summary>
-		/// Asynchronous reads are not supported a NotSupportedException is always thrown
-		/// </summary>
-		/// <param name="buffer">The buffer to read into.</param>
-		/// <param name="offset">The offset to start storing data at.</param>
-		/// <param name="count">The number of bytes to read</param>
-		/// <param name="callback">The async callback to use.</param>
-		/// <param name="state">The state to use.</param>
-		/// <returns>Returns an <see cref="IAsyncResult"/></returns>
-		/// <exception cref="NotSupportedException">Any access</exception>
-		public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-		{
-			throw new NotSupportedException("DeflaterOutputStream BeginRead not currently supported");
-		}
-
-		/// <summary>
-		/// Asynchronous writes arent supported, a NotSupportedException is always thrown
-		/// </summary>
-		/// <param name="buffer">The buffer to write.</param>
-		/// <param name="offset">The offset to begin writing at.</param>
-		/// <param name="count">The number of bytes to write.</param>
-		/// <param name="callback">The <see cref="AsyncCallback"/> to use.</param>
-		/// <param name="state">The state object.</param>
-		/// <returns>Returns an IAsyncResult.</returns>
-		/// <exception cref="NotSupportedException">Any access</exception>
-		public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-		{
-			throw new NotSupportedException("BeginWrite is not supported");
-		}
-
-		/// <summary>
 		/// Flushes the stream by calling <see cref="DeflaterOutputStream.Flush">Flush</see> on the deflater and then
 		/// on the underlying stream.  This ensures that all bytes are flushed.
 		/// </summary>
@@ -386,7 +356,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// Calls <see cref="Finish"/> and closes the underlying
 		/// stream when <see cref="IsStreamOwner"></see> is true.
 		/// </summary>
-		public override void Close()
+		protected override void Dispose(bool disposing)
 		{
 			if (!isClosed_) {
 				isClosed_ = true;
@@ -400,7 +370,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 					}
 				} finally {
 					if (isStreamOwner_) {
-						baseOutputStream_.Close();
+						baseOutputStream_.Dispose();
 					}
 				}
 			}
@@ -470,7 +440,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		#region Static Fields
 
 		// Static to help ensure that multiple files within a zip will get different random salt
-		private static RNGCryptoServiceProvider _aesRnd;
+		private static RandomNumberGenerator _aesRnd = RandomNumberGenerator.Create();
 		#endregion
 	}
 }

--- a/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -557,30 +557,15 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		}
 
 		/// <summary>
-		/// Entry point to begin an asynchronous write.  Always throws a NotSupportedException.
-		/// </summary>
-		/// <param name="buffer">The buffer to write data from</param>
-		/// <param name="offset">Offset of first byte to write</param>
-		/// <param name="count">The maximum number of bytes to write</param>
-		/// <param name="callback">The method to be called when the asynchronous write operation is completed</param>
-		/// <param name="state">A user-provided object that distinguishes this particular asynchronous write request from other requests</param>
-		/// <returns>An <see cref="System.IAsyncResult">IAsyncResult</see> that references the asynchronous write</returns>
-		/// <exception cref="NotSupportedException">Any access</exception>
-		public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-		{
-			throw new NotSupportedException("InflaterInputStream BeginWrite not supported");
-		}
-
-		/// <summary>
 		/// Closes the input stream.  When <see cref="IsStreamOwner"></see>
 		/// is true the underlying stream is also closed.
 		/// </summary>
-		public override void Close()
+		protected override void Dispose(bool disposing)
 		{
 			if (!isClosed) {
 				isClosed = true;
 				if (isStreamOwner) {
-					baseInputStream.Close();
+					baseInputStream.Dispose();
 				}
 			}
 		}

--- a/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Text;
 using System.Threading;
 
@@ -427,11 +428,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// Given this value, <see cref="Encoding.GetEncoding(int)"/> throws an <see cref="ArgumentException"/>.
 		/// So replace it with some fallback, e.g. 437 which is the default cpcp in a console in a default Windows installation.
 		/// </remarks>
-		static int defaultCodePage =
-			// these values cause ArgumentException in subsequent calls to Encoding::GetEncoding()
-			((Thread.CurrentThread.CurrentCulture.TextInfo.OEMCodePage == 1) || (Thread.CurrentThread.CurrentCulture.TextInfo.OEMCodePage == 2) || (Thread.CurrentThread.CurrentCulture.TextInfo.OEMCodePage == 3) || (Thread.CurrentThread.CurrentCulture.TextInfo.OEMCodePage == 42))
-			? 437 // The default OEM encoding in a console in a default Windows installation, as a fallback.
-			: Thread.CurrentThread.CurrentCulture.TextInfo.OEMCodePage;
+		static int defaultCodePage = -1;
 
 		/// <summary>
 		/// Default encoding used for string conversion.  0 gives the default system OEM code page.
@@ -442,6 +439,18 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </summary>
 		public static int DefaultCodePage {
 			get {
+				const int FALLBACK_CODE_PAGE = 437;
+				if (defaultCodePage == -1)
+				{
+					try
+					{
+						var codePage = Encoding.GetEncoding(0).CodePage;
+						defaultCodePage = (codePage == 1 || codePage == 2 || codePage == 3 || codePage == 42) ? FALLBACK_CODE_PAGE : codePage;
+					}
+					catch {
+						defaultCodePage = FALLBACK_CODE_PAGE;
+					}
+				}
 				return defaultCodePage;
 			}
 			set {

--- a/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -103,7 +103,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <br/>
 	/// <br/>Author of the original java version : Jochen Hoenicke
 	/// </summary>
-	public class ZipEntry : ICloneable
+	public class ZipEntry
 	{
 		[Flags]
 		enum Known : byte

--- a/ICSharpCode.SharpZipLib/Zip/ZipException.cs
+++ b/ICSharpCode.SharpZipLib/Zip/ZipException.cs
@@ -6,18 +6,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// ZipException represents exceptions specific to Zip classes and code.
 	/// </summary>
-	[Serializable]
 	public class ZipException : SharpZipBaseException
 	{
-		/// <summary>
-		/// Deserialization constructor 
-		/// </summary>
-		/// <param name="info"><see cref="SerializationInfo"/> for this constructor</param>
-		/// <param name="context"><see cref="StreamingContext"/> for this constructor</param>
-		protected ZipException(SerializationInfo info, StreamingContext context)
-			: base(info, context)
-		{
-		}
 
 		/// <summary>
 		/// Initialise a new instance of <see cref="ZipException" />.

--- a/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
+++ b/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
@@ -878,7 +878,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public void Dispose()
 		{
 			if (_newEntry != null) {
-				_newEntry.Close();
+				_newEntry.Dispose();
 			}
 		}
 

--- a/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -646,7 +646,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			// TODO: This will be slow as the next ice age for huge archives!
 			for (int i = 0; i < entries_.Length; i++) {
-				if (string.Compare(name, entries_[i].Name, ignoreCase, CultureInfo.InvariantCulture) == 0) {
+				if (string.Compare(name, entries_[i].Name, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) == 0) {
 					return i;
 				}
 			}
@@ -2409,7 +2409,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				updateFile = new ZipHelperStream(copyStream);
 				updateFile.IsStreamOwner = true;
 
-				baseStream_.Close();
+				baseStream_.Dispose();
 				baseStream_ = null;
 			} else {
 				if (archiveStorage_.UpdateMode == FileUpdateMode.Direct) {
@@ -2423,7 +2423,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					baseStream_ = archiveStorage_.OpenForDirectUpdate(baseStream_);
 					updateFile = new ZipHelperStream(baseStream_);
 				} else {
-					baseStream_.Close();
+					baseStream_.Dispose();
 					baseStream_ = null;
 					updateFile = new ZipHelperStream(Name);
 				}
@@ -2620,7 +2620,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				isNewArchive_ = false;
 				ReadEntries();
 			} else {
-				baseStream_.Close();
+				baseStream_.Dispose();
 				Reopen(archiveStorage_.ConvertTemporaryToFinal());
 			}
 		}
@@ -2810,7 +2810,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				if (IsStreamOwner && (baseStream_ != null)) {
 					lock (baseStream_) {
-						baseStream_.Close();
+						baseStream_.Dispose();
 					}
 				}
 
@@ -3347,13 +3347,6 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			#endregion
 
-			/// <summary>
-			/// Close this stream instance.
-			/// </summary>
-			public override void Close()
-			{
-				// Do nothing
-			}
 
 			/// <summary>
 			/// Gets a value indicating whether the current stream supports reading.
@@ -3532,17 +3525,6 @@ namespace ICSharpCode.SharpZipLib.Zip
 					baseStream_.Seek(readPos_++, SeekOrigin.Begin);
 					return baseStream_.ReadByte();
 				}
-			}
-
-			/// <summary>
-			/// Close this <see cref="PartialInputStream">partial input stream</see>.
-			/// </summary>
-			/// <remarks>
-			/// The underlying stream is not closed.  Close the parent ZipFile class to do that.
-			/// </remarks>
-			public override void Close()
-			{
-				// Do nothing at all!
 			}
 
 			/// <summary>
@@ -4021,7 +4003,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			bool newFileCreated = false;
 
 			try {
-				temporaryStream_.Close();
+				temporaryStream_.Dispose();
 				File.Move(fileName_, moveTempName);
 				File.Move(temporaryName_, fileName_);
 				newFileCreated = true;
@@ -4050,7 +4032,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <returns>Returns a temporary output <see cref="Stream"/> that is a copy of the input.</returns>
 		public override Stream MakeTemporaryCopy(Stream stream)
 		{
-			stream.Close();
+			stream.Dispose();
 
 			temporaryName_ = GetTempFileName(fileName_, true);
 			File.Copy(fileName_, temporaryName_, true);
@@ -4072,7 +4054,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			Stream result;
 			if ((stream == null) || !stream.CanWrite) {
 				if (stream != null) {
-					stream.Close();
+					stream.Dispose();
 				}
 
 				result = new FileStream(fileName_,
@@ -4091,7 +4073,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public override void Dispose()
 		{
 			if (temporaryStream_ != null) {
-				temporaryStream_.Close();
+				temporaryStream_.Dispose();
 			}
 		}
 
@@ -4232,7 +4214,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					stream.Position = 0;
 					StreamUtils.Copy(stream, result, new byte[4096]);
 
-					stream.Close();
+					stream.Dispose();
 				}
 			} else {
 				result = stream;
@@ -4247,7 +4229,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public override void Dispose()
 		{
 			if (temporaryStream_ != null) {
-				temporaryStream_.Close();
+				temporaryStream_.Dispose();
 			}
 		}
 

--- a/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
+++ b/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
@@ -150,15 +150,16 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <remarks>
 		/// The underlying stream is closed only if <see cref="IsStreamOwner"/> is true.
 		/// </remarks>
-		override public void Close()
+		protected override void Dispose(bool disposing)
 		{
 			Stream toClose = stream_;
 			stream_ = null;
 			if (isOwner_ && (toClose != null)) {
 				isOwner_ = false;
-				toClose.Close();
+				toClose.Dispose();
 			}
 		}
+
 		#endregion
 
 		// Write the local file header

--- a/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -162,7 +162,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				header == ZipConstants.ArchiveExtraDataSignature ||
 				header == ZipConstants.Zip64CentralFileHeaderSignature) {
 				// No more individual entries exist
-				Close();
+				Dispose();
 				return null;
 			}
 
@@ -598,13 +598,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Closes the zip input stream
 		/// </summary>
-		public override void Close()
+		protected override void Dispose(bool disposing)
 		{
 			internalReader = new ReadDataHandler(ReadingNotAvailable);
 			crc = null;
 			entry = null;
 
-			base.Close();
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/ICSharpCode.SharpZipLib/project.json
+++ b/ICSharpCode.SharpZipLib/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
     "NETStandard.Library": "1.6.0",
     "System.Collections.NonGeneric": "4.0.1"
   },

--- a/ICSharpCode.SharpZipLib/project.json
+++ b/ICSharpCode.SharpZipLib/project.json
@@ -1,0 +1,11 @@
+﻿{
+  "supports": {},
+  "dependencies": {
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "NETStandard.Library": "1.6.0",
+    "System.Collections.NonGeneric": "4.0.1"
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  }
+}


### PR DESCRIPTION
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

Creating a pull request for review purposes. These changes need reviewed and tested before merging. 

No features were removed during this refactoring other than some exception serialization related stuff. 
- The ZIP AES changes need tested
- The streams were improperly overriding Stream.Close() according to https://msdn.microsoft.com/en-us/library/ms143450(v=vs.110).aspx ... these were changed to Stream.Dispose(bool) but there may be problems around garbage collection - needs reviewed and tested
- Unsupported exception serialization and constructors were removed
- DefaultCodePage changes need reviewed
- Some commenting may need updated
