### PR TITLE
Change FastZip.ExtractZip to use the new ZipFile constructor to set isStreamOwner, rather than setting the property after construction

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -464,13 +464,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 			directoryFilter_ = new NameFilter(directoryFilter);
 			restoreDateTimeOnExtract_ = restoreDateTime;
 
-			using (zipFile_ = new ZipFile(inputStream))
+			using (zipFile_ = new ZipFile(inputStream, !isStreamOwner))
 			{
 				if (password_ != null)
 				{
 					zipFile_.Password = password_;
 				}
-				zipFile_.IsStreamOwner = isStreamOwner;
+
 				System.Collections.IEnumerator enumerator = zipFile_.GetEnumerator();
 				while (continueRunning_ && enumerator.MoveNext())
 				{


### PR DESCRIPTION
FastZip.ExtractZip uses ZipFile internally and might fall over #144 when working with a corrupt file (whereby it closes the input stream even if isStreamOwner is set to false when an error occurs).

Try to avoid that by using the new ZipFile constructor and setting leaveOpen as required.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
