### PR TITLE
Make the custom exception types serializable

### DIFF
--- a/src/ICSharpCode.SharpZipLib/BZip2/BZip2Exception.cs
+++ b/src/ICSharpCode.SharpZipLib/BZip2/BZip2Exception.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib.BZip2
 {
 	/// <summary>
 	/// BZip2Exception represents exceptions specific to BZip2 classes and code.
 	/// </summary>
+	[Serializable]
 	public class BZip2Exception : SharpZipBaseException
 	{
 		/// <summary>
@@ -30,6 +32,22 @@ namespace ICSharpCode.SharpZipLib.BZip2
 		/// <param name="innerException">The <see cref="Exception"/> that caused this exception.</param>
 		public BZip2Exception(string message, Exception innerException)
 			: base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the BZip2Exception class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected BZip2Exception(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/src/ICSharpCode.SharpZipLib/Core/Exceptions/SharpZipBaseException.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/Exceptions/SharpZipBaseException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib
 {
@@ -8,6 +9,7 @@ namespace ICSharpCode.SharpZipLib
 	/// </summary>
 	/// <remarks>NOTE: Not all exceptions thrown will be derived from this class.
 	/// A variety of other exceptions are possible for example <see cref="ArgumentNullException"></see></remarks>
+	[Serializable]
 	public class SharpZipBaseException : Exception
 	{
 		/// <summary>
@@ -34,6 +36,22 @@ namespace ICSharpCode.SharpZipLib
 		/// <param name="innerException">The inner exception</param>
 		public SharpZipBaseException(string message, Exception innerException)
 			: base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the SharpZipBaseException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected SharpZipBaseException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/src/ICSharpCode.SharpZipLib/Core/Exceptions/StreamDecodingException.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/Exceptions/StreamDecodingException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib
 {
@@ -6,6 +7,7 @@ namespace ICSharpCode.SharpZipLib
 	/// Indicates that an error occured during decoding of a input stream due to corrupt
 	/// data or (unintentional) library incompability.
 	/// </summary>
+	[Serializable]
 	public class StreamDecodingException : SharpZipBaseException
 	{
 		private const string GenericMessage = "Input stream could not be decoded";
@@ -28,5 +30,21 @@ namespace ICSharpCode.SharpZipLib
 		/// <param name="message">A message describing the exception.</param>
 		/// <param name="innerException">The inner exception</param>
 		public StreamDecodingException(string message, Exception innerException) : base(message, innerException) { }
+
+		/// <summary>
+		/// Initializes a new instance of the StreamDecodingException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected StreamDecodingException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Core/Exceptions/StreamUnsupportedException.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/Exceptions/StreamUnsupportedException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib
 {
 	/// <summary>
 	/// Indicates that the input stream could not decoded due to known library incompability or missing features
 	/// </summary>
+	[Serializable]
 	public class StreamUnsupportedException : StreamDecodingException
 	{
 		private const string GenericMessage = "Input stream is in a unsupported format";
@@ -27,5 +29,21 @@ namespace ICSharpCode.SharpZipLib
 		/// <param name="message">A message describing the exception.</param>
 		/// <param name="innerException">The inner exception</param>
 		public StreamUnsupportedException(string message, Exception innerException) : base(message, innerException) { }
+
+		/// <summary>
+		/// Initializes a new instance of the StreamUnsupportedException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected StreamUnsupportedException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Core/Exceptions/UnexpectedEndOfStreamException.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/Exceptions/UnexpectedEndOfStreamException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib
 {
 	/// <summary>
 	/// Indicates that the input stream could not decoded due to the stream ending before enough data had been provided
 	/// </summary>
+	[Serializable]
 	public class UnexpectedEndOfStreamException : StreamDecodingException
 	{
 		private const string GenericMessage = "Input stream ended unexpectedly";
@@ -27,5 +29,21 @@ namespace ICSharpCode.SharpZipLib
 		/// <param name="message">A message describing the exception.</param>
 		/// <param name="innerException">The inner exception</param>
 		public UnexpectedEndOfStreamException(string message, Exception innerException) : base(message, innerException) { }
+
+		/// <summary>
+		/// Initializes a new instance of the UnexpectedEndOfStreamException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected UnexpectedEndOfStreamException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Core/Exceptions/ValueOutOfRangeException.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/Exceptions/ValueOutOfRangeException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib
 {
 	/// <summary>
 	/// Indicates that a value was outside of the expected range when decoding an input stream
 	/// </summary>
+	[Serializable]
 	public class ValueOutOfRangeException : StreamDecodingException
 	{
 		/// <summary>
@@ -42,6 +44,22 @@ namespace ICSharpCode.SharpZipLib
 		}
 
 		private ValueOutOfRangeException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the ValueOutOfRangeException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected ValueOutOfRangeException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/src/ICSharpCode.SharpZipLib/Core/InvalidNameException.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/InvalidNameException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib.Core
 {
 	/// <summary>
 	/// InvalidNameException is thrown for invalid names such as directory traversal paths and names with invalid characters
 	/// </summary>
+	[Serializable]
 	public class InvalidNameException : SharpZipBaseException
 	{
 		/// <summary>
@@ -29,6 +31,22 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <param name="message">A message describing the exception.</param>
 		/// <param name="innerException">The inner exception</param>
 		public InvalidNameException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the InvalidNameException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected InvalidNameException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/src/ICSharpCode.SharpZipLib/GZip/GZipException.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GZipException.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib.GZip
 {
 	/// <summary>
 	/// GZipException represents exceptions specific to GZip classes and code.
 	/// </summary>
+	[Serializable]
 	public class GZipException : SharpZipBaseException
 	{
 		/// <summary>
@@ -30,6 +32,22 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// <param name="innerException">The <see cref="Exception"/> that caused this exception.</param>
 		public GZipException(string message, Exception innerException)
 			: base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the GZipException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected GZipException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/src/ICSharpCode.SharpZipLib/Lzw/LzwException.cs
+++ b/src/ICSharpCode.SharpZipLib/Lzw/LzwException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib.Lzw
 {
 	/// <summary>
 	/// LzwException represents exceptions specific to LZW classes and code.
 	/// </summary>
+	[Serializable]
 	public class LzwException : SharpZipBaseException
 	{
 		/// <summary>
@@ -30,6 +32,22 @@ namespace ICSharpCode.SharpZipLib.Lzw
 		/// <param name="innerException">The <see cref="Exception"/> that caused this exception.</param>
 		public LzwException(string message, Exception innerException)
 			: base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the LzwException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected LzwException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/src/ICSharpCode.SharpZipLib/Tar/TarException.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarException.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib.Tar
 {
 	/// <summary>
 	/// TarException represents exceptions specific to Tar classes and code.
 	/// </summary>
+	[Serializable]
 	public class TarException : SharpZipBaseException
 	{
 		/// <summary>
@@ -30,6 +32,22 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="innerException">The <see cref="Exception"/> that caused this exception.</param>
 		public TarException(string message, Exception innerException)
 			: base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the TarException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected TarException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipException.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipException.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
 	/// <summary>
 	/// ZipException represents exceptions specific to Zip classes and code.
 	/// </summary>
+	[Serializable]
 	public class ZipException : SharpZipBaseException
 	{
 		/// <summary>
@@ -30,6 +32,22 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="innerException">The <see cref="Exception"/> that caused this exception.</param>
 		public ZipException(string message, Exception innerException)
 			: base(message, innerException)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the ZipException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected ZipException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/test/ICSharpCode.SharpZipLib.Tests/Serialization/SerializationTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Serialization/SerializationTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+using NUnit.Framework;
+using ICSharpCode.SharpZipLib.BZip2;
+using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Lzw;
+using ICSharpCode.SharpZipLib.Tar;
+using ICSharpCode.SharpZipLib.Zip;
+
+namespace ICSharpCode.SharpZipLib.Tests.Serialization
+{
+	[TestFixture]
+	public class SerializationTests
+	{
+        /// <summary>
+        /// Test that SharpZipLib Custom Exceptions can be serialized.
+        /// </summary>
+        [Test]
+        [Category("Core")]
+        [Category("Serialization")]
+        [TestCase(typeof(BZip2Exception))]
+        [TestCase(typeof(GZipException))]
+        [TestCase(typeof(InvalidNameException))]
+        [TestCase(typeof(LzwException))]
+        [TestCase(typeof(SharpZipBaseException))]
+        [TestCase(typeof(StreamDecodingException))]
+        [TestCase(typeof(StreamUnsupportedException))]
+        [TestCase(typeof(TarException))]
+        [TestCase(typeof(UnexpectedEndOfStreamException))]
+        [TestCase(typeof(ZipException))]
+        public void SerializeException(Type exceptionType)
+        {
+            string message = $"Serialized {exceptionType.Name}";
+            var exception = Activator.CreateInstance(exceptionType, message);
+
+            var deserializedException = ExceptionSerialiseHelper(exception, exceptionType) as Exception;
+            Assert.That(deserializedException, Is.InstanceOf(exceptionType), "deserialized object should have the correct type");
+            Assert.That(deserializedException.Message, Is.EqualTo(message), "deserialized message should match original message");
+        }
+
+		/// <summary>
+		/// Test that ValueOutOfRangeException can be serialized.
+		/// </summary>
+		[Test]
+		[Category("Core")]
+		[Category("Serialization")]
+		public void SerializeValueOutOfRangeException()
+		{
+			string message = "Serialized ValueOutOfRangeException";
+			var exception = new ValueOutOfRangeException(message);
+
+			var deserializedException = ExceptionSerialiseHelper(exception, typeof(ValueOutOfRangeException)) as ValueOutOfRangeException;
+
+			// ValueOutOfRangeException appends 'out of range' to the end of the message
+			Assert.That(deserializedException.Message, Is.EqualTo($"{message} out of range"), "should have expected message");
+		}
+
+		// Shared serialization helper
+		// round trips the specified exception using DataContractSerializer
+		private static object ExceptionSerialiseHelper(object exception, Type exceptionType)
+		{
+			DataContractSerializer ser = new DataContractSerializer(exceptionType);
+
+			using (var memoryStream = new MemoryStream())
+			{
+				ser.WriteObject(memoryStream, exception);
+
+				memoryStream.Seek(0, loc: SeekOrigin.Begin);
+
+				return ser.ReadObject(memoryStream);
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
refs #365 :

-Mark the custom exception types as Serializable
-Add the constructor overloads needed for deserialization
-Add unit tests for (de)serialization

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
