### PR TITLE
Change ZipAESStream to handle reads of less data than the AES block size

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -27,8 +27,6 @@ namespace ICSharpCode.SharpZipLib.Encryption
 			_transform = transform;
 			_slideBuffer = new byte[1024];
 
-			_blockAndAuth = CRYPTO_BLOCK_SIZE + AUTH_CODE_LENGTH;
-
 			// mode:
 			//  CryptoStreamMode.Read means we read from "stream" and pass decrypted to our Read() method.
 			//  Write bypasses this stream and uses the Transform directly.
@@ -41,16 +39,25 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		// The final n bytes of the AES stream contain the Auth Code.
 		private const int AUTH_CODE_LENGTH = 10;
 
+		// Blocksize is always 16 here, even for AES-256 which has transform.InputBlockSize of 32.
+		private const int CRYPTO_BLOCK_SIZE = 16;
+
+		// total length of block + auth code
+		private const int BLOCK_AND_AUTH = CRYPTO_BLOCK_SIZE + AUTH_CODE_LENGTH;
+
 		private Stream _stream;
 		private ZipAESTransform _transform;
 		private byte[] _slideBuffer;
 		private int _slideBufStartPos;
 		private int _slideBufFreePos;
 
-		// Blocksize is always 16 here, even for AES-256 which has transform.InputBlockSize of 32.
-		private const int CRYPTO_BLOCK_SIZE = 16;
+		// Buffer block transforms to enable partial reads
+		private byte[] _transformBuffer = null;// new byte[CRYPTO_BLOCK_SIZE];
+		private int _transformBufferFreePos;
+		private int _transformBufferStartPos;
 
-		private int _blockAndAuth;
+		// Do we have some buffered data available?
+		private bool HasBufferedData =>_transformBuffer != null && _transformBufferStartPos < _transformBufferFreePos;
 
 		/// <summary>
 		/// Reads a sequence of bytes from the current CryptoStream into buffer,
@@ -58,16 +65,46 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		/// </summary>
 		public override int Read(byte[] buffer, int offset, int count)
 		{
+			// Nothing to do
+			if (count == 0)
+				return 0;
+
+			// If we have buffered data, read that first
+			int nBytes = 0;
+			if (HasBufferedData)
+			{
+				nBytes = ReadBufferedData(buffer, offset, count);
+
+				// Read all requested data from the buffer
+				if (nBytes == count)
+					return nBytes;
+
+				offset += nBytes;
+				count -= nBytes;
+			}
+
+			// Read more data from the input, if available
+			if (_slideBuffer != null)
+				nBytes += ReadAndTransform(buffer, offset, count);
+
+			return nBytes;
+		}
+
+		// Read data from the underlying stream and decrypt it
+		private int ReadAndTransform(byte[] buffer, int offset, int count)
+		{
 			int nBytes = 0;
 			while (nBytes < count)
 			{
+				int bytesLeftToRead = count - nBytes;
+
 				// Calculate buffer quantities vs read-ahead size, and check for sufficient free space
 				int byteCount = _slideBufFreePos - _slideBufStartPos;
 
 				// Need to handle final block and Auth Code specially, but don't know total data length.
 				// Maintain a read-ahead equal to the length of (crypto block + Auth Code).
 				// When that runs out we can detect these final sections.
-				int lengthToRead = _blockAndAuth - byteCount;
+				int lengthToRead = BLOCK_AND_AUTH - byteCount;
 				if (_slideBuffer.Length - _slideBufFreePos < lengthToRead)
 				{
 					// Shift the data to the beginning of the buffer
@@ -84,17 +121,11 @@ namespace ICSharpCode.SharpZipLib.Encryption
 
 				// Recalculate how much data we now have
 				byteCount = _slideBufFreePos - _slideBufStartPos;
-				if (byteCount >= _blockAndAuth)
+				if (byteCount >= BLOCK_AND_AUTH)
 				{
-					// At least a 16 byte block and an auth code remains.
-					_transform.TransformBlock(_slideBuffer,
-											  _slideBufStartPos,
-											  CRYPTO_BLOCK_SIZE,
-											  buffer,
-											  offset);
-					nBytes += CRYPTO_BLOCK_SIZE;
-					offset += CRYPTO_BLOCK_SIZE;
-					_slideBufStartPos += CRYPTO_BLOCK_SIZE;
+					var read = TransformAndBufferBlock(buffer, offset, bytesLeftToRead, CRYPTO_BLOCK_SIZE);
+					nBytes += read;
+					offset += read;
 				}
 				else
 				{
@@ -103,14 +134,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 					{
 						// At least one byte of data plus auth code
 						int finalBlock = byteCount - AUTH_CODE_LENGTH;
-						_transform.TransformBlock(_slideBuffer,
-												  _slideBufStartPos,
-												  finalBlock,
-												  buffer,
-												  offset);
-
-						nBytes += finalBlock;
-						_slideBufStartPos += finalBlock;
+						nBytes += TransformAndBufferBlock(buffer, offset, bytesLeftToRead, finalBlock);
 					}
 					else if (byteCount < AUTH_CODE_LENGTH)
 						throw new Exception("Internal error missed auth code"); // Coding bug
@@ -125,10 +149,60 @@ namespace ICSharpCode.SharpZipLib.Encryption
 						}
 					}
 
+					// don't need this any more, so use it as a 'complete' flag
+					_slideBuffer = null;
+
 					break;  // Reached the auth code
 				}
 			}
 			return nBytes;
+		}
+
+		// read some buffered data
+		private int ReadBufferedData(byte[] buffer, int offset, int count)
+		{
+			int copyCount = Math.Min(count, _transformBufferFreePos - _transformBufferStartPos);
+
+			Array.Copy(_transformBuffer, _transformBufferStartPos, buffer, offset, count);
+			_transformBufferStartPos += copyCount;
+
+			return copyCount;
+		}
+
+		// Perform the crypto transform, and buffer the data if less than one block has been requested.
+		private int TransformAndBufferBlock(byte[] buffer, int offset, int count, int blockSize)
+		{
+			// If the requested data is greater than one block, transform it directly into the output
+			// If it's smaller, do it into a temporary buffer and copy the requested part
+			bool bufferRequired = (blockSize > count);
+
+			if (bufferRequired && _transformBuffer == null)
+				_transformBuffer = new byte[CRYPTO_BLOCK_SIZE];
+
+			var targetBuffer = bufferRequired ? _transformBuffer : buffer;
+			var targetOffset = bufferRequired ? 0 : offset;
+
+			// Transform the data
+			_transform.TransformBlock(_slideBuffer,
+									  _slideBufStartPos,
+									  blockSize,
+									  targetBuffer,
+									  targetOffset);
+
+			_slideBufStartPos += blockSize;
+
+			if (!bufferRequired)
+			{
+				return blockSize;
+			}
+			else
+			{
+				Array.Copy(_transformBuffer, 0, buffer, offset, count);
+				_transformBufferStartPos = count;
+				_transformBufferFreePos = blockSize;
+
+				return count;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
This is an attempt to handle #324 by changing ZipAESStream.Read() to buffer the transformed data in cases where the length of the data to read is less than the crypto block size (or not a multiple of the block size).
When reading full blocks, it transforms directly into the output buffer so the data doesn't need to bew copied again.

Not sure if it's best to do it like this, or to buffer the data seperately in this case?

(also, fwiw, I originally saw this issue when looking at #315 and then reproed it with Stored files, so changing this will help with that as well).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
