### PR TITLE
Support AES encryption in FastZip.CreateZip

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -227,6 +227,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
+		/// Get / set the method of encrypting entries.
+		/// </summary>
+		/// <remarks>
+		/// Only applies when <see cref="Password"/> is set.
+		/// Defaults to ZipCrypto for backwards compatibility purposes.
+		/// </remarks>
+		public ZipEncryptionMethod EntryEncryptionMethod { get; set; } = ZipEncryptionMethod.ZipCrypto;
+
+		/// <summary>
 		/// Get or set the <see cref="INameTransform"></see> active when creating Zip files.
 		/// </summary>
 		/// <seealso cref="EntryFactory"></seealso>
@@ -369,7 +378,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				outputStream_.SetLevel((int)CompressionLevel);
 
-				if (password_ != null)
+				if (false == string.IsNullOrEmpty(password_) && EntryEncryptionMethod != ZipEncryptionMethod.None)
 				{
 					outputStream_.Password = password_;
 				}
@@ -539,6 +548,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 					using (FileStream stream = File.Open(e.Name, FileMode.Open, FileAccess.Read, FileShare.Read))
 					{
 						ZipEntry entry = entryFactory_.MakeFileEntry(e.Name);
+
+						// Set up AES encryption for the entry if required.
+						ConfigureEntryEncryption(entry);
+
 						outputStream_.PutNextEntry(entry);
 						AddFileContents(e.Name, stream);
 					}
@@ -554,6 +567,26 @@ namespace ICSharpCode.SharpZipLib.Zip
 						continueRunning_ = false;
 						throw;
 					}
+				}
+			}
+		}
+
+		// Set up the encryption method to use for the specific entry.
+		private void ConfigureEntryEncryption(ZipEntry entry)
+		{
+			// Only alter the entries options if AES isn't already enabled for it
+			// (it might have been set up by the entry factory, and if so we let that take precedence)
+			if (!string.IsNullOrEmpty(Password) && entry.AESEncryptionStrength == 0)
+			{
+				switch (EntryEncryptionMethod)
+				{
+					case ZipEncryptionMethod.AES128:
+						entry.AESKeySize = 128;
+						break;
+
+					case ZipEncryptionMethod.AES256:
+						entry.AESKeySize = 256;
+						break;
 				}
 			}
 		}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEncryptionMethod.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEncryptionMethod.cs
@@ -1,0 +1,28 @@
+﻿namespace ICSharpCode.SharpZipLib.Zip
+{
+	/// <summary>
+	/// The method of encrypting entries when creating zip archives.
+	/// </summary>
+	public enum ZipEncryptionMethod
+	{
+		/// <summary>
+		/// No encryption will be used.
+		/// </summary>
+		None,
+
+		/// <summary>
+		/// Encrypt entries with ZipCrypto.
+		/// </summary>
+		ZipCrypto,
+
+		/// <summary>
+		/// Encrypt entries with AES 128.
+		/// </summary>
+		AES128,
+
+		/// <summary>
+		/// Encrypt entries with AES 256.
+		/// </summary>
+		AES256
+	}
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -159,8 +159,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		}
 
 		[Test]
+		[TestCase(ZipEncryptionMethod.ZipCrypto)]
+		[TestCase(ZipEncryptionMethod.AES128)]
+		[TestCase(ZipEncryptionMethod.AES256)]
 		[Category("Zip")]
-		public void Encryption()
+		public void Encryption(ZipEncryptionMethod encryptionMethod)
 		{
 			const string tempName1 = "a.dat";
 
@@ -174,8 +177,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			try
 			{
-				var fastZip = new FastZip();
-				fastZip.Password = "Ahoy";
+				var fastZip = new FastZip
+				{
+					Password = "Ahoy",
+					EntryEncryptionMethod = encryptionMethod
+				};
 
 				fastZip.CreateZip(target, tempFilePath, false, @"a\.dat", null);
 
@@ -189,6 +195,21 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					Assert.AreEqual(1, entry.Size);
 					Assert.IsTrue(zf.TestArchive(true));
 					Assert.IsTrue(entry.IsCrypted);
+
+					switch (encryptionMethod)
+					{
+						case ZipEncryptionMethod.ZipCrypto:
+							Assert.That(entry.AESKeySize, Is.Zero, "AES key size should be 0 for ZipCrypto encrypted entries");
+							break;
+
+						case ZipEncryptionMethod.AES128:
+							Assert.That(entry.AESKeySize, Is.EqualTo(128), "AES key size should be 128 for AES128 encrypted entries");
+							break;
+
+						case ZipEncryptionMethod.AES256:
+							Assert.That(entry.AESKeySize, Is.EqualTo(256), "AES key size should be 256 for AES256 encrypted entries");
+							break;
+					}
 				}
 			}
 			finally


### PR DESCRIPTION
Provide a means of enabling AES encryption when creating zips with FastZip (by settings the AESKeySize of the entries it creates prior to giving them to ZipOutputStream).

Notes:

- I added a new mode enum in its own file rather than in FastZip.cs (easy to merge if needed).
- I'm not sure if the encryption mode should have a 'None' option, given that the setting only applies if the password property has been set seperately?
- ~~The call to TestArchive in the unit tests is commented out because of #317~~ 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
