### PR TITLE
Correctly handle Unicode strings

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -434,5 +434,36 @@ namespace ICSharpCode.SharpZipLib.Zip
 			set => ZipStrings.DefaultCodePage = value;
 		}
 
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToString(byte[], int)"/></summary>
+		[Obsolete("Use ZipStrings.ConvertToString instead")]
+		public static string ConvertToString(byte[] data, int count)
+			=> ZipStrings.ConvertToString(data, count);
+
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToString(byte[])"/></summary>
+		[Obsolete("Use ZipStrings.ConvertToString instead")]
+		public static string ConvertToString(byte[] data)
+			=> ZipStrings.ConvertToString(data);
+
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToStringExt(int, byte[], int)"/></summary>
+		[Obsolete("Use ZipStrings.ConvertToStringExt instead")]
+		public static string ConvertToStringExt(int flags, byte[] data, int count)
+			=> ZipStrings.ConvertToStringExt(flags, data, count);
+
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToStringExt(int, byte[])"/></summary>
+		[Obsolete("Use ZipStrings.ConvertToStringExt instead")]
+		public static string ConvertToStringExt(int flags, byte[] data)
+			=> ZipStrings.ConvertToStringExt(flags, data);
+
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToArray(string)"/></summary>
+		[Obsolete("Use ZipStrings.ConvertToArray instead")]
+		public static byte[] ConvertToArray(string str)
+			=> ZipStrings.ConvertToArray(str);
+
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToArray(int, string)"/></summary>
+		[Obsolete("Use ZipStrings.ConvertToArray instead")]
+		public static byte[] ConvertToArray(int flags, string str)
+			=> ZipStrings.ConvertToArray(flags, str);
+
+
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -430,8 +430,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 		[Obsolete("Use ZipStrings instead")]
 		public static int DefaultCodePage
 		{
-			get => ZipStrings.DefaultCodePage;
-			set => ZipStrings.DefaultCodePage = value;
+			get => ZipStrings.CodePage;
+			set => ZipStrings.CodePage = value;
 		}
 
 		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToString(byte[], int)"/></summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -202,7 +202,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// This class contains constants used for Zip format files
 	/// </summary>
