### PR TITLE
Remove bad GZipException and don't loop forever on 0 reads

### DIFF
--- a/src/ICSharpCode.SharpZipLib/GZip/GzipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipInputStream.cs
@@ -139,12 +139,10 @@ namespace ICSharpCode.SharpZipLib.GZip
 				if (inf.IsFinished)
 				{
 					ReadFooter();
-				} else if (inf.RemainingInput == 0) {
-					// If the stream is not finished but we have no more data to read, don't keep looping forever
-					throw new GZipException("Unexpected EOF");
 				}
 
-				if (bytesRead > 0)
+				// Attempting to read 0 bytes will never yield any bytesRead, so we return instead of looping forever
+				if (bytesRead > 0 || count == 0)
 				{
 					return bytesRead;
 				}


### PR DESCRIPTION
PR #225 introduced a new throw that did not test the right values. The case of stream EOF is handled when attempting to fill the input buffer and `inf.RemainingInput` should not be used for this. Instead, the reason for the test getting stuck is that it attempts to read 0 bytes from the stream. Since the loop tries to read data until it can read at least one byte, it's forever stuck (since attempting to read 0 bytes never returns more than 0 bytes read).  

The use case for supplying 0 as `count` is probably slim, but at least now we're not stuck in an infinite loop.

Corr for #225
Fixes #360

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._