### PR TITLE
Change ZipFile.TestLocalHeader to use entry.CompressionMethodForHeader rather than entry.CompressionMethod

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1215,7 +1215,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					}
 
 					// Central header compression method matches local entry
-					if (entry.CompressionMethod != (CompressionMethod)compressionMethod)
+					if (entry.CompressionMethodForHeader != (CompressionMethod)compressionMethod)
 					{
 						throw new ZipException("Central header/local header compression method mismatch");
 					}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -71,6 +71,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 						Assert.AreEqual(DummyDataString, content, "Decompressed content does not match input data");
 					}
 				}
+
+				Assert.That(zipFile.TestArchive(false), Is.True, "Encrypted archive should pass validation.");
 			}
 		}
 


### PR DESCRIPTION
Change ZipFile.TestLocalHeader to use entry.CompressionMethodForHeader rather than CompressionMethod, to handle the two being different for AES encrypted entries.

Fixes #317 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
