### PR TITLE
 An an override of Flush() to GZipOutputStream to ensure the headers are writen before flushing

### DIFF
--- a/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -160,6 +160,20 @@ namespace ICSharpCode.SharpZipLib.GZip
 			}
 		}
 
+		/// <summary>
+		/// Flushes the stream by ensuring the header is written, and then calling <see cref="DeflaterOutputStream.Flush">Flush</see>
+		/// on the deflater.
+		/// </summary>
+		public override void Flush()
+		{
+			if (state_ == OutputState.Header)
+			{
+				WriteHeader();
+			}
+
+			base.Flush();
+		}
+
 		#endregion Stream overrides
 
 		#region DeflaterOutputStream overrides


### PR DESCRIPTION
refs #382 - An an override of Flush() to GZipOutputStream to ensure the GZip header is always written before any data is flushed to the output stream.

I'm not entirely sure that there aren't any other issues occuring the described example or with the way flushing is handled, but ensuring the header is written before flushing fixes the tests and seems a reasonable thing to do.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
