### PR TITLE
Treat empty string as no RootPath in TarArchive (fixes #334)

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
@@ -784,7 +784,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			string newName = null;
 
-			if (rootPath != null)
+			if (!String.IsNullOrEmpty(rootPath))
 			{
 				if (entry.Name.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
 				{


### PR DESCRIPTION
Ensures that, if the root path is an empty string, the library will not try to take a substring of the file name (and cause the first character of the filename to be truncated).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
