### PR TITLE
Change ZipOutputStream.CloseEntry() to work for AES encrypted Stored entries

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -414,7 +414,10 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 			}
 		}
 
-		private void GetAuthCodeIfAES()
+		/// <summary>
+		/// Get the Auth code for AES encrypted entries
+		/// </summary>
+		protected void GetAuthCodeIfAES()
 		{
 			if (cryptoTransform_ is ZipAESTransform)
 			{

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -486,6 +486,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 					deflater_.Reset();
 				}
 			}
+			else if (curMethod == CompressionMethod.Stored)
+			{
+				// This is done by Finsh() for Deflated entries, but we need to do it
+				// ourselves for Stored ones
+				base.GetAuthCodeIfAES();
+			}
 
 			// Write the AES Authentication Code (a hash of the compressed and encrypted data)
 			if (curEntry.AESKeySize > 0)

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -22,9 +22,25 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Test]
 		[Category("Encryption")]
 		[Category("Zip")]
+		public void Aes128EncryptionStored()
+		{
+			CreateZipWithEncryptedEntries("foo", 128, CompressionMethod.Stored);
+		}
+
+		[Test]
+		[Category("Encryption")]
+		[Category("Zip")]
 		public void Aes256Encryption()
 		{
 			CreateZipWithEncryptedEntries("foo", 256);
+		}
+
+		[Test]
+		[Category("Encryption")]
+		[Category("Zip")]
+		public void Aes256EncryptionStored()
+		{
+			CreateZipWithEncryptedEntries("foo", 256, CompressionMethod.Stored);
 		}
 
 		[Test]
@@ -88,6 +104,47 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 		}
 
+		/// <summary>
+		/// Test using AES encryption on a file whose contents are Stored rather than deflated
+		/// </summary>
+		[Test]
+		[Category("Encryption")]
+		[Category("Zip")]
+		public void ZipFileStoreAes()
+		{
+			string password = "password";
+
+			using (var memoryStream = new MemoryStream())
+			{
+				// Try to create a zip stream
+				WriteEncryptedZipToStream(memoryStream, password, 256, CompressionMethod.Stored);
+
+				// reset
+				memoryStream.Seek(0, SeekOrigin.Begin);
+
+				// try to read it
+				var zipFile = new ZipFile(memoryStream, leaveOpen: true)
+				{
+					Password = password
+				};
+
+				foreach (ZipEntry entry in zipFile)
+				{
+					if (!entry.IsFile) continue;
+
+					// Should be stored rather than deflated
+					Assert.That(entry.CompressionMethod, Is.EqualTo(CompressionMethod.Stored), "Entry should be stored");
+
+					using (var zis = zipFile.GetInputStream(entry))
+					using (var sr = new StreamReader(zis, Encoding.UTF8))
+					{
+						var content = sr.ReadToEnd();
+						Assert.That(content, Is.EqualTo(DummyDataString), "Decompressed content does not match input data");
+					}
+				}
+			}
+		}
+
 		private static readonly string[] possible7zPaths = new[] {
 			// Check in PATH
 			"7z", "7za",
@@ -135,7 +192,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			return false;
 		}
 
-		public void WriteEncryptedZipToStream(Stream stream, string password, int keySize)
+		public void WriteEncryptedZipToStream(Stream stream, string password, int keySize, CompressionMethod compressionMethod = CompressionMethod.Deflated)
 		{
 			using (var zs = new ZipOutputStream(stream))
 			{
@@ -146,6 +203,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				ZipEntry zipEntry = new ZipEntry("test");
 				zipEntry.AESKeySize = keySize;
 				zipEntry.DateTime = DateTime.Now;
+				zipEntry.CompressionMethod = compressionMethod;
 
 				zs.PutNextEntry(zipEntry);
 
@@ -160,11 +218,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 		}
 
-		public void CreateZipWithEncryptedEntries(string password, int keySize)
+		public void CreateZipWithEncryptedEntries(string password, int keySize, CompressionMethod compressionMethod = CompressionMethod.Deflated)
 		{
 			using (var ms = new MemoryStream())
 			{
-				WriteEncryptedZipToStream(ms, password, keySize);
+				WriteEncryptedZipToStream(ms, password, keySize, compressionMethod);
 
 				if (TryGet7zBinPath(out string path7z))
 				{


### PR DESCRIPTION
Possible fix for #322 - Change ZipOutputStream.CloseEntry() to set up AESAuthCode itself when the compression method is 'Stored' (it's normally done by DeflatorOutputStream.Finish(), which isn't called in this case).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
