### PR TITLE
Changes to AES zip handling to better handle stream read attempts only returning partial data

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/StreamUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/StreamUtils.cs
@@ -65,6 +65,54 @@ namespace ICSharpCode.SharpZipLib.Core
 		}
 
 		/// <summary>
+		/// Read as much data as possible from a <see cref="Stream"/>", up to the requested number of bytes
+		/// </summary>
+		/// <param name="stream">The stream to read data from.</param>
+		/// <param name="buffer">The buffer to store data in.</param>
+		/// <param name="offset">The offset at which to begin storing data.</param>
+		/// <param name="count">The number of bytes of data to store.</param>
+		/// <exception cref="ArgumentNullException">Required parameter is null</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="offset"/> and or <paramref name="count"/> are invalid.</exception>
+		static public int ReadRequestedBytes(Stream stream, byte[] buffer, int offset, int count)
+		{
+			if (stream == null)
+			{
+				throw new ArgumentNullException(nameof(stream));
+			}
+
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
+			// Offset can equal length when buffer and count are 0.
+			if ((offset < 0) || (offset > buffer.Length))
+			{
+				throw new ArgumentOutOfRangeException(nameof(offset));
+			}
+
+			if ((count < 0) || (offset + count > buffer.Length))
+			{
+				throw new ArgumentOutOfRangeException(nameof(count));
+			}
+
+			int totalReadCount = 0;
+			while (count > 0)
+			{
+				int readCount = stream.Read(buffer, offset, count);
+				if (readCount <= 0)
+				{
+					break;
+				}
+				offset += readCount;
+				count -= readCount;
+				totalReadCount += readCount;
+			}
+
+			return totalReadCount;
+		}
+
+		/// <summary>
 		/// Copy the contents of one <see cref="Stream"/> to another.
 		/// </summary>
 		/// <param name="source">The stream to source data from.</param>

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
+using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.Encryption
 {
@@ -78,7 +79,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 					_slideBufFreePos -= _slideBufStartPos;      // Note the -=
 					_slideBufStartPos = 0;
 				}
-				int obtained = _stream.Read(_slideBuffer, _slideBufFreePos, lengthToRead);
+				int obtained = StreamUtils.ReadRequestedBytes(_stream, _slideBuffer, _slideBufFreePos, lengthToRead);
 				_slideBufFreePos += obtained;
 
 				// Recalculate how much data we now have

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -3523,12 +3523,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 					}
 					int saltLen = entry.AESSaltLen;
 					byte[] saltBytes = new byte[saltLen];
-					int saltIn = baseStream.Read(saltBytes, 0, saltLen);
+					int saltIn = StreamUtils.ReadRequestedBytes(baseStream, saltBytes, 0, saltLen);
 					if (saltIn != saltLen)
 						throw new ZipException("AES Salt expected " + saltLen + " got " + saltIn);
 					//
 					byte[] pwdVerifyRead = new byte[2];
-					baseStream.Read(pwdVerifyRead, 0, 2);
+					StreamUtils.ReadFully(baseStream, pwdVerifyRead);
 					int blockSize = entry.AESKeySize / 8;   // bits to bytes
 
 					var decryptor = new ZipAESTransform(rawPassword_, saltBytes, blockSize, false);

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
@@ -453,4 +453,22 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
 		#endregion Instance Fields
 	}
+
+	internal class SingleByteReadingStream : MemoryStream
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SingleByteReadingStream"/> class.
+		/// </summary>
+		public SingleByteReadingStream()
+		{
+		}
+
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			if (count > 0)
+				count = 1;
+
+			return base.Read(buffer, offset, count);
+		}
+	}
 }


### PR DESCRIPTION
Some changes to the reading of AES encrypted zips, to try to better handle reading from streams which might onyl return part of the requested data.

Refs https://github.com/icsharpcode/SharpZipLib/issues/303, posible alternative approach to https://github.com/icsharpcode/SharpZipLib/pull/305



_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
