### PR TITLE
Change ZipInputStream.GetNextEntry to set the entry compression method via its constructor.

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -206,10 +206,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			string name = ZipStrings.ConvertToStringExt(flags, buffer);
 
-			entry = new ZipEntry(name, versionRequiredToExtract)
+			entry = new ZipEntry(name, versionRequiredToExtract, ZipConstants.VersionMadeBy, (CompressionMethod)method)
 			{
 				Flags = flags,
-				CompressionMethod = (CompressionMethod)method
 			};
 
 			if ((flags & 8) == 0)

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
@@ -324,5 +324,33 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				}
 			);
 		}
+
+		const string BZip2CompressedZip =
+			"UEsDBC4AAAAMAEyxgU5p3ou9JwAAAAcAAAAFAAAAYS5kYXRCWmg5MUFZJlNZ0buMcAAAAkgACABA" +
+			"ACAAIQCCCxdyRThQkNG7jHBQSwECMwAuAAAADABMsYFOad6LvScAAAAHAAAABQAAAAAAAAAAAAAA" +
+			"AAAAAAAAYS5kYXRQSwUGAAAAAAEAAQAzAAAASgAAAAAA";
+
+		/// <summary>
+		/// Should fail to read a zip with BZip2 compression
+		/// </summary>
+		[Test]
+		[Category("Zip")]
+		public void ShouldReadBZip2EntryButNotDecompress()
+		{
+			var fileBytes = System.Convert.FromBase64String(BZip2CompressedZip);
+
+			using (var input = new MemoryStream(fileBytes, false))
+			{
+				var zis = new ZipInputStream(input);
+				var entry = zis.GetNextEntry();
+
+				Assert.That(entry.Name, Is.EqualTo("a.dat"), "Should be able to get entry name");
+				Assert.That(entry.CompressionMethod, Is.EqualTo(CompressionMethod.BZip2), "Entry should be BZip2 compressed");
+				Assert.That(zis.CanDecompressEntry, Is.False, "Should not be able to decompress BZip2 entry");
+
+				var buffer = new byte[1];
+				Assert.Throws<ZipException>(() => zis.Read(buffer, 0, 1), "Trying to read the stream should throw");
+			}
+		}
 	}
 }


### PR DESCRIPTION
This pulls part of the change for #333 into a seperate PR (just the piece that sets the ZipEntry compression method via the constructor rather than setting the property after construction).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
