### PR TITLE
FastZip: Raise ProcessDirectory event for extractions

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -783,7 +783,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			// TODO: Fire delegate/throw exception were compression method not supported, or name is invalid?
 
-			string dirName = null;
+			string dirName = string.Empty;
 
 			if (doExtraction)
 			{
@@ -803,11 +803,18 @@ namespace ICSharpCode.SharpZipLib.Zip
 				{
 					try
 					{
-						Directory.CreateDirectory(dirName);
-
-						if (entry.IsDirectory && restoreDateTimeOnExtract_)
+						continueRunning_ = events_?.OnProcessDirectory(dirName, true) ?? true;
+						if (continueRunning_)
 						{
-							Directory.SetLastWriteTime(dirName, entry.DateTime);
+							Directory.CreateDirectory(dirName);
+							if (entry.IsDirectory && restoreDateTimeOnExtract_)
+							{
+								Directory.SetLastWriteTime(dirName, entry.DateTime);
+							}
+						}
+						else
+						{
+							doExtraction = false;
 						}
 					}
 					catch (Exception ex)


### PR DESCRIPTION
FastZip's ExtractZip method did not raise the ProcessDirectory event when
creating a directory.  There was no way to determine or control when
ExtractZip decided to create a new directory.

(This presented an issue when I tried using ExtractZip in conjunction as part of an installation tool with automatic-rollback functionality; it did not rollback the creation of directories, so the cleanup didn't work correctly.)

NOTE: The logic to raise the event only triggers when the target directory
doesn't already exist in the destination.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
