### PR TITLE
Fix Gzip.Compress arguments

### DIFF
--- a/src/ICSharpCode.SharpZipLib/GZip/GZip.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GZip.cs
@@ -15,19 +15,27 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// <param name="inStream">The readable stream containing data to decompress.</param>
 		/// <param name="outStream">The output stream to receive the decompressed data.</param>
 		/// <param name="isStreamOwner">Both streams are closed on completion if true.</param>
+		/// <exception cref="ArgumentNullException">Input or output stream is null</exception>
 		public static void Decompress(Stream inStream, Stream outStream, bool isStreamOwner)
 		{
-			if (inStream == null || outStream == null) {
-				throw new Exception("Null Stream");
-			}
+			if (inStream == null)
+				throw new ArgumentNullException(nameof(inStream), "Input stream is null");
 
-			try {
-				using (GZipInputStream bzipInput = new GZipInputStream(inStream)) {
-					bzipInput.IsStreamOwner = isStreamOwner;
-					Core.StreamUtils.Copy(bzipInput, outStream, new byte[4096]);
+			if (outStream == null)
+				throw new ArgumentNullException(nameof(outStream), "Output stream is null");
+
+			try
+			{
+				using (GZipInputStream gzipInput = new GZipInputStream(inStream))
+				{
+					gzipInput.IsStreamOwner = isStreamOwner;
+					Core.StreamUtils.Copy(gzipInput, outStream, new byte[4096]);
 				}
-			} finally {
-				if (isStreamOwner) {
+			}
+			finally
+			{
+				if (isStreamOwner)
+				{
 					// inStream is closed by the GZipInputStream if stream owner
 					outStream.Dispose();
 				}
@@ -41,21 +49,31 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// <param name="inStream">The readable stream to compress.</param>
 		/// <param name="outStream">The output stream to receive the compressed data.</param>
 		/// <param name="isStreamOwner">Both streams are closed on completion if true.</param>
-		/// <param name="level">Block size acts as compression level (1 to 9) with 1 giving 
-		/// the lowest compression and 9 the highest.</param>
-		public static void Compress(Stream inStream, Stream outStream, bool isStreamOwner, int level)
+		/// <param name="bufferSize">Deflate buffer size, minimum 512</param>
+		/// <exception cref="ArgumentNullException">Input or output stream is null</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Buffer Size is smaller than 512</exception>
+		public static void Compress(Stream inStream, Stream outStream, bool isStreamOwner, int bufferSize = 512)
 		{
-			if (inStream == null || outStream == null) {
-				throw new Exception("Null Stream");
-			}
+			if (inStream == null)
+				throw new ArgumentNullException(nameof(inStream), "Input stream is null");
 
-			try {
-				using (GZipOutputStream bzipOutput = new GZipOutputStream(outStream, level)) {
-					bzipOutput.IsStreamOwner = isStreamOwner;
-					Core.StreamUtils.Copy(inStream, bzipOutput, new byte[4096]);
+			if(outStream == null)
+				throw new ArgumentNullException(nameof(outStream), "Output stream is null");
+
+			if (bufferSize < 512)
+				throw new ArgumentOutOfRangeException(nameof(bufferSize), "Deflate buffer size must be >= 512");
+
+			try
+			{
+				using (GZipOutputStream gzipOutput = new GZipOutputStream(outStream, bufferSize))
+				{
+					gzipOutput.IsStreamOwner = isStreamOwner;
+					Core.StreamUtils.Copy(inStream, gzipOutput, new byte[bufferSize]);
 				}
-			} finally {
-				if (isStreamOwner) {
+			}
+			finally {
+				if (isStreamOwner)
+				{
 					// outStream is closed by the GZipOutputStream if stream owner
 					inStream.Dispose();
 				}

--- a/src/ICSharpCode.SharpZipLib/GZip/GZip.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GZip.cs
@@ -3,6 +3,8 @@ using System.IO;
 
 namespace ICSharpCode.SharpZipLib.GZip
 {
+	using static Zip.Compression.Deflater;
+
 	/// <summary>
 	/// An example class to demonstrate compression and decompression of GZip streams.
 	/// </summary>
@@ -50,9 +52,11 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// <param name="outStream">The output stream to receive the compressed data.</param>
 		/// <param name="isStreamOwner">Both streams are closed on completion if true.</param>
 		/// <param name="bufferSize">Deflate buffer size, minimum 512</param>
+		/// <param name="level">Deflate compression level, 0-9</param>
 		/// <exception cref="ArgumentNullException">Input or output stream is null</exception>
 		/// <exception cref="ArgumentOutOfRangeException">Buffer Size is smaller than 512</exception>
-		public static void Compress(Stream inStream, Stream outStream, bool isStreamOwner, int bufferSize = 512)
+		/// <exception cref="ArgumentOutOfRangeException">Compression level outside 0-9</exception>
+		public static void Compress(Stream inStream, Stream outStream, bool isStreamOwner, int bufferSize = 512, int level = 6)
 		{
 			if (inStream == null)
 				throw new ArgumentNullException(nameof(inStream), "Input stream is null");
@@ -63,15 +67,20 @@ namespace ICSharpCode.SharpZipLib.GZip
 			if (bufferSize < 512)
 				throw new ArgumentOutOfRangeException(nameof(bufferSize), "Deflate buffer size must be >= 512");
 
+			if (level<NO_COMPRESSION || level> BEST_COMPRESSION)
+				throw new ArgumentOutOfRangeException(nameof(level), "Compression level must be 0-9");
+
 			try
 			{
 				using (GZipOutputStream gzipOutput = new GZipOutputStream(outStream, bufferSize))
 				{
+					gzipOutput.SetLevel(level);
 					gzipOutput.IsStreamOwner = isStreamOwner;
 					Core.StreamUtils.Copy(inStream, gzipOutput, new byte[bufferSize]);
 				}
 			}
-			finally {
+			finally
+			{
 				if (isStreamOwner)
 				{
 					// outStream is closed by the GZipOutputStream if stream owner

--- a/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -80,7 +80,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 
 		#region Public API
 		/// <summary>
-		/// Sets the active compression level (1-9).  The new level will be activated
+		/// Sets the active compression level (0-9).  The new level will be activated
 		/// immediately.
 		/// </summary>
 		/// <param name="level">The compression level to set.</param>
@@ -90,9 +90,9 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// <see cref="Deflater"/>
 		public void SetLevel(int level)
 		{
-			if (level < Deflater.BEST_SPEED) {
-				throw new ArgumentOutOfRangeException(nameof(level));
-			}
+			if (level < Deflater.NO_COMPRESSION || level > Deflater.BEST_COMPRESSION)
+				throw new ArgumentOutOfRangeException(nameof(level), "Compression level must be 0-9");
+
 			deflater_.SetLevel(level);
 		}
 


### PR DESCRIPTION
Fixes XML Comment for `GZip.Compress` and add supposed functionality by optional argument.

Fixes #151 without breaking backwards compability. 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