-	public sealed class ZipConstants
+	public static class ZipConstants
 	{
 		#region Versions
 		/// <summary>
@@ -421,166 +421,18 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public const int ENDSIG = 'P' | ('K' << 8) | (5 << 16) | (6 << 24);
 		#endregion
 
-		/// <remarks>
-		/// The original Zip specification (https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) states 
-		/// that file names should only be encoded with IBM Code Page 437 or UTF-8. 
-		/// In practice, most zip apps use OEM or system encoding (typically cp437 on Windows). 
-		/// Let's be good citizens and default to UTF-8 http://utf8everywhere.org/
-		/// </remarks>
-		static int defaultCodePage = Encoding.UTF8.CodePage;
-
 		/// <summary>
 		/// Default encoding used for string conversion.  0 gives the default system OEM code page.
 		/// Using the default code page isnt the full solution neccessarily
 		/// there are many variable factors, codepage 850 is often a good choice for
 		/// European users, however be careful about compatability.
 		/// </summary>
-		public static int DefaultCodePage {
-			get {
-				return defaultCodePage;
-			}
-			set {
-				if ((value < 0) || (value > 65535) ||
-					(value == 1) || (value == 2) || (value == 3) || (value == 42)) {
-					throw new ArgumentOutOfRangeException(nameof(value));
-				}
-
-				defaultCodePage = value;
-			}
-		}
-
-		/// <summary>
-		/// Convert a portion of a byte array to a string.
-		/// </summary>		
-		/// <param name="data">
-		/// Data to convert to string
-		/// </param>
-		/// <param name="count">
-		/// Number of bytes to convert starting from index 0
-		/// </param>
-		/// <returns>
-		/// data[0]..data[count - 1] converted to a string
-		/// </returns>
-		public static string ConvertToString(byte[] data, int count)
+		[Obsolete("Use ZipStrings instead")]
+		public static int DefaultCodePage
 		{
-			if (data == null) {
-				return string.Empty;
-			}
-
-			return Encoding.GetEncoding(DefaultCodePage).GetString(data, 0, count);
+			get => ZipStrings.DefaultCodePage;
+			set => ZipStrings.DefaultCodePage = value;
 		}
 
-		/// <summary>
-		/// Convert a byte array to string
-		/// </summary>
-		/// <param name="data">
-		/// Byte array to convert
-		/// </param>
-		/// <returns>
-		/// <paramref name="data">data</paramref>converted to a string
-		/// </returns>
-		public static string ConvertToString(byte[] data)
-		{
-			if (data == null) {
-				return string.Empty;
-			}
-			return ConvertToString(data, data.Length);
-		}
-
-		/// <summary>
-		/// Convert a byte array to string
-		/// </summary>
-		/// <param name="flags">The applicable general purpose bits flags</param>
-		/// <param name="data">
-		/// Byte array to convert
-		/// </param>
-		/// <param name="count">The number of bytes to convert.</param>
-		/// <returns>
-		/// <paramref name="data">data</paramref>converted to a string
-		/// </returns>
-		public static string ConvertToStringExt(int flags, byte[] data, int count)
-		{
-			if (data == null) {
-				return string.Empty;
-			}
-
-			if ((flags & (int)GeneralBitFlags.UnicodeText) != 0) {
-				return Encoding.UTF8.GetString(data, 0, count);
-			} else {
-				return ConvertToString(data, count);
-			}
-		}
-
-		/// <summary>
-		/// Convert a byte array to string
-		/// </summary>
-		/// <param name="data">
-		/// Byte array to convert
-		/// </param>
-		/// <param name="flags">The applicable general purpose bits flags</param>
-		/// <returns>
-		/// <paramref name="data">data</paramref>converted to a string
-		/// </returns>
-		public static string ConvertToStringExt(int flags, byte[] data)
-		{
-			if (data == null) {
-				return string.Empty;
-			}
-
-			if ((flags & (int)GeneralBitFlags.UnicodeText) != 0) {
-				return Encoding.UTF8.GetString(data, 0, data.Length);
-			} else {
-				return ConvertToString(data, data.Length);
-			}
-		}
-
-		/// <summary>
-		/// Convert a string to a byte array
-		/// </summary>
-		/// <param name="str">
-		/// String to convert to an array
-		/// </param>
-		/// <returns>Converted array</returns>
-		public static byte[] ConvertToArray(string str)
-		{
-			if (str == null) {
-				return new byte[0];
-			}
-
-			return Encoding.GetEncoding(DefaultCodePage).GetBytes(str);
-		}
-
-		/// <summary>
-		/// Convert a string to a byte array
-		/// </summary>
-		/// <param name="flags">The applicable <see cref="GeneralBitFlags">general purpose bits flags</see></param>
-		/// <param name="str">
-		/// String to convert to an array
-		/// </param>
-		/// <returns>Converted array</returns>
-		public static byte[] ConvertToArray(int flags, string str)
-		{
-			if (str == null) {
-				return new byte[0];
-			}
-
-			if ((flags & (int)GeneralBitFlags.UnicodeText) != 0) {
-				return Encoding.UTF8.GetBytes(str);
-			} else {
-				return ConvertToArray(str);
-			}
-		}
-
-
-		/// <summary>
-		/// Initialise default instance of <see cref="ZipConstants">ZipConstants</see>
-		/// </summary>
-		/// <remarks>
-		/// Private to prevent instances being created.
-		/// </remarks>
-		ZipConstants()
-		{
-			// Do nothing
-		}
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -191,6 +191,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 			this.versionMadeBy = (ushort)madeByInfo;
 			this.versionToExtract = (ushort)versionRequiredToExtract;
 			this.method = method;
+
+			IsUnicodeText = ZipStrings.UseUnicode;
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntryFactory.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntryFactory.cs
@@ -59,27 +59,26 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public ZipEntryFactory()
 		{
 			nameTransform_ = new ZipNameTransform();
+			isUnicodeText_ = ZipStrings.UseUnicode;
 		}
 
 		/// <summary>
 		/// Initialise a new instance of <see cref="ZipEntryFactory"/> using the specified <see cref="TimeSetting"/>
 		/// </summary>
 		/// <param name="timeSetting">The <see cref="TimeSetting">time setting</see> to use when creating <see cref="ZipEntry">Zip entries</see>.</param>
-		public ZipEntryFactory(TimeSetting timeSetting)
+		public ZipEntryFactory(TimeSetting timeSetting): this()
 		{
 			timeSetting_ = timeSetting;
-			nameTransform_ = new ZipNameTransform();
 		}
 
 		/// <summary>
 		/// Initialise a new instance of <see cref="ZipEntryFactory"/> using the specified <see cref="DateTime"/>
 		/// </summary>
 		/// <param name="time">The time to set all <see cref="ZipEntry.DateTime"/> values to.</param>
-		public ZipEntryFactory(DateTime time)
+		public ZipEntryFactory(DateTime time): this()
 		{
 			timeSetting_ = TimeSetting.Fixed;
 			FixedDateTime = time;
-			nameTransform_ = new ZipNameTransform();
 		}
 
 		#endregion

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -98,7 +98,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public void SetComment(string comment)
 		{
 			// TODO: Its not yet clear how to handle unicode comments here.
-			byte[] commentBytes = ZipConstants.ConvertToArray(comment);
+			byte[] commentBytes = ZipStrings.ConvertToArray(comment);
 			if (commentBytes.Length > 0xffff) {
 				throw new ArgumentOutOfRangeException(nameof(comment));
 			}
@@ -320,7 +320,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 			}
 
-			byte[] name = ZipConstants.ConvertToArray(entry.Flags, entry.Name);
+			byte[] name = ZipStrings.ConvertToArray(entry.Flags, entry.Name);
 
 			if (name.Length > 0xFFFF) {
 				throw new ZipException("Entry name too long.");
@@ -669,7 +669,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					WriteLeInt((int)entry.Size);
 				}
 
-				byte[] name = ZipConstants.ConvertToArray(entry.Flags, entry.Name);
+				byte[] name = ZipStrings.ConvertToArray(entry.Flags, entry.Name);
 
 				if (name.Length > 0xffff) {
 					throw new ZipException("Name too long.");
@@ -705,7 +705,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				byte[] entryComment =
 					(entry.Comment != null) ?
-					ZipConstants.ConvertToArray(entry.Flags, entry.Comment) :
+					ZipStrings.ConvertToArray(entry.Flags, entry.Comment) :
 					new byte[0];
 
 				if (entryComment.Length > 0xffff) {

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -22,27 +22,25 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 		}
 
-		/// <summary>Default code page backing field</summary>
+		/// <summary>Code page backing field</summary>
 		/// <remarks>
 		/// The original Zip specification (https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) states 
 		/// that file names should only be encoded with IBM Code Page 437 or UTF-8. 
 		/// In practice, most zip apps use OEM or system encoding (typically cp437 on Windows). 
 		/// Let's be good citizens and default to UTF-8 http://utf8everywhere.org/
 		/// </remarks>
-		static int defaultCodePage = Encoding.UTF8.CodePage;
+		private static int codePage = Encoding.UTF8.CodePage;
 
 
 		/// <summary>
-		/// Default encoding used for string conversion.  0 gives the default system OEM code page.
-		/// Using the default code page isnt the full solution neccessarily
-		/// there are many variable factors, codepage 850 is often a good choice for
-		/// European users, however be careful about compatability.
+		/// Encoding used for string conversion. Setting this to 65001 (UTF-8) will
+		/// also set the Language encoding flag to indicate UTF-8 encoded file names.
 		/// </summary>
-		public static int DefaultCodePage
+		public static int CodePage
 		{
 			get
 			{
-				return defaultCodePage;
+				return codePage;
 			}
 			set
 			{
@@ -52,7 +50,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					throw new ArgumentOutOfRangeException(nameof(value));
 				}
 
-				defaultCodePage = value;
+				codePage = value;
 			}
 		}
 
@@ -67,7 +65,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 		/// <summary>
 		/// Get wether the default codepage is set to UTF-8. Setting this property to false will
-		/// set the <see cref="DefaultCodePage"/> to <see cref="SystemDefaultCodePage"/>
+		/// set the <see cref="CodePage"/> to <see cref="SystemDefaultCodePage"/>
 		/// </summary>
 		/// <remarks>
 		/// /// Get OEM codepage from NetFX, which parses the NLP file with culture info table etc etc.
@@ -80,23 +78,23 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			get
 			{
-				return defaultCodePage == Encoding.UTF8.CodePage;
+				return codePage == Encoding.UTF8.CodePage;
 			}
 			set
 			{
 				if (value)
 				{
-					defaultCodePage = Encoding.UTF8.CodePage;
+					codePage = Encoding.UTF8.CodePage;
 				}
 				else
 				{
-					defaultCodePage = SystemDefaultCodePage;
+					codePage = SystemDefaultCodePage;
 				}
 			}
 		}
 
 		/// <summary>
