### PR TITLE
Add LZMA and PPMd to the Zip CompressionMethod enum

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -53,6 +53,16 @@ namespace ICSharpCode.SharpZipLib.Zip
 		BZip2 = 12,
 
 		/// <summary>
+		/// LZMA compression. Not supported by #Zip.
+		/// </summary>
+		LZMA = 14,
+
+		/// <summary>
+		/// PPMd compression. Not supported by #Zip.
+		/// </summary>
+		PPMd = 98,
+
+		/// <summary>
 		/// WinZip special for AES encryption, Now supported by #Zip.
 		/// </summary>
 		WinZipAES = 99,


### PR DESCRIPTION
They aren't currently used by the library, but for completeness and testing purposes add the LZMA and PPMd compression methods to ZipConstants (values taken from section 4.4.5 of the AppNote).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
