### PR TITLE
When invoking 7-zip in the tests, put quotes around the path to the test file

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -181,7 +181,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 							ms.CopyTo(fs);
 						}
 
-						var p = Process.Start(path7z, $"t -p{password} {fileName}");
+						var p = Process.Start(path7z, $"t -p{password} \"{fileName}\"");
 						if (!p.WaitForExit(2000))
 						{
 							Assert.Warn("Timed out verifying zip file!");


### PR DESCRIPTION
When running the unit tests, I've seen a couple of failures in the encryption tests that seem to be simply because the temp file path has a space in it, which causes issues when invoking 7-zip on the file.

Perhaps it needs quotes putting around the test file path?

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
