### PR TITLE
Performance enhancement by skipping the (unnecessary) checks in ArraySegment

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Checksum/BZip2Crc.cs
+++ b/src/ICSharpCode.SharpZipLib/Checksum/BZip2Crc.cs
@@ -177,10 +177,11 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		/// </param>
 		public void Update(ArraySegment<byte> segment)
 		{
-			foreach (byte b in segment)
-			{
-				Update(b);
-			}
+			var count = segment.Count;
+			var offset = segment.Offset;
+
+			while (--count >= 0)
+				Update(segment.Array[offset++]);
 		}
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Checksum/Crc32.cs
+++ b/src/ICSharpCode.SharpZipLib/Checksum/Crc32.cs
@@ -166,10 +166,11 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		/// </param>
 		public void Update(ArraySegment<byte> segment)
 		{
-			foreach (byte b in segment)
-			{
-				Update(b);
-			}
+			var count = segment.Count;
+			var offset = segment.Offset;
+
+			while (--count >= 0)
+				Update(segment.Array[offset++]);
 		}
 	}
 }


### PR DESCRIPTION
Another fix for this issue: https://github.com/icsharpcode/SharpZipLib/issues/289


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
