### PR TITLE
Add a leaveOpen parameter to the ZipFile constructor, used to set the…

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -425,7 +425,25 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <exception cref="ZipException">
 		/// The file doesn't contain a valid zip archive.
 		/// </exception>
-		public ZipFile(FileStream file)
+		public ZipFile(FileStream file) :
+			this(file, false)
+		{
+			
+		}
+
+		/// <summary>
+		/// Opens a Zip file reading the given <see cref="FileStream"/>.
+		/// </summary>
+		/// <param name="file">The <see cref="FileStream"/> to read archive data from.</param>
+		/// <param name="leaveOpen">true to leave the <see cref="FileStream">file</see> open when the ZipFile is disposed, false to dispose of it</param>
+		/// <exception cref="ArgumentNullException">The supplied argument is null.</exception>
+		/// <exception cref="IOException">
+		/// An i/o error occurs.
+		/// </exception>
+		/// <exception cref="ZipException">
+		/// The file doesn't contain a valid zip archive.
+		/// </exception>
+		public ZipFile(FileStream file, bool leaveOpen)
 		{
 			if (file == null)
 			{
@@ -439,7 +457,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			baseStream_ = file;
 			name_ = file.Name;
-			isStreamOwner = true;
+			isStreamOwner = !leaveOpen;
 
 			try
 			{
@@ -468,7 +486,30 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <exception cref="ArgumentNullException">
 		/// The <see cref="Stream">stream</see> argument is null.
 		/// </exception>
-		public ZipFile(Stream stream)
+		public ZipFile(Stream stream) :
+			this(stream, false)
+		{
+			
+		}
+
+		/// <summary>
+		/// Opens a Zip file reading the given <see cref="Stream"/>.
+		/// </summary>
+		/// <param name="stream">The <see cref="Stream"/> to read archive data from.</param>
+		/// <param name="leaveOpen">true to leave the <see cref="Stream">stream</see> open when the ZipFile is disposed, false to dispose of it</param>
+		/// <exception cref="IOException">
+		/// An i/o error occurs
+		/// </exception>
+		/// <exception cref="ZipException">
+		/// The stream doesn't contain a valid zip archive.<br/>
+		/// </exception>
+		/// <exception cref="ArgumentException">
+		/// The <see cref="Stream">stream</see> doesnt support seeking.
+		/// </exception>
+		/// <exception cref="ArgumentNullException">
+		/// The <see cref="Stream">stream</see> argument is null.
+		/// </exception>
+		public ZipFile(Stream stream, bool leaveOpen)
 		{
 			if (stream == null)
 			{
@@ -481,7 +522,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 
 			baseStream_ = stream;
-			isStreamOwner = true;
+			isStreamOwner = !leaveOpen;
 
 			if (baseStream_.Length > 0)
 			{

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
@@ -100,6 +100,74 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 	}
 
 	/// <summary>
+	/// An extended <see cref="FileStream">file stream</see>
+	/// that tracks closing and disposing
+	/// </summary>
+	public class TrackedFileStream : FileStream
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TrackedMemoryStream"/> class.
+		/// </summary>
+		/// <param name="buffer">The buffer.</param>
+		public TrackedFileStream(string path, FileMode mode = FileMode.Open, FileAccess access = FileAccess.Read)
+			: base(path, mode, access)
+		{
+		}
+
+		/// <summary>
+		/// Releases the unmanaged resources used by the <see cref="T:System.IO.MemoryStream"/> class and optionally releases the managed resources.
+		/// </summary>
+		/// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+		protected override void Dispose(bool disposing)
+		{
+			isDisposed_ = true;
+			base.Dispose(disposing);
+		}
+
+		/// <summary>
+		/// Closes the current stream and releases any resources (such as sockets and file handles) associated with the current stream.
+		/// </summary>
+		public override void Close()
+		{
+			if (isClosed_)
+			{
+				throw new InvalidOperationException("Already closed");
+			}
+
+			isClosed_ = true;
+			base.Close();
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether this instance is closed.
+		/// </summary>
+		/// <value><c>true</c> if this instance is closed; otherwise, <c>false</c>.</value>
+		public bool IsClosed
+		{
+			get { return isClosed_; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether this instance is disposed.
+		/// </summary>
+		/// <value>
+		/// 	<c>true</c> if this instance is disposed; otherwise, <c>false</c>.
+		/// </value>
+		public bool IsDisposed
+		{
+			get { return isDisposed_; }
+		}
+
+		#region Instance Fields
+
+		private bool isDisposed_;
+
+		private bool isClosed_;
+
+		#endregion Instance Fields
+	}
+
+	/// <summary>
 	/// A <see cref="Stream"/> that cannot seek.
 	/// </summary>
 	public class MemoryStreamWithoutSeek : TrackedMemoryStream


### PR DESCRIPTION
… default value of isStreamOwner

Related to #144 - This change adds an extra version of the constructor for ZipFile which takes a 'leaveOpen' flag, which can be set to set the isStreamOwner flag during construction rather than after, which can help avoid unwanted stream disposal if the constructor throws (the param is called leaveOpen rather than isStreamOwner to match the naming of various other .net libs, and could be changed).

[WIP] because it could do with some tests if deemed a reasonable thing to do.


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
