### PR TITLE
Fix exception from deleting a directory ZipEntry in a ZipFile

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -2461,7 +2461,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		private int FindExistingUpdate(ZipEntry entry)
 		{
 			int result = -1;
-			string convertedName = GetTransformedFileName(entry.Name);
+			string convertedName = entry.IsDirectory
+				? GetTransformedDirectoryName(entry.Name)
+				: GetTransformedFileName(entry.Name);
 
 			if (updateIndex_.ContainsKey(convertedName))
 			{

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -403,6 +403,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			string addFile2 = Path.Combine(tempFile, "b.dat");
 			MakeTempFile(addFile2, 259);
 
+			string addDirectory = Path.Combine(tempFile, "dir");
+
 			tempFile = Path.Combine(tempFile, "SharpZipTest.Zip");
 
 			using (ZipFile f = ZipFile.Create(tempFile))
@@ -410,16 +412,26 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				f.BeginUpdate();
 				f.Add(addFile);
 				f.Add(addFile2);
+				f.AddDirectory(addDirectory);
 				f.CommitUpdate();
 				Assert.IsTrue(f.TestArchive(true));
 			}
 
 			using (ZipFile f = new ZipFile(tempFile))
 			{
-				Assert.AreEqual(2, f.Count);
+				Assert.AreEqual(3, f.Count);
 				Assert.IsTrue(f.TestArchive(true));
+
+				// Delete file
 				f.BeginUpdate();
 				f.Delete(f[0]);
+				f.CommitUpdate();
+				Assert.AreEqual(2, f.Count);
+				Assert.IsTrue(f.TestArchive(true));
+
+				// Delete directory
+				f.BeginUpdate();
+				f.Delete(f[1]);
 				f.CommitUpdate();
 				Assert.AreEqual(1, f.Count);
 				Assert.IsTrue(f.TestArchive(true));


### PR DESCRIPTION
`ZipFile.FindExistingUpdate(ZipEntry)` would always return -1 for directory `ZipEntry`s due to using `GetTransformedFileName` on all `ZipEntry`s. As a result, `ZipFile.Delete(ZipEntry)` would always throw an exception when passed a directory `ZipEntry`. The fix is to call `GetTransformedDirectoryName` for directory `ZipEntry`s.

I updated the test `AddAndDeleteEntries` in `ZipFileHandling.cs` to add and delete a directory; this test failed without the change to `ZipFile.FindExistingUpdate`.

I believe issue #290 is related.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
