### PR TITLE
Efficient skip in TarInputStream

### DIFF
--- a/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -316,14 +316,17 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </param>
 		public void Skip(long skipCount)
 		{
-			// TODO: REVIEW efficiency of TarInputStream.Skip
-			// This is horribly inefficient, but it ensures that we
-			// properly skip over bytes via the TarBuffer...
-			//
-			byte[] skipBuf = new byte[8 * 1024];
+            int blocksToSkip = (int)(skipCount / TarBuffer.BlockSize);
+            tarBuffer.SkipBlocks(blocksToSkip);
+            readBuffer = null;
+            long newSkipCount = skipCount % TarBuffer.BlockSize;
+            entryOffset += skipCount - newSkipCount;
 
-			for (long num = skipCount; num > 0;) {
-				int toRead = num > skipBuf.Length ? skipBuf.Length : (int)num;
+            byte[] skipBuf = new byte[8 * 1024];
+
+            for (long num = newSkipCount; num > 0;)
+            {
+                int toRead = num > skipBuf.Length ? skipBuf.Length : (int)num;
 				int numRead = Read(skipBuf, 0, toRead);
 
 				if (numRead == -1) {


### PR DESCRIPTION
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

Added a small bit of code that allows a TarInputStream to efficiently
skip portions of its underlying InputStream without screwing up the
bookkeeping in TarBuffer.
