### PR TITLE
Wire up support for BZip2 compresion in zip files

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -281,6 +281,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </summary>
 		public const int VersionZip64 = 45;
 
+		/// <summary>
+		/// The version required for BZip2 compression (4.6 or higher)
+		/// </summary>
+		public const int VersionBZip2 = 46;
+
 		#endregion Versions
 
 		#region Header Sizes

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -585,6 +585,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 					{
 						result = 20;
 					}
+					else if (CompressionMethod.BZip2 == method)
+					{
+						result = ZipConstants.VersionBZip2;
+					}
 					else if (IsDirectory == true)
 					{
 						result = 20;
@@ -616,6 +620,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					(Version == 11) ||
 					(Version == 20) ||
 					(Version == 45) ||
+					(Version == 46) ||
 					(Version == 51)) &&
 					IsCompressionMethodSupported();
 			}
@@ -1290,7 +1295,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			return
 				(method == CompressionMethod.Deflated) ||
-				(method == CompressionMethod.Stored);
+				(method == CompressionMethod.Stored) ||
+				(method == CompressionMethod.BZip2);
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -883,6 +883,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 					result = new InflaterInputStream(result, new Inflater(true));
 					break;
 
+				case CompressionMethod.BZip2:
+					result = new BZip2.BZip2InputStream(result);
+					break;
+
 				default:
 					throw new ZipException("Unsupported compression method " + method);
 			}
@@ -1899,7 +1903,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="compressionMethod">The compression method for the new entry.</param>
 		private void CheckSupportedCompressionMethod(CompressionMethod compressionMethod)
 		{
-			if (compressionMethod != CompressionMethod.Deflated && compressionMethod != CompressionMethod.Stored)
+			if (compressionMethod != CompressionMethod.Deflated && compressionMethod != CompressionMethod.Stored && compressionMethod != CompressionMethod.BZip2)
 			{
 				throw new NotImplementedException("Compression method not supported");
 			}
@@ -2627,6 +2631,16 @@ namespace ICSharpCode.SharpZipLib.Zip
 						IsStreamOwner = false
 					};
 					result = dos;
+					break;
+
+				case CompressionMethod.BZip2:
+					var bzos = new BZip2.BZip2OutputStream(result)
+					{
+						// If there is an encryption stream in use, then we want that to be disposed when the BZip2OutputStream stream is disposed
+						// If not, then we don't want it to dispose the base stream
+						IsStreamOwner = entry.IsCrypted
+					};
+					result = bzos;
 					break;
 
 				default:

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
@@ -141,7 +141,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			var ze = new ZipEntry("HumblePie");
 			//ze.CompressionMethod = CompressionMethod.BZip2;
 
-			Assert.That(() => ze.CompressionMethod = CompressionMethod.BZip2,
+			Assert.That(() => ze.CompressionMethod = CompressionMethod.Deflate64,
 				Throws.TypeOf<NotSupportedException>());
 		}
 


### PR DESCRIPTION
Work in progress changes to wire up BZip2 support in Zip files using the ZipFile API. refs #315 

Notes: 
~~Needs #333 to prevent ZipInputStream breaking if you try to read such an entry with it.~~
~~Needs #422 to reject attempts to add bzip2 compressed entries to ZipOutputStream.~~
Might need some other tweaks.

It does seem to be reading small zip/bzip2 format files produced with 7-zip successfully at least.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
