### PR TITLE
Update README.md to reflect namespace change for ICSharpCode.SharpZipLib.Checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Namespace layout
 | Module | Namespace |
 |:----------------:|:-----------------------------|
 |BZip2 implementation|ICSharpCode.SharpZipLib.BZip2.\*|
-|Checksum implementation|ICSharpCode.SharpZipLib.Checksums.\*|
+|Checksum implementation|ICSharpCode.SharpZipLib.Checksum.\*|
 |Core utilities / interfaces|ICSharpCode.SharpZipLib.Core.\*|
 |Encryption implementation|ICSharpCode.SharpZipLib.Encryption.\*|
 |GZip implementation|ICSharpCode.SharpZipLib.GZip.\*|


### PR DESCRIPTION
The checksum namespace changed from `ICSharpCode.SharpZipLib.Checksums.*` to `ICSharpCode.SharpZipLib.Checksum.*`, but the readme/documentation still referred to the plural name...

This should probably also be added as breaking change when upgrading from 0.86 to 1.0.0!