### PR TITLE
Set and Get a file name internal gzip

### DIFF
--- a/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -132,7 +132,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 			{
 				filename_ = value;
 				flagFname_ = !string.IsNullOrEmpty(filename_)
-					? flagFname_ = FlagSetFileName.SET
+					? FlagSetFileName.SET
 					: FlagSetFileName.NotSet;
 			}
 		}


### PR DESCRIPTION
**Steps to reproduce**

I need to compress a file in a Gzip, but when I rename the gzip file, it is also renamed the internal file.

**Expected behavior**

The internal gzip file is always renamed

**Actual behavior**

Modify the head of the gzip to enter the real name of the internal file

#175
Change this file ICSharpCode.SharpZipLib.GZip.GZipOutputStream.cs


<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
