### PR TITLE
Do not set the StrongEncryption flag for WinZipAes encrypted entries

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -1131,10 +1131,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			if (extraData.Find(0x9901))
 			{
-				// Set version and flag for Zipfile.CreateAndInitDecryptionStream
+				// Set version for Zipfile.CreateAndInitDecryptionStream
 				versionToExtract = ZipConstants.VERSION_AES;            // Ver 5.1 = AES see "Version" getter
-																		// Set StrongEncryption flag for ZipFile.CreateAndInitDecryptionStream
-				Flags = Flags | (int)GeneralBitFlags.StrongEncryption;
+
 				//
 				// Unpack AES extra data field see http://www.winzip.com/aes_info.htm
 				int length = extraData.ValueLength;         // Data size currently 7

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -3542,23 +3542,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			CryptoStream result = null;
 
-			if ((entry.Version < ZipConstants.VersionStrongEncryption)
-				|| (entry.Flags & (int)GeneralBitFlags.StrongEncryption) == 0)
+			if (entry.CompressionMethodForHeader == CompressionMethod.WinZipAES)
 			{
-				var classicManaged = new PkzipClassicManaged();
-
-				OnKeysRequired(entry.Name);
-				if (HaveKeys == false)
-				{
-					throw new ZipException("No password available for encrypted stream");
-				}
-
-				result = new CryptoStream(baseStream, classicManaged.CreateDecryptor(key, null), CryptoStreamMode.Read);
-				CheckClassicPassword(result, entry);
-			}
-			else
-			{
-				if (entry.Version == ZipConstants.VERSION_AES)
+				if (entry.Version >= ZipConstants.VERSION_AES)
 				{
 					//
 					OnKeysRequired(entry.Name);
@@ -3584,6 +3570,28 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 				else
 				{
+					throw new ZipException("Decryption method not supported");
+				}
+			}
+			else
+			{
+				if ((entry.Version < ZipConstants.VersionStrongEncryption)
+					|| (entry.Flags & (int)GeneralBitFlags.StrongEncryption) == 0)
+				{
+					var classicManaged = new PkzipClassicManaged();
+
+					OnKeysRequired(entry.Name);
+					if (HaveKeys == false)
+					{
+						throw new ZipException("No password available for encrypted stream");
+					}
+
+					result = new CryptoStream(baseStream, classicManaged.CreateDecryptor(key, null), CryptoStreamMode.Read);
+					CheckClassicPassword(result, entry);
+				}
+				else
+				{
+					// We don't support PKWare strong encryption
 					throw new ZipException("Decryption method not supported");
 				}
 			}


### PR DESCRIPTION
Change ZipEntry.ProcessAESExtraData to not set the StrongEncryption flag for WinZipAes encrypted entries.

As mentioned in #317, setting the StrongEncryption flag in ProcessAESExtraData doesn't seem correct.
This changes that, and rearranges CreateAndInitDecryptionStream to check for the compression method being WinZipAES rather than for the StrongEncryption flag being set.
This will throw if the archive is really using the PKWare strong encryption, which I think is correct if that isn't actually supported?

Related to this: I'm not sure if the 
```
versionToExtract = ZipConstants.VERSION_AES
```

in ProcessAESExtraData is correct either (what happens if the existing version is greater than that?). Maybe needs a seperate change?

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
