### PR TITLE
Ability to mimic a zip file created by a Linux file-system.

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -169,7 +169,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <exception cref="ArgumentNullException">
 		/// The name passed is null
 		/// </exception>
-		internal ZipEntry(string name, int versionRequiredToExtract)
+		public ZipEntry(string name, int versionRequiredToExtract)
 			: this(name, versionRequiredToExtract, ZipConstants.VersionMadeBy,
 			CompressionMethod.Deflated)
 		{
@@ -192,7 +192,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// This constructor is used by the ZipFile class when reading from the central header
 		/// It is not generally useful, use the constructor specifying the name only.
 		/// </remarks>
-		internal ZipEntry(string name, int versionRequiredToExtract, int madeByInfo,
+		public ZipEntry(string name, int versionRequiredToExtract, int madeByInfo,
 			CompressionMethod method)
 		{
 			if (name == null)
@@ -444,7 +444,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			get
 			{
-				return (versionMadeBy & 0xff);
+				return versionMadeBy;
 			}
 		}
 
@@ -526,7 +526,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			set
 			{
-				versionMadeBy &= 0xff;
+				versionMadeBy &= 0xff00;
 				versionMadeBy |= (ushort)((value & 0xff) << 8);
 			}
 		}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -169,7 +169,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <exception cref="ArgumentNullException">
 		/// The name passed is null
 		/// </exception>
-		public ZipEntry(string name, int versionRequiredToExtract)
+		internal ZipEntry(string name, int versionRequiredToExtract)
 			: this(name, versionRequiredToExtract, ZipConstants.VersionMadeBy,
 			CompressionMethod.Deflated)
 		{
@@ -192,7 +192,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// This constructor is used by the ZipFile class when reading from the central header
 		/// It is not generally useful, use the constructor specifying the name only.
 		/// </remarks>
-		public ZipEntry(string name, int versionRequiredToExtract, int madeByInfo,
+		internal ZipEntry(string name, int versionRequiredToExtract, int madeByInfo,
 			CompressionMethod method)
 		{
 			if (name == null)
@@ -444,7 +444,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			get
 			{
-				return versionMadeBy;
+				return (versionMadeBy & 0xff);
 			}
 		}
 
@@ -526,7 +526,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			set
 			{
-				versionMadeBy &= 0xff00;
+				versionMadeBy &= 0x00ff;
 				versionMadeBy |= (ushort)((value & 0xff) << 8);
 			}
 		}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -428,7 +428,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public ZipFile(FileStream file) :
 			this(file, false)
 		{
-			
+
 		}
 
 		/// <summary>
@@ -489,7 +489,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public ZipFile(Stream stream) :
 			this(stream, false)
 		{
-			
+
 		}
 
 		/// <summary>
@@ -2157,7 +2157,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			WriteLEInt(ZipConstants.CentralHeaderSignature);
 
 			// Version made by
-			WriteLEShort(ZipConstants.VersionMadeBy);
+			WriteLEShort(entry.VersionMadeBy);
 
 			// Version required to extract
 			WriteLEShort(entry.Version);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -2157,7 +2157,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			WriteLEInt(ZipConstants.CentralHeaderSignature);
 
 			// Version made by
-			WriteLEShort(entry.VersionMadeBy);
+			WriteLEShort((entry.HostSystem << 8) | entry.VersionMadeBy);
 
 			// Version required to extract
 			WriteLEShort(entry.Version);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -750,7 +750,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			foreach (ZipEntry entry in entries)
 			{
 				WriteLeInt(ZipConstants.CentralHeaderSignature);
-				WriteLeShort(entry.VersionMadeBy);
+				WriteLeShort((entry.HostSystem << 8) | entry.VersionMadeBy);
 				WriteLeShort(entry.Version);
 				WriteLeShort(entry.Flags);
 				WriteLeShort((short)entry.CompressionMethodForHeader);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -744,7 +744,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			foreach (ZipEntry entry in entries)
 			{
 				WriteLeInt(ZipConstants.CentralHeaderSignature);
-				WriteLeShort(ZipConstants.VersionMadeBy);
+				WriteLeShort(entry.VersionMadeBy);
 				WriteLeShort(entry.Version);
 				WriteLeShort(entry.Flags);
 				WriteLeShort((short)entry.CompressionMethodForHeader);


### PR DESCRIPTION
# Use Case
Create a zip archive with specific permissions, such as the executable flag, using the `ExternalAttributes` property. The Linux `unzip` command only applies such permissions if the zip entry indicates the file was added by a Linux host-system.

# Solution
Expose the more specific `ZipEntry` constructors that allow controlling the version number and host-system information. Ensure this information is used when creating the zip archive.

# Changes:
1. Changed access level from `internal` to `public` on constructors for `ZipEntry`. This allows setting the `madeByInfo` value.
1. Changed `VersionMadeBy` property to return the entire `ushort`. This is required by `ZipFile` and `ZipOutputStream` to write the correct value.
1. Fixed `HostSystem` property to clear out the upper byte where the host system information is stored.
1. Changed `ZipFile` and `ZipOutputStream` to respect the `VersionMadeBy` value of the `ZipEntry` instance instead of hard-coding it.

# Agreement 
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
