### PR TITLE
GZip.Compress ArgumentOutOfRangeException:bufferSize

### DIFF
--- a/ICSharpCode.SharpZipLib/GZip/GZip.cs
+++ b/ICSharpCode.SharpZipLib/GZip/GZip.cs
@@ -50,7 +50,8 @@ namespace ICSharpCode.SharpZipLib.GZip
 			}
 
 			try {
-				using (GZipOutputStream bzipOutput = new GZipOutputStream(outStream, level)) {
+				using (GZipOutputStream bzipOutput = new GZipOutputStream(outStream)){
+				    bzipOutput.SetLevel(level);
 					bzipOutput.IsStreamOwner = isStreamOwner;
 					Core.StreamUtils.Copy(inStream, bzipOutput, new byte[4096]);
 				}


### PR DESCRIPTION
when set compression level=1 then throw new
ArgumentOutOfRangeException(nameof(bufferSize));