### PR TITLE
Don't call CleanName from the ZipEntry constructor.

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -211,7 +211,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 
 			this.DateTime = DateTime.Now;
-			this.name = CleanName(name);
+			this.name = name;
 			this.versionMadeBy = (ushort)madeByInfo;
 			this.versionToExtract = (ushort)versionRequiredToExtract;
 			this.method = method;

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
@@ -352,5 +352,34 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				Assert.Throws<ZipException>(() => zis.Read(buffer, 0, 1), "Trying to read the stream should throw");
 			}
 		}
+
+		/// <summary>
+		/// Test for https://github.com/icsharpcode/SharpZipLib/issues/341
+		/// Should be able to read entries whose names contain invalid filesystem
+		/// characters
+		/// </summary>
+		[Test]
+		[Category("Zip")]
+		public void ShouldBeAbleToReadEntriesWithInvalidFileNames()
+		{
+			var testFileName = "<A|B?C>.txt";
+
+			using (var memoryStream = new MemoryStream())
+			{
+				using (var outStream = new ZipOutputStream(memoryStream))
+				{
+					outStream.IsStreamOwner = false;
+					outStream.PutNextEntry(new ZipEntry(testFileName));
+				}
+
+				memoryStream.Seek(0, SeekOrigin.Begin);
+
+				using (var inStream = new ZipInputStream(memoryStream))
+				{
+					var entry = inStream.GetNextEntry();
+					Assert.That(entry.Name, Is.EqualTo(testFileName), "output name must match original name");
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Possible fix for #341 - don't call CleanName in the ZipEntry constructor.

This matches the doc comments on one of the ZipEntry constructors which says that the name format isn't enforced anyway. Not sure if this causes any gaps where names won't be validated on creating zips - not sure whether it'd be better to do some validation for 'new' ZipEntries, but just not for ones created internally when reading an existing zip?

Also marked as WIP because on further testing it seems that a lot of the validation for the characters in paths has been removed from .NET Core, meaning that the exception described in #341 might only happen in the full version of .NET (and as the unit tests are only built as Core, the exception won't be seen there).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