-		/// Convert a portion of a byte array to a string using <see cref="DefaultCodePage"/>
+		/// Convert a portion of a byte array to a string using <see cref="CodePage"/>
 		/// </summary>		
 		/// <param name="data">
 		/// Data to convert to string
@@ -110,10 +108,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public static string ConvertToString(byte[] data, int count) 
 			=> data == null
 			? string.Empty
-			: Encoding.GetEncoding(DefaultCodePage).GetString(data, 0, count);
+			: Encoding.GetEncoding(CodePage).GetString(data, 0, count);
 
 		/// <summary>
-		/// Convert a byte array to a string using <see cref="DefaultCodePage"/>
+		/// Convert a byte array to a string using <see cref="CodePage"/>
 		/// </summary>
 		/// <param name="data">
 		/// Byte array to convert
@@ -130,7 +128,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				: Encoding.GetEncoding(SystemDefaultCodePage);
 
 		/// <summary>
-		/// Convert a byte array to a string  using <see cref="DefaultCodePage"/>
+		/// Convert a byte array to a string  using <see cref="CodePage"/>
 		/// </summary>
 		/// <param name="flags">The applicable general purpose bits flags</param>
 		/// <param name="data">
@@ -146,7 +144,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				: EncodingFromFlag(flags).GetString(data, 0, count);
 
 		/// <summary>
