### PR TITLE
Improve the behaviour of ZipInputStream when reading zip entries with unsupported compression methods

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -131,8 +131,24 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			get
 			{
-				return (entry != null) && entry.CanDecompress;
+				return (entry != null) && IsEntryCompressionMethodSupported(entry) && entry.CanDecompress;
 			}
+		}
+
+		/// <summary>
+		/// Is the compression method for the specified entry supported?
+		/// </summary>
+		/// <remarks>
+		/// Uses entry.CompressionMethodForHeader so that entries of type WinZipAES will be rejected. 
+		/// </remarks>
+		/// <param name="entry">the entry to check.</param>
+		/// <returns>true if the compression methiod is supported, false if not.</returns>
+		private static bool IsEntryCompressionMethodSupported(ZipEntry entry)
+		{
+			var entryCompressionMethod = entry.CompressionMethodForHeader;
+
+			return entryCompressionMethod == CompressionMethod.Deflated ||
+				   entryCompressionMethod == CompressionMethod.Stored;
 		}
 
 		/// <summary>
@@ -271,7 +287,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 
 			// Determine how to handle reading of data if this is attempted.
-			if (entry.IsCompressionMethodSupported())
+			if (IsEntryCompressionMethodSupported(entry))
 			{
 				internalReader = new ReadDataHandler(InitialRead);
 			}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -400,7 +400,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		}
 
 		/// <summary>
-		/// ZipInputStream can't decrypt AES encrypted entries, but it should repot that to the caller
+		/// ZipInputStream can't decrypt AES encrypted entries, but it should report that to the caller
 		/// rather than just failing.
 		/// </summary>
 		[Test]

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -399,6 +399,40 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 		}
 
+		/// <summary>
+		/// ZipInputStream can't decrypt AES encrypted entries, but it should repot that to the caller
+		/// rather than just failing.
+		/// </summary>
+		[Test]
+		[Category("Zip")]
+		public void ZipinputStreamShouldGracefullyFailWithAESStreams()
+		{
+			string password = "password";
+
+			using (var memoryStream = new MemoryStream())
+			{
+				// Try to create a zip stream
+				WriteEncryptedZipToStream(memoryStream, password, 256);
+
+				// reset
+				memoryStream.Seek(0, SeekOrigin.Begin);
+
+				// Try to read
+				using (var inputStream = new ZipInputStream(memoryStream))
+				{
+					inputStream.Password = password;
+					var entry = inputStream.GetNextEntry();
+					Assert.That(entry.AESKeySize, Is.EqualTo(256), "Test entry should be AES256 encrypted.");
+
+					// CanDecompressEntry should be false.
+					Assert.That(inputStream.CanDecompressEntry, Is.False, "CanDecompressEntry should be false for AES encrypted entries");
+
+					// Should throw on read.
+					Assert.Throws<ZipException>(() => inputStream.ReadByte());
+				}
+			}
+		}
+
 		private static readonly string[] possible7zPaths = new[] {
 			// Check in PATH
 			"7z", "7za",


### PR DESCRIPTION
When I was looking at BZip2 support in zip files, I had an issue where changing ZipEntry.IsCompressionMethodSupported to return true for BZip2 compression caused issues with ZipInputStream, where it went through its read logic and didn't read anything, but also didn't 'fail'.

When i went to make a change to do something about that, I found that calling GetNextEntry() to get an entry compressed with BZip2 compression (without any other changes) caused it to throw, when it attempted to set ZipEntry.CompressionMethod after construction.

This PR Makes 2 changes that might help with that:

1) Change ZipInputStream.GetNextEntry to use the ZipEntry constructor that takes the CompressionMethod as a parameter, rather than setting it afterwards.

2) Change it to use its own IsEntryCompressionMethodSupported function rather than relying on ZipEntry.IsCompressionMethodSupported (Given that the stream itself is in control of the supported methods, it seems reasonable to make that choice locally).

I wonder if it might be better here if ZipEntry.CanDecompress returned a value derived from the input source (ZipFile/ZipInputStream) rather than using a fixed algorithm list? something of a bigger change though.


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
