### PR TITLE
ZipFile: Bugfix: Use unicode encoding to read the name string if UseUnicode is set

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -3020,6 +3020,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 				byte[] buffer = new byte[Math.Max(nameLen, commentLen)];
 
 				StreamUtils.ReadFully(baseStream_, buffer, 0, nameLen);
+				if (ZipStrings.UseUnicode)
+				{
+					bitFlags |= (int)GeneralBitFlags.UnicodeText;
+				}
 				string name = ZipConstants.ConvertToStringExt(bitFlags, buffer, nameLen);
 
 				var entry = new ZipEntry(name, versionToExtract, versionMadeBy, (CompressionMethod)method);


### PR DESCRIPTION
This is to amend PR #255, note that before this patch the UnicodeText flag is set in the ZipEntry constructor, after we have already read the name as non-unicode, which is obviously not right.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