-		/// Convert a byte array to a string using <see cref="DefaultCodePage"/>
+		/// Convert a byte array to a string using <see cref="CodePage"/>
 		/// </summary>
 		/// <param name="data">
 		/// Byte array to convert
@@ -159,7 +157,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			=> ConvertToStringExt(flags, data, data.Length);
 
 		/// <summary>
-		/// Convert a string to a byte array using <see cref="DefaultCodePage"/>
+		/// Convert a string to a byte array using <see cref="CodePage"/>
 		/// </summary>
 		/// <param name="str">
 		/// String to convert to an array
@@ -168,10 +166,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public static byte[] ConvertToArray(string str)
 			=> str == null
 			? new byte[0]
-			: Encoding.GetEncoding(DefaultCodePage).GetBytes(str);
+			: Encoding.GetEncoding(CodePage).GetBytes(str);
 
 		/// <summary>
-		/// Convert a string to a byte array using <see cref="DefaultCodePage"/>
+		/// Convert a string to a byte array using <see cref="CodePage"/>
 		/// </summary>
 		/// <param name="flags">The applicable <see cref="GeneralBitFlags">general purpose bits flags</see></param>
 		/// <param name="str">

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -1,8 +1,14 @@
-﻿namespace ICSharpCode.SharpZipLib.Zip
+﻿using System;
+using System.Text;
+
+namespace ICSharpCode.SharpZipLib.Zip
 {
+	/// <summary>
+	/// This static class contains functions for encoding and decoding zip file strings
+	/// </summary>
 	public static class ZipStrings
 	{
-
+		/// <summary>Default code page backing field</summary>
 		/// <remarks>
 		/// The original Zip specification (https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) states 
 		/// that file names should only be encoded with IBM Code Page 437 or UTF-8. 

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -1,0 +1,218 @@
+﻿namespace ICSharpCode.SharpZipLib.Zip
+{
+	public static class ZipStrings
+	{
+
+		/// <remarks>
+		/// The original Zip specification (https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) states 
+		/// that file names should only be encoded with IBM Code Page 437 or UTF-8. 
+		/// In practice, most zip apps use OEM or system encoding (typically cp437 on Windows). 
+		/// Let's be good citizens and default to UTF-8 http://utf8everywhere.org/
+		/// </remarks>
+		static int defaultCodePage = Encoding.UTF8.CodePage;
+
+
+		/// <summary>
+		/// Default encoding used for string conversion.  0 gives the default system OEM code page.
+		/// Using the default code page isnt the full solution neccessarily
+		/// there are many variable factors, codepage 850 is often a good choice for
+		/// European users, however be careful about compatability.
+		/// </summary>
+		public static int DefaultCodePage
+		{
+			get
+			{
+				return defaultCodePage;
+			}
+			set
+			{
+				if ((value < 0) || (value > 65535) ||
+					(value == 1) || (value == 2) || (value == 3) || (value == 42))
+				{
+					throw new ArgumentOutOfRangeException(nameof(value));
+				}
+
+				defaultCodePage = value;
+			}
+		}
+
+
+		private const int FallbackCodePage = 437;
+
+		/// <summary>
+		/// Get wether the default codepage is set to UTF-8. Setting this property to false will attempt to
+		/// set the default codepage to the default code page of the operating system ,or failing that, to
+		/// the fallback code page IBM 437.
+		/// </summary>
+		/// <remarks>
+		/// /// Get OEM codepage from NetFX, which parses the NLP file with culture info table etc etc.
+		/// But sometimes it yields the special value of 1 which is nicknamed <c>CodePageNoOEM</c> in <see cref="Encoding"/> sources (might also mean <c>CP_OEMCP</c>, but Encoding puts it so).
+		/// This was observed on Ukranian and Hindu systems.
+		/// Given this value, <see cref="Encoding.GetEncoding(int)"/> throws an <see cref="ArgumentException"/>.
+		/// So replace it with <see cref="FallbackCodePage"/>, (IBM 437 which is the default code page in a default Windows installation console.
+		/// </remarks>
+		public static bool UseUnicode
+		{
+			get
+			{
+				return defaultCodePage == Encoding.UTF8.CodePage;
+			}
+			set
+			{
+				if (value)
+				{
+					defaultCodePage = Encoding.UTF8.CodePage;
+				}
+				else
+				{
+					try
+					{
+						var codePage = Encoding.GetEncoding(0).CodePage;
+						defaultCodePage = (codePage == 1 || codePage == 2 || codePage == 3 || codePage == 42) ? FallbackCodePage : codePage;
+					}
+					catch
+					{
+						defaultCodePage = FallbackCodePage;
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Convert a portion of a byte array to a string.
+		/// </summary>		
+		/// <param name="data">
+		/// Data to convert to string
+		/// </param>
+		/// <param name="count">
+		/// Number of bytes to convert starting from index 0
+		/// </param>
+		/// <returns>
+		/// data[0]..data[count - 1] converted to a string
+		/// </returns>
+		public static string ConvertToString(byte[] data, int count)
+		{
+			if (data == null)
+			{
+				return string.Empty;
+			}
+
+			return Encoding.GetEncoding(DefaultCodePage).GetString(data, 0, count);
+		}
+
+		/// <summary>
+		/// Convert a byte array to string
+		/// </summary>
+		/// <param name="data">
+		/// Byte array to convert
+		/// </param>
+		/// <returns>
+		/// <paramref name="data">data</paramref>converted to a string
+		/// </returns>
+		public static string ConvertToString(byte[] data)
+		{
+			if (data == null)
+			{
+				return string.Empty;
+			}
+			return ConvertToString(data, data.Length);
+		}
+
+		/// <summary>
+		/// Convert a byte array to string
+		/// </summary>
+		/// <param name="flags">The applicable general purpose bits flags</param>
+		/// <param name="data">
+		/// Byte array to convert
+		/// </param>
+		/// <param name="count">The number of bytes to convert.</param>
+		/// <returns>
+		/// <paramref name="data">data</paramref>converted to a string
+		/// </returns>
+		public static string ConvertToStringExt(int flags, byte[] data, int count)
+		{
+			if (data == null)
+			{
+				return string.Empty;
+			}
+
+			if ((flags & (int)GeneralBitFlags.UnicodeText) != 0)
+			{
+				return Encoding.UTF8.GetString(data, 0, count);
+			}
+			else
+			{
+				return ConvertToString(data, count);
+			}
+		}
+
+		/// <summary>
+		/// Convert a byte array to string
+		/// </summary>
+		/// <param name="data">
+		/// Byte array to convert
+		/// </param>
+		/// <param name="flags">The applicable general purpose bits flags</param>
+		/// <returns>
+		/// <paramref name="data">data</paramref>converted to a string
+		/// </returns>
+		public static string ConvertToStringExt(int flags, byte[] data)
+		{
+			if (data == null)
+			{
+				return string.Empty;
+			}
+
+			if ((flags & (int)GeneralBitFlags.UnicodeText) != 0)
+			{
+				return Encoding.UTF8.GetString(data, 0, data.Length);
+			}
+			else
+			{
+				return ConvertToString(data, data.Length);
+			}
+		}
+
+		/// <summary>
+		/// Convert a string to a byte array
+		/// </summary>
+		/// <param name="str">
+		/// String to convert to an array
+		/// </param>
+		/// <returns>Converted array</returns>
+		public static byte[] ConvertToArray(string str)
+		{
+			if (str == null)
+			{
+				return new byte[0];
+			}
+
+			return Encoding.GetEncoding(DefaultCodePage).GetBytes(str);
+		}
+
+		/// <summary>
+		/// Convert a string to a byte array
+		/// </summary>
+		/// <param name="flags">The applicable <see cref="GeneralBitFlags">general purpose bits flags</see></param>
+		/// <param name="str">
+		/// String to convert to an array
+		/// </param>
+		/// <returns>Converted array</returns>
+		public static byte[] ConvertToArray(int flags, string str)
+		{
+			if (str == null)
+			{
+				return new byte[0];
+			}
+
+			if ((flags & (int)GeneralBitFlags.UnicodeText) != 0)
+			{
+				return Encoding.UTF8.GetBytes(str);
+			}
+			else
+			{
+				return ConvertToArray(str);
+			}
+		}
+	}
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/StringTesting.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/StringTesting.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ICSharpCode.SharpZipLib.Tests.TestSupport
+{
+    public static class StringTesting
+    {
+		static StringTesting()
+		{
+			AddLanguage("Chinese", "測試.txt", "big5");
+			AddLanguage("Greek", "Ϗΰ.txt", "windows-1253");
+			AddLanguage("Nordic", "Åæ.txt", "windows-1252");
+			AddLanguage("Arabic", "ڀڅ.txt", "windows-1256");
+		}
+
+		private static void AddLanguage(string language, string filename, string encoding)
+		{
+			languages.Add(language);
+			filenames.Add(filename);
+			encodings.Add(encoding);
+			entries++;
+		}
+
+		private static int entries = 0;
+		private static List<string> languages = new List<string>();
+		private static List<string> filenames = new List<string>();
+		private static List<string> encodings = new List<string>();
+
+		public static IEnumerable<string> Languages => filenames.AsReadOnly();
+		public static IEnumerable<string> Filenames => filenames.AsReadOnly();
+		public static IEnumerable<string> Encodings => filenames.AsReadOnly();
+
+		public static IEnumerable<(string language, string filename, string encoding)> GetTestSamples()
+		{
+			for (int i = 0; i < entries; i++)
+			{
+				yield return (languages[i], filenames[i], encodings[i]);
+			}
+		}
+	}
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using NUnit.Framework;
 
 namespace ICSharpCode.SharpZipLib.Tests.TestSupport
@@ -27,21 +28,29 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 			}
 		}
 
-		public static TempFile GetDummyFile(int size = -1)
+		public static void WriteDummyData(string fileName, int size = -1)
 		{
-			var tempFile = new TempFile();
 			if (size < 0)
 			{
-				File.WriteAllText(tempFile.Filename, DateTime.UtcNow.Ticks.ToString("x16"));
+				File.WriteAllText(fileName, DateTime.UtcNow.Ticks.ToString("x16"));
 			}
 			else if (size > 0)
 			{
 				var bytes = Array.CreateInstance(typeof(byte), size) as byte[];
 				random.NextBytes(bytes);
-				File.WriteAllBytes(tempFile.Filename, bytes);
+				File.WriteAllBytes(fileName, bytes);
 			}
+		}
+
+		public static TempFile GetDummyFile(int size = -1)
+		{
+			var tempFile = new TempFile();
+			WriteDummyData(tempFile.Filename, size);
 			return tempFile;
 		}
+
+		public static string GetDummyFileName()
+			=> $"{random.Next():x8}{random.Next():x8}{random.Next():x8}";
 
 		public class TempFile : IDisposable
 		{
@@ -113,6 +122,16 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
 			public void Dispose()
 				=> Dispose(true);
+
+			internal string CreateDummyFile(int size = -1)
+				=> CreateDummyFile(GetDummyFileName(), size);
+
+			internal string CreateDummyFile(string name, int size = -1)
+			{
+				var fileName = Path.Combine(Fullpath, name);
+				WriteDummyData(fileName, size);
+				return fileName;
+			}
 
 			#endregion
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
@@ -805,8 +805,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 		void CheckNameConversion(string toCheck)
 		{
-			byte[] intermediate = ZipConstants.ConvertToArray(toCheck);
-			string final = ZipConstants.ConvertToString(intermediate);
+			byte[] intermediate = ZipStrings.ConvertToArray(toCheck);
+			string final = ZipStrings.ConvertToString(intermediate);
 
 			Assert.AreEqual(toCheck, final, "Expected identical result");
 		}
@@ -830,17 +830,17 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			byte[] rawData = Encoding.ASCII.GetBytes(sample);
 
-			string converted = ZipConstants.ConvertToStringExt(0, rawData);
+			string converted = ZipStrings.ConvertToStringExt(0, rawData);
 			Assert.AreEqual(sample, converted);
 
-			converted = ZipConstants.ConvertToStringExt((int)GeneralBitFlags.UnicodeText, rawData);
+			converted = ZipStrings.ConvertToStringExt((int)GeneralBitFlags.UnicodeText, rawData);
 			Assert.AreEqual(sample, converted);
 
 			// This time use some greek characters
 			sample = "\u03A5\u03d5\u03a3";
 			rawData = Encoding.UTF8.GetBytes(sample);
 
-			converted = ZipConstants.ConvertToStringExt((int)GeneralBitFlags.UnicodeText, rawData);
+			converted = ZipStrings.ConvertToStringExt((int)GeneralBitFlags.UnicodeText, rawData);
 			Assert.AreEqual(sample, converted);
 		}
 


### PR DESCRIPTION
Commit 2c458be replaced the default code page with UTF-8, but ZipEntry.IsUnicodeText is still set to `false` by default.
This makes it the default behaviour of SharpZipLib to create zip files that *claim* they are **not** coded using UTF-8 (but instead with what is presumed to be the locale default code page), but still containing  UTF-8 encoded file names.

This PR will rectify that by setting the `ZipEntry.IsUnicodeText` default based on what `ZipStrings.CodePage` (previously called `ZipConstants.DefaultCodePage`) is set to.

This also moves the string transcoding from `ZipConstants` to `ZipStrings` as I could not let it stay inside a class obviously named for another purpose.
There are still wrappers for all public functionality that provides full backwards compability.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
