### PR TITLE
Fix writing extra data when updating Zip64 entries

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -2171,8 +2171,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 				WriteLEInt((int)entry.Crc);
 			}
 
+			bool useExtraCompressedSize = false; //Do we want to store the compressed size in the extra data?
 			if ((entry.IsZip64Forced()) || (entry.CompressedSize >= 0xffffffff))
 			{
+				useExtraCompressedSize = true;
 				WriteLEInt(-1);
 			}
 			else
@@ -2180,8 +2182,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 				WriteLEInt((int)(entry.CompressedSize & 0xffffffff));
 			}
 
+			bool useExtraUncompressedSize = false; //Do we want to store the uncompressed size in the extra data?
 			if ((entry.IsZip64Forced()) || (entry.Size >= 0xffffffff))
 			{
+				useExtraUncompressedSize = true;
 				WriteLEInt(-1);
 			}
 			else
@@ -2205,12 +2209,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				ed.StartNewEntry();
 
-				if ((entry.Size >= 0xffffffff) || (useZip64_ == UseZip64.On))
+				if (useExtraUncompressedSize)
 				{
 					ed.AddLeLong(entry.Size);
 				}
 
-				if ((entry.CompressedSize >= 0xffffffff) || (useZip64_ == UseZip64.On))
+				if (useExtraCompressedSize)
 				{
 					ed.AddLeLong(entry.CompressedSize);
 				}


### PR DESCRIPTION
WriteCentralDirectoryHeader currently checks IsZip64Forced when deciding to write -1 to the base size fields [ZipFile.cs#L2174](https://github.com/Numpsy/SharpZipLib/blob/0fff917d8ef61e9cd0b9b8574301498a6416e0bf/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs#L2174) but not when writing the extra data [ZipFile.cs#L2208](https://github.com/icsharpcode/SharpZipLib/blob/4f541a404f324bd882bc1e8ecd1182c05909b08a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs#L2208), so the length doesn't get written.

This changes it to check in both places, and adds a test

Assuming that the length field and extra data should always be in sync (would you ever set size to -1 and not write the extra data?), might be better to set some 'wantsExtraSize' flags rather than checking ((entry.Size >= 0xffffffff) || otherFlags) in two places?

Closes #310.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
