### PR TITLE
Change value of CompressionMethod.Bzip2 from 11 to 12

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -50,7 +50,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// BZip2 compression. Not supported by #Zip.
 		/// </summary>
-		BZip2 = 11,
+		BZip2 = 12,
 
 		/// <summary>
 		/// WinZip special for AES encryption, Now supported by #Zip.


### PR DESCRIPTION
CompressionMethod.BZip is curently defined as 11, but it seems that it should actually be 12

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
