### PR TITLE
Add Condition for Break function

### DIFF
--- a/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -152,6 +152,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			if (entry != null) {
 				CloseEntry();
+				if (inputBuffer.Available <= 0){
+                    return null;
+                }
 			}
 
 			int header = inputBuffer.ReadLeInt();


### PR DESCRIPTION
<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
- Change GetNextEntry() function 
- its thrown "EOF in Header" exception while extracting zip file
