### PR TITLE
Fixed issue by using lower 16 bytes as IV for AES256

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -81,18 +81,14 @@ namespace ICSharpCode.SharpZipLib.Encryption
 			var rm = new AesManaged();
 			rm.Mode = CipherMode.ECB;           // No feedback from cipher for CTR mode
 			_counterNonce = new byte[_blockSize];
-			byte[] byteKey1 = pdb.GetBytes(_blockSize);
-			byte[] byteIV = pdb.GetBytes(_blockSize);
-			if (byteIV.Length > 16)
-			{
-				byte[] byteInit = new byte[16];
-				Buffer.BlockCopy(byteIV, 0, byteInit, 0, 16);
-				byteIV = byteInit;
-			}
-			_encryptor = rm.CreateEncryptor(byteKey1, byteIV);
+			byte[] key1bytes = pdb.GetBytes(_blockSize);
+			byte[] key2bytes = pdb.GetBytes(_blockSize);
+			
+			// Use empty IV for AES
+			_encryptor = rm.CreateEncryptor(key1bytes, new byte[16]);
 			_pwdVerifier = pdb.GetBytes(PWD_VER_LENGTH);
 			//
-			_hmacsha1 = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA1, byteIV);
+			_hmacsha1 = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA1, key2bytes);
 			_writeMode = writeMode;
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -78,7 +78,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 
 			// Performs the equivalent of derive_key in Dr Brian Gladman's pwd2key.c
 			var pdb = new Rfc2898DeriveBytes(key, saltBytes, KEY_ROUNDS);
-			var rm = new AesManaged();//Aes.Create();
+			var rm = new AesManaged();
 			rm.Mode = CipherMode.ECB;           // No feedback from cipher for CTR mode
 			_counterNonce = new byte[_blockSize];
 			byte[] byteKey1 = pdb.GetBytes(_blockSize);

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -78,7 +78,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 
 			// Performs the equivalent of derive_key in Dr Brian Gladman's pwd2key.c
 			var pdb = new Rfc2898DeriveBytes(key, saltBytes, KEY_ROUNDS);
-			var rm = new AesManaged();
+			var rm = Aes.Create();
 			rm.Mode = CipherMode.ECB;           // No feedback from cipher for CTR mode
 			_counterNonce = new byte[_blockSize];
 			byte[] key1bytes = pdb.GetBytes(_blockSize);


### PR DESCRIPTION
<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
