### PR TITLE
inline crc32 checksum update, about 2x higher crc throughput

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Checksum/Crc32.cs
+++ b/src/ICSharpCode.SharpZipLib/Checksum/Crc32.cs
@@ -181,9 +181,13 @@ namespace ICSharpCode.SharpZipLib.Checksum
 				throw new ArgumentOutOfRangeException(nameof(count), "exceeds buffer size");
 			}
 
-			for (int i = 0; i < count; ++i) {
-				Update(buffer[offset++]);
-			}
-		}
+            uint crc = checkValue;
+            for (int i = 0; i < count; ++i)
+            {
+                byte b = buffer[offset++];
+                crc = crcTable[(crc ^ b) & 0xFF] ^ (crc >> 8);
+            }
+            checkValue = crc;
+        }
 	}
 }


### PR DESCRIPTION
Removes redundant function call for each checked byte. The speedup is most noticeable when decoding highly compressed data, where crc takes a significant amount of time.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
