### PR TITLE
Add a benchmarks project using BenchmarkDotNet

### DIFF
--- a/ICSharpCode.SharpZipLib.sln
+++ b/ICSharpCode.SharpZipLib.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28705.295
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Configuration", "Solution Configuration", "{F1097E98-4DEB-4A0A-81EE-5CEC667EBDF0}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,7 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.SharpZipLib", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.SharpZipLib.Tests", "test\ICSharpCode.SharpZipLib.Tests\ICSharpCode.SharpZipLib.Tests.csproj", "{82211166-9C45-4603-8E3A-2CA2EFFCBC26}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICSharpCode.SharpZipLib.TestBootstrapper", "test\ICSharpCode.SharpZipLib.TestBootstrapper\ICSharpCode.SharpZipLib.TestBootstrapper.csproj", "{535D7365-C5B1-4253-9233-D72D972CA851}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.SharpZipLib.TestBootstrapper", "test\ICSharpCode.SharpZipLib.TestBootstrapper\ICSharpCode.SharpZipLib.TestBootstrapper.csproj", "{535D7365-C5B1-4253-9233-D72D972CA851}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.SharpZipLib.Benchmark", "benchmark\ICSharpCode.SharpZipLib.Benchmark\ICSharpCode.SharpZipLib.Benchmark.csproj", "{C51E638B-DDD0-48B6-A6BD-EBC4E6A104C7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,8 +37,15 @@ Global
 		{535D7365-C5B1-4253-9233-D72D972CA851}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{535D7365-C5B1-4253-9233-D72D972CA851}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{535D7365-C5B1-4253-9233-D72D972CA851}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C51E638B-DDD0-48B6-A6BD-EBC4E6A104C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C51E638B-DDD0-48B6-A6BD-EBC4E6A104C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C51E638B-DDD0-48B6-A6BD-EBC4E6A104C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C51E638B-DDD0-48B6-A6BD-EBC4E6A104C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0A049193-65F8-49AF-82CB-75D42563DA16}
 	EndGlobalSection
 EndGlobal

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Checksum/Adler32.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Checksum/Adler32.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.Checksum
+{
+	[Config(typeof(MultipleRuntimes))]
+	public class Adler32
+	{
+		private const int ChunkCount = 256;
+		private const int ChunkSize = 1024 * 1024;
+		private const int N = ChunkCount * ChunkSize;
+		private readonly byte[] data;
+
+		public Adler32()
+		{
+			data = new byte[N];
+			new Random(1).NextBytes(data);
+		}
+
+		[Benchmark]
+		public long Adler32LargeUpdate()
+		{
+			var adler32 = new ICSharpCode.SharpZipLib.Checksum.Adler32();
+			adler32.Update(data);
+			return adler32.Value;
+		}
+
+		/*
+		[Benchmark]
+		public long Adler32ChunkedUpdate()
+		{
+			var adler32 = new ICSharpCode.SharpZipLib.Checksum.Adler32();
+
+			for (int i = 0; i < ChunkCount; i++)
+			{
+				var segment = new ArraySegment<byte>(data, ChunkSize * i, ChunkSize);
+				adler32.Update(segment);
+			}
+
+			return adler32.Value;
+		}
+		*/
+	}
+}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Checksum/BZip2Crc.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Checksum/BZip2Crc.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.Checksum
+{
+	[Config(typeof(MultipleRuntimes))]
+	public class BZip2Crc
+	{
+		private const int ChunkCount = 256;
+		private const int ChunkSize = 1024 * 1024;
+		private const int N = ChunkCount * ChunkSize;
+		private readonly byte[] data;
+
+		public BZip2Crc()
+		{
+			data = new byte[N];
+			new Random(1).NextBytes(data);
+		}
+
+		[Benchmark]
+		public long BZip2CrcLargeUpdate()
+		{
+			var bzipCrc = new ICSharpCode.SharpZipLib.Checksum.BZip2Crc();
+			bzipCrc.Update(data);
+			return bzipCrc.Value;
+		}
+
+		/*
+		[Benchmark]
+		public long BZip2CrcChunkedUpdate()
+		{
+			var bzipCrc = new ICSharpCode.SharpZipLib.Checksum.BZip2Crc();
+
+			for (int i = 0; i < ChunkCount; i++)
+			{
+				var segment = new ArraySegment<byte>(data, ChunkSize * i, ChunkSize);
+				bzipCrc.Update(segment);
+			}
+
+			return bzipCrc.Value;
+		}
+		*/
+	}
+}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Checksum/Crc32.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Checksum/Crc32.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.Checksum
+{
+	[Config(typeof(MultipleRuntimes))]
+	public class Crc32
+	{
+		private const int ChunkCount = 256;
+		private const int ChunkSize = 1024 * 1024;
+		private const int N = ChunkCount * ChunkSize;
+		private readonly byte[] data;
+
+		public Crc32()
+		{
+			data = new byte[N];
+			new Random(1).NextBytes(data);
+		}
+
+		[Benchmark]
+		public long Crc32LargeUpdate()
+		{
+			var crc32 = new ICSharpCode.SharpZipLib.Checksum.Crc32();
+			crc32.Update(data);
+			return crc32.Value;
+		}
+
+		/*
+		[Benchmark]
+		public long Crc32ChunkedUpdate()
+		{
+			var crc32 = new ICSharpCode.SharpZipLib.Checksum.Crc32();
+
+			for (int i = 0; i < ChunkCount; i++)
+			{
+				var segment = new ArraySegment<byte>(data, ChunkSize * i, ChunkSize);
+				crc32.Update(segment);
+			}
+
+			return crc32.Value;
+		}
+		*/
+	}
+}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="BenchmarkDotNet">
+			<Version>0.11.4</Version>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\src\ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using BenchmarkDotNet;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.CsProj;
+
+namespace ICSharpCode.SharpZipLib.Benchmark
+{
+	public class MultipleRuntimes : ManualConfig
+	{
+		public MultipleRuntimes()
+		{
+			Add(Job.Default.With(CsProjClassicNetToolchain.Net461).AsBaseline()); // NET 4.6.1
+			Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp21)); // .NET Core 2.1
+			//Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp30)); // .NET Core 3.0
+		}
+	}
+
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+		}
+	}
+}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipInputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipInputStream.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.Zip
+{
+	[Config(typeof(MultipleRuntimes))]
+	public class ZipInputStream
+	{
+		private const int ChunkCount = 64;
+		private const int ChunkSize = 1024 * 1024;
+		private const int N = ChunkCount * ChunkSize;
+
+		byte[] zippedData;
+
+		public ZipInputStream()
+		{
+			using (var memoryStream = new MemoryStream())
+			{
+				using (var zipOutputStream = new SharpZipLib.Zip.ZipOutputStream(memoryStream))
+				{
+					zipOutputStream.PutNextEntry(new SharpZipLib.Zip.ZipEntry("0"));
+
+					var inputBuffer = new byte[ChunkSize];
+
+					for (int i = 0; i < ChunkCount; i++)
+					{
+						zipOutputStream.Write(inputBuffer, 0, inputBuffer.Length);
+					}
+				}
+
+				zippedData = memoryStream.ToArray();
+			}
+		}
+
+		[Benchmark]
+		public long ReadZipInputStream()
+		{
+			using (var memoryStream = new MemoryStream(zippedData))
+			{
+				using (var zipInputStream = new SharpZipLib.Zip.ZipInputStream(memoryStream))
+				{
+					var buffer = new byte[4096];
+					var entry = zipInputStream.GetNextEntry();
+
+					while (zipInputStream.Read(buffer, 0, buffer.Length) > 0)
+					{
+
+					}
+
+					return entry.Size;
+				}
+			}
+		}
+	}
+}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.Zip
+{
+	[Config(typeof(MultipleRuntimes))]
+	public class ZipOutputStream
+	{
+		private const int ChunkCount = 64;
+		private const int ChunkSize = 1024 * 1024;
+		private const int N = ChunkCount * ChunkSize;
+
+		byte[] outputBuffer;
+		byte[] inputBuffer;
+
+		public ZipOutputStream()
+		{
+			inputBuffer = new byte[ChunkSize];
+			outputBuffer = new byte[N];
+		}
+
+		[Benchmark]
+		public long WriteZipOutputStream()
+		{
+			using (var memoryStream = new MemoryStream(outputBuffer))
+			{
+				var zipOutputStream = new SharpZipLib.Zip.ZipOutputStream(memoryStream);
+				zipOutputStream.PutNextEntry(new SharpZipLib.Zip.ZipEntry("0"));
+
+				for (int i = 0; i < ChunkCount; i++)
+				{
+					zipOutputStream.Write(inputBuffer, 0, inputBuffer.Length);
+				}
+
+				return memoryStream.Position;
+			}
+		}
+	}
+}


### PR DESCRIPTION
As I proposed in #328, this PR adds a benchmarks project using BenchmarkDotNet, with a few simple benchmarks for the CRC handling and zip input/output streams that i did when testing the proposed CRC changes and playing with .NET Core 3.

Could be useful for testing performance related changes in the future? It's a start anyway.


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
