### PR TITLE
tiny change to make appveyor back to work

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ nuget:
 #---------------------------------#
 
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.
-platform: Any CPU
+#platform: Any CPU
 
 # to add several platforms to build matrix:
 #platform:


### PR DESCRIPTION
This tiny change can get appveyor going again, as shown here:
https://ci.appveyor.com/project/xied75/sharpziplib/build/1.0.2

Ref: http://help.appveyor.com/discussions/problems/5145-build-failing

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

