### PR TITLE
Restrict path traversal on FastZip extraction (fixes #232)

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/InvalidNameException.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/InvalidNameException.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ICSharpCode.SharpZipLib.Core
+{
+
+	/// <summary>
+	/// InvalidNameException is thrown for invalid names such as directory traversal paths and names with invalid characters
+	/// </summary>
+	public class InvalidNameException: SharpZipBaseException
+    {
+		/// <summary>
+		/// Initializes a new instance of the InvalidNameException class with a default error message.
+		/// </summary>
+		public InvalidNameException(): base("An invalid name was specified")
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the InvalidNameException class with a specified error message.
+		/// </summary>
+		/// <param name="message">A message describing the exception.</param>
+		public InvalidNameException(string message) : base(message)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the InvalidNameException class with a specified
+		/// error message and a reference to the inner exception that is the cause of this exception.
+		/// </summary>
+		/// <param name="message">A message describing the exception.</param>
+		/// <param name="innerException">The inner exception</param>
+		public InvalidNameException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+	}
+}

--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -385,12 +385,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="fileFilter">A filter to apply to files.</param>
 		/// <param name="directoryFilter">A filter to apply to directories.</param>
 		/// <param name="restoreDateTime">Flag indicating whether to restore the date and time for extracted files.</param>
+		/// <param name="allowParentTraversal">Allow parent directory traversal in file paths (e.g. ../file)</param>
 		public void ExtractZip(string zipFileName, string targetDirectory,
 							   Overwrite overwrite, ConfirmOverwriteDelegate confirmDelegate,
-							   string fileFilter, string directoryFilter, bool restoreDateTime)
+							   string fileFilter, string directoryFilter, bool restoreDateTime, bool allowParentTraversal = false)
 		{
 			Stream inputStream = File.Open(zipFileName, FileMode.Open, FileAccess.Read, FileShare.Read);
-			ExtractZip(inputStream, targetDirectory, overwrite, confirmDelegate, fileFilter, directoryFilter, restoreDateTime, true);
+			ExtractZip(inputStream, targetDirectory, overwrite, confirmDelegate, fileFilter, directoryFilter, restoreDateTime, true, allowParentTraversal);
 		}
 
 		/// <summary>
@@ -404,10 +405,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="directoryFilter">A filter to apply to directories.</param>
 		/// <param name="restoreDateTime">Flag indicating whether to restore the date and time for extracted files.</param>
 		/// <param name="isStreamOwner">Flag indicating whether the inputStream will be closed by this method.</param>
+		/// <param name="allowParentTraversal">Allow parent directory traversal in file paths (e.g. ../file)</param>
 		public void ExtractZip(Stream inputStream, string targetDirectory,
 					   Overwrite overwrite, ConfirmOverwriteDelegate confirmDelegate,
 					   string fileFilter, string directoryFilter, bool restoreDateTime,
-					   bool isStreamOwner)
+					   bool isStreamOwner, bool allowParentTraversal = false)
 		{
 			if ((overwrite == Overwrite.Prompt) && (confirmDelegate == null)) {
 				throw new ArgumentNullException(nameof(confirmDelegate));
@@ -416,7 +418,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			continueRunning_ = true;
 			overwrite_ = overwrite;
 			confirmDelegate_ = confirmDelegate;
-			extractNameTransform_ = new WindowsNameTransform(targetDirectory);
+			extractNameTransform_ = new WindowsNameTransform(targetDirectory, allowParentTraversal);
 
 			fileFilter_ = new NameFilter(fileFilter);
 			directoryFilter_ = new NameFilter(directoryFilter);

--- a/src/ICSharpCode.SharpZipLib/Zip/WindowsNameTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/WindowsNameTransform.cs
@@ -19,6 +19,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		string _baseDirectory;
 		bool _trimIncomingPaths;
 		char _replacementChar = '_';
+		private bool _allowParentTraversal;
 
 		/// <summary>
 		/// In this case we need Windows' invalid path characters.
@@ -38,13 +39,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// Initialises a new instance of <see cref="WindowsNameTransform"/>
 		/// </summary>
 		/// <param name="baseDirectory"></param>
-		public WindowsNameTransform(string baseDirectory)
+		/// <param name="allowParentTraversal">Allow parent directory traversal in file paths (e.g. ../file)</param>
+		public WindowsNameTransform(string baseDirectory, bool allowParentTraversal = false)
 		{
-			if (baseDirectory == null) {
-				throw new ArgumentNullException(nameof(baseDirectory), "Directory name is invalid");
-			}
-
-			BaseDirectory = baseDirectory;
+			BaseDirectory = baseDirectory ?? throw new ArgumentNullException(nameof(baseDirectory), "Directory name is invalid");
+			AllowParentTraversal = allowParentTraversal;
 		}
 
 		/// <summary>
@@ -70,6 +69,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
+		/// Allow parent directory traversal in file paths (e.g. ../file)
+		/// </summary>
+		public bool AllowParentTraversal
+		{
+			get => _allowParentTraversal;
+			set => _allowParentTraversal = value;
+		}
+
+		/// <summary>
 		/// Gets or sets a value indicating wether paths on incoming values should be removed.
 		/// </summary>
 		public bool TrimIncomingPaths {
@@ -90,7 +98,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					name = name.Remove(name.Length - 1, 1);
 				}
 			} else {
-				throw new ZipException("Cannot have an empty directory name");
+				throw new InvalidNameException("Cannot have an empty directory name");
 			}
 			return name;
 		}
@@ -113,6 +121,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 				// Combine will throw a PathTooLongException in that case.
 				if (_baseDirectory != null) {
 					name = Path.Combine(_baseDirectory, name);
+
+					if(!_allowParentTraversal && !Path.GetFullPath(name).StartsWith(_baseDirectory, StringComparison.InvariantCultureIgnoreCase))
+					{
+						throw new InvalidNameException("Parent traversal in paths is not allowed");
+					}
 				}
 			} else {
 				name = string.Empty;


### PR DESCRIPTION
Prevents files from being written outside of target directory when invoked from `FastZip.ExtractZip()`.

Attempting to extract a file that has a path traversing outside of the `targetDirectory` will throw and `InvalidNameException` unless explicitly overridden:
```.cs
new FastZip().ExtractZip(archive, targetDirectory, FastZip.Overwrite.Never,
 null, "", "", true, allowParentTraversal: true);
```

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._