### PR TITLE
Change ZipFile.ReadEntries to always look for the Zip64 central directory

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipCorruptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipCorruptionHandling.cs
@@ -1,15 +1,12 @@
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
-using ICSharpCode.SharpZipLib;
 using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
-    public class ZipCorruptionHandling
+	public class ZipCorruptionHandling
     {
 
         const string TestFileZeroCodeLength = "UEsDBBQA+AAIANwyZ0U5T8HwjQAAAL8AAAAIABUAbGltZXJpY2t" +
@@ -52,6 +49,23 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
             });
         }
 
-    }
+		const string TestFileBadCDGoodCD64 = @"UEsDBC0AAAAIANhy+k4cj+r8//////////8IABQAdGVzdGZpbGUBABAAAAA
+			AAAAAAAAUAAAAAAAAACtJLS5Jy8xJVUjOzytJzSsp5gIAUEsBAjMALQAAAAgA2HL6ThyP6vz//////////wgAFAAAAAAAA
+			AAAAAAAAAAAAHRlc3RmaWxlAQAQABIAAAAAAAAAFAAAAAAAAABQSwUGAAAAAAEAAQBKAAAATgAAAAAA";
+
+		[Test]
+		[Category("Zip")]
+		public void CorruptCentralDirWithCorrectZip64CD()
+		{
+			var fileBytes = Convert.FromBase64String(TestFileBadCDGoodCD64);
+			using (var ms = new MemoryStream(fileBytes))
+			using (var zip = new ZipFile(ms))
+			{
+				Assert.AreEqual(1, zip.Count);
+				Assert.AreNotEqual(0, zip[0].Size, "Uncompressed file size read from corrupt CentralDir instead of CD64");
+			}
+		}
+
+	}
 
 }


### PR DESCRIPTION
Possible change for #357 - in ZipFile.ReadEntries, always look for the zip64 central directory and use it if present, rather than only looking if we think we need it.
This change will still throw if it thinks the zip64 directory is required but can't find it (same logic there as before).

The change is sufficient to get the file from #356 loading successfully without causing any issues with the existing unit tests, but doesn't add any more tests as I don't have an appropriate test file to hand (the one linked from #356 being too large to use for a unit test)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
