### PR TITLE
update test sdk and nunit packages to the curent versions.

### DIFF
--- a/test/ICSharpCode.SharpZipLib.TestBootstrapper/ICSharpCode.SharpZipLib.TestBootstrapper.csproj
+++ b/test/ICSharpCode.SharpZipLib.TestBootstrapper/ICSharpCode.SharpZipLib.TestBootstrapper.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="NUnitLite" Version="3.7.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
+++ b/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="coveralls.net" Version="0.7.0" />
-    <PackageReference Include="nunit" Version="3.7.1" />
-    <PackageReference Include="nunit.console" Version="3.7.0" />
-    <PackageReference Include="NUnit.Runners" Version="3.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit.console" Version="3.10.0" />
+    <PackageReference Include="NUnit.Runners" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="PublishCoverity" Version="0.11.0" />
     <PackageReference Include="ReportGenerator" Version="2.5.10" />


### PR DESCRIPTION
I tried running code coverage on the unit tests with Visual Studio 2019 and found that it didn't work, which I think is down to limitations of the old packages with the .NET Core tests.

Any objections to updating the SDK and NUnit packages in the test projects to the current versions where it works ok?

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
