### PR TITLE
TarInputStream.RealPosition

### DIFF
--- a/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -97,10 +97,33 @@ namespace ICSharpCode.SharpZipLib.Tar
 			}
 		}
 
-		/// <summary>
-		/// Flushes the baseInputStream
-		/// </summary>
-		public override void Flush()
+        /// <summary>
+        /// Gets or sets the position within the stream of the next byte
+        /// that will be read by Read(), accounting for the internal
+        /// buffering that makes the Position property useless.
+        /// </summary>
+        public long RealPosition
+        {
+            get
+            {
+                long pos = (tarBuffer.CurrentRecord) * tarBuffer.RecordSize +
+                    (tarBuffer.CurrentBlock - 1) * TarBuffer.BlockSize;
+                if (readBuffer != null)
+                {
+                    pos += (TarBuffer.BlockSize - readBuffer.Length);
+                }
+                else
+                {
+                    pos += TarBuffer.BlockSize;
+                }
+                return pos;
+            }
+        }
+
+        /// <summary>
+        /// Flushes the baseInputStream
+        /// </summary>
+        public override void Flush()
 		{
 			inputStream.Flush();
 		}

--- a/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -98,7 +98,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		}
 
         /// <summary>
-        /// Gets or sets the position within the stream of the next byte
+        /// Gets the position within the stream of the next byte
         /// that will be read by Read(), accounting for the internal
         /// buffering that makes the Position property useless.
         /// </summary>


### PR DESCRIPTION
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

Added a property called RealPosition that returns the position within
the stream of the next byte that will be read by Read(), accounting for
the internal buffering that makes the Position property useless.
