### PR TITLE
Prevent exception in ZipAESTransform

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -155,8 +155,11 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		/// </summary>
 		public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
 		{
-
-			throw new NotImplementedException("ZipAESTransform.TransformFinalBlock");
+			if(inputCount > 0)
+			{
+				throw new NotImplementedException("TransformFinalBlock is not implemented and inputCount is greater than 0");
+			}
+			return new byte[0];
 		}
 
 		/// <summary>


### PR DESCRIPTION
As long as `inputCount` is 0, no actual work has to be done inside `TransformFinalBlock` so no exception should be thrown.
This should fix AES decryption since the last block is handled by `TransformBlock` as far as I can tell.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
