### PR TITLE
Fix 274 and 278

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 
 namespace ICSharpCode.SharpZipLib.Zip
@@ -29,8 +29,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// In practice, most zip apps use OEM or system encoding (typically cp437 on Windows). 
 		/// Let's be good citizens and default to UTF-8 http://utf8everywhere.org/
 		/// </remarks>
-		private static int codePage = Encoding.UTF8.CodePage;
+		private static int codePage = AutomaticCodePage;
 
+		/// Automatically select codepage while opening archive
+		/// see https://github.com/icsharpcode/SharpZipLib/pull/280#issuecomment-433608324
+		/// 
+		private const int AutomaticCodePage = -1;
 
 		/// <summary>
 		/// Encoding used for string conversion. Setting this to 65001 (UTF-8) will
@@ -40,7 +44,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			get
 			{
-				return codePage;
+				return codePage == AutomaticCodePage? Encoding.UTF8.CodePage:codePage;
 			}
 			set
 			{
@@ -130,9 +134,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 					// then we must use SystemDefault (old behavior)
 					// otherwise, CodePage should be preferred over SystemDefault
 					// see https://github.com/icsharpcode/SharpZipLib/issues/274
-					CodePage == Encoding.UTF8.CodePage? 
+					codePage == AutomaticCodePage? 
 						SystemDefaultCodePage:
-						CodePage);
+						codePage);
 
 		/// <summary>
 		/// Convert a byte array to a string  using <see cref="CodePage"/>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -125,7 +125,14 @@ namespace ICSharpCode.SharpZipLib.Zip
 		private static Encoding EncodingFromFlag(int flags)
 			=> ((flags & (int)GeneralBitFlags.UnicodeText) != 0)
 				? Encoding.UTF8
-				: Encoding.GetEncoding(SystemDefaultCodePage);
+				: Encoding.GetEncoding(
+					// if CodePage wasn't set manually and no utf flag present
+					// then we must use SystemDefault (old behavior)
+					// otherwise, CodePage should be preferred over SystemDefault
+					// see https://github.com/icsharpcode/SharpZipLib/issues/274
+					CodePage == Encoding.UTF8.CodePage? 
+						SystemDefaultCodePage:
+						CodePage);
 
 		/// <summary>
 		/// Convert a byte array to a string  using <see cref="CodePage"/>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 
 namespace ICSharpCode.SharpZipLib.Zip
@@ -13,8 +13,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			try
 			{
-				var codePage = Encoding.GetEncoding(0).CodePage;
-				SystemDefaultCodePage = (codePage == 1 || codePage == 2 || codePage == 3 || codePage == 42) ? FallbackCodePage : codePage;
+				var platformCodepage = Encoding.GetEncoding(0).CodePage;
+				SystemDefaultCodePage = (platformCodepage == 1 || platformCodepage == 2 || platformCodepage == 3 || platformCodepage == 42) ? FallbackCodePage : platformCodepage;
 			}
 			catch
 			{

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/StringTesting.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/StringTesting.cs
@@ -12,6 +12,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 			AddLanguage("Greek", "Ϗΰ.txt", "windows-1253");
 			AddLanguage("Nordic", "Åæ.txt", "windows-1252");
 			AddLanguage("Arabic", "ڀڅ.txt", "windows-1256");
+			AddLanguage("Russian", "Прйвёт.txt", "windows-1251");
 		}
 
 		private static void AddLanguage(string language, string filename, string encoding)

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -224,6 +224,20 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				foreach((string language, string filename, string encoding) in StringTesting.GetTestSamples())
 				{
 					Console.WriteLine($"{language} filename \"{filename}\" using \"{encoding}\":");
+
+					// TODO: samples of this test must be reversible
+					// Some samples can't be restored back with their encoding.
+					// test wasn't failing only because SystemDefaultCodepage is 65001 on Net.Core and
+					// old behaviour actually was using Unicode instead of user's passed codepage
+					var encoder = Encoding.GetEncoding(encoding);
+					var bytes = encoder.GetBytes(filename);
+					var restoredString = encoder.GetString(bytes);
+					if(string.CompareOrdinal(filename, restoredString) != 0)
+					{
+						Console.WriteLine($"Sample for language {language} with value of {filename} is skipped, because it's irreversable");
+						continue;
+					}
+
 					ZipStrings.CodePage = Encoding.GetEncoding(encoding).CodePage;
 					TestFileNames(filename);
 				}


### PR DESCRIPTION
<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

Issues #274 and #278 are fixed, but there's an another issue with Unicode test samples.

It seems, that Greek and Arabic samples are incorrect. I've added a workaround in https://github.com/EvilBeaver/SharpZipLib/commit/887e10def8eec0cd41fa531b9f4dd1f8c1c39227

Probably, old-code tests weren't failing, because ZipStrings.SystemDefaultCodePage was set to 65001, which is seems to be returned by default from Encoding.GetEncoding(0) on net.core
