### PR TITLE
Better handle baseStreams closing themselves unexpectedly

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -116,7 +116,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 			rawLength = 0;
 			int toRead = rawData.Length;
 
-			while (toRead > 0)
+			while (toRead > 0 && inputStream.CanRead)
 			{
 				int count = inputStream.Read(rawData, rawLength, toRead);
 				if (count <= 0)

--- a/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipTests.cs
@@ -390,9 +390,41 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 
 
 				}
+			}
+
 		}
 
-	}
+		/// <summary>
+		/// Should gracefully handle reading from a stream that becomes unreadable after
+		///  all of the data has been read.
+		/// </summary>
+		/// <remarks>
+		/// Test for https://github.com/icsharpcode/SharpZipLib/issues/379
+		/// </remarks>
+		[Test]
+		[Category("Zip")]
+		public void ShouldGracefullyHandleReadingANonReableStream()
+		{
+			MemoryStream ms = new SelfClosingStream();
+			using (var gzos = new GZipOutputStream(ms))
+			{
+				gzos.IsStreamOwner = false;
+
+				byte[] buf = new byte[100000];
+				var rnd = new Random();
+				rnd.NextBytes(buf);
+
+				gzos.Write(buf, 0, buf.Length);
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using (var gzis = new GZipInputStream(ms))
+			using (var msRaw = new MemoryStream())
+			{
+				gzis.CopyTo(msRaw);
+			}
+		}
 
 		[Test]
 		[Category("GZip")]

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
@@ -539,4 +539,52 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 			return base.Read(buffer, offset, count);
 		}
 	}
+
+	/// <summary>
+	/// A stream that closes itself when all of its data is read.
+	/// </summary>
+	/// <remarks>
+	/// Useful for testing issues such as https://github.com/icsharpcode/SharpZipLib/issues/379
+	/// </remarks>
+	internal class SelfClosingStream : MemoryStream
+	{
+		private bool isFullyRead = false;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SelfClosingStream"/> class.
+		/// </summary>
+		public SelfClosingStream()
+		{
+		}
+
+		// <inheritdoc/>
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			var read = base.Read(buffer, offset, count);
+
+			if (read == 0)
+			{
+				isFullyRead = true;
+				Close();
+			}
+
+			return read;
+		}
+
+		/// <summary>
+		/// CanRead is false if we're closed, or base.CanRead otherwise.
+		/// </summary>
+		public override bool CanRead
+		{
+			get
+			{
+				if (isFullyRead)
+				{
+					return false;
+				}
+
+				return base.CanRead;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Possible fix for #379, using the change to InflaterInputStream suggested there.

I'm not certain if its best to do the extra check in the inflator code or in gzipinputstream - putting it in the lower level code could effect the handling of Zip files as well, but i'm not certain if the issue can effect ZipInputStream in the same way as GZipInputStream.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
