### PR TITLE
Skip forced Deflate flush when using Stored compression

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -379,7 +379,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		}
 
 		/// <summary>
-		/// Flushes the stream by calling <see cref="DeflaterOutputStream.Flush">Flush</see> on the deflater and then
+		/// Flushes the stream by calling <see cref="Flush">Flush</see> on the deflater and then
 		/// on the underlying stream.  This ensures that all bytes are flushed.
 		/// </summary>
 		public override void Flush()

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1069,10 +1069,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 				bool testHeader = (tests & HeaderTest.Header) != 0;
 				bool testData = (tests & HeaderTest.Extract) != 0;
 
-				baseStream_.Seek(offsetOfFirstEntry + entry.Offset, SeekOrigin.Begin);
-				if ((int)ReadLEUint() != ZipConstants.LocalHeaderSignature)
+				var entryAbsOffset = offsetOfFirstEntry + entry.Offset;
+				
+				baseStream_.Seek(entryAbsOffset, SeekOrigin.Begin);
+				var signature = (int)ReadLEUint();
+
+				if (signature != ZipConstants.LocalHeaderSignature)
 				{
-					throw new ZipException(string.Format("Wrong local header signature @{0:X}", offsetOfFirstEntry + entry.Offset));
+					throw new ZipException(string.Format("Wrong local header signature at 0x{0:x}, expected 0x{1:x8}, actual 0x{2:x8}",
+						entryAbsOffset, ZipConstants.LocalHeaderSignature, signature));
 				}
 
 				var extractVersion = (short)(ReadLEUshort() & 0x00ff);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -887,6 +887,22 @@ namespace ICSharpCode.SharpZipLib.Zip
 			entries = null;
 		}
 
+		/// <summary>
+		/// Flushes the stream by calling <see cref="DeflaterOutputStream.Flush">Flush</see> on the deflater stream unless
+		/// the current compression method is <see cref="CompressionMethod.Stored"/>. Then it flushes the underlying output stream.
+		/// </summary>
+		public override void Flush()
+		{
+			if(curMethod == CompressionMethod.Stored)
+			{
+				baseOutputStream_.Flush();
+			} 
+			else
+			{
+				base.Flush();
+			}
+		}
+
 		#region Instance Fields
 
 		/// <summary>

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/RingBuffer.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/RingBuffer.cs
@@ -405,6 +405,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 	}
 
 	[TestFixture]
+	[Explicit("Meta tests (for ringbuffer)")]
 	public class ExerciseBuffer
 	{
 		[Test]

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.Text;
 
 namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 {
@@ -9,6 +10,8 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 	/// </summary>
 	public static class Utils
 	{
+		public static int DummyContentLength = 16;
+
 		private static Random random = new Random();
 
 		private static void Compare(byte[] a, byte[] b)
@@ -32,16 +35,24 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
 		public static void WriteDummyData(string fileName, int size = -1)
 		{
-			if (size < 0)
+			using(var fs = File.OpenWrite(fileName))
 			{
-				File.WriteAllText(fileName, DateTime.UtcNow.Ticks.ToString("x16"));
+				WriteDummyData(fs, size);
 			}
-			else if (size > 0)
+		}
+
+		public static void WriteDummyData(Stream stream, int size = -1)
+		{
+			var bytes = (size < 0)
+				? Encoding.ASCII.GetBytes(DateTime.UtcNow.Ticks.ToString("x16"))
+				: new byte[size];
+
+			if(size > 0)
 			{
-				var bytes = Array.CreateInstance(typeof(byte), size) as byte[];
 				random.NextBytes(bytes);
-				File.WriteAllBytes(fileName, bytes);
 			}
+
+			stream.Write(bytes, 0, bytes.Length);
 		}
 
 		public static TempFile GetDummyFile(int size = -1)
@@ -85,7 +96,10 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 			}
 
 			public void Dispose()
-				=> Dispose(true);
+			{
+				Dispose(true);
+				GC.SuppressFinalize(this);
+			}
 
 			#endregion IDisposable Support
 		}
@@ -122,7 +136,10 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 			}
 
 			public void Dispose()
-				=> Dispose(true);
+			{
+				Dispose(true);
+				GC.SuppressFinalize(this);
+			}
 
 			internal string CreateDummyFile(int size = -1)
 				=> CreateDummyFile(GetDummyFileName(), size);

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -95,6 +95,32 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 		[Test]
 		[Category("Zip")]
+		[Category("CreatesTempFile")]
+		public void ContentEqualAfterAfterArchived([Values(0, 1, 64)]int contentSize)
+		{
+			using(var sourceDir = new Utils.TempDir())
+			using(var targetDir = new Utils.TempDir())
+			using(var zipFile = Utils.GetDummyFile(0))
+			{
+				var sourceFile = sourceDir.CreateDummyFile(contentSize);
+				var sourceContent = File.ReadAllBytes(sourceFile);
+				new FastZip().CreateZip(zipFile.Filename, sourceDir.Fullpath, true, null);
+
+				Assert.DoesNotThrow(() =>
+				{
+					new FastZip().ExtractZip(zipFile.Filename, targetDir.Fullpath, null);
+				}, "Exception during extraction of test archive");
+				
+				var targetFile = Path.Combine(targetDir.Fullpath, Path.GetFileName(sourceFile));
+				var targetContent = File.ReadAllBytes(targetFile);
+
+				Assert.AreEqual(sourceContent.Length, targetContent.Length, "Extracted file size does not match source file size");
+				Assert.AreEqual(sourceContent, targetContent, "Extracted content does not match source content");
+			}
+		}
+
+		[Test]
+		[Category("Zip")]
 		public void Encryption()
 		{
 			const string tempName1 = "a.dat";

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -615,6 +615,37 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			File.Delete(tempFile);
 		}
 
+		[Test]
+		[Category("Zip")]
+		[Category("CreatesTempFile")]
+		public void CreateArchiveWithNoCompression()
+		{
+
+			using (var sourceFile = Utils.GetDummyFile())
+			using (var zipFile = Utils.GetDummyFile(0))
+			{
+				var inputContent = File.ReadAllText(sourceFile.Filename);
+				using (ZipFile f = ZipFile.Create(zipFile.Filename))
+				{
+					f.BeginUpdate();
+					f.Add(sourceFile.Filename, CompressionMethod.Stored);
+					f.CommitUpdate();
+					Assert.IsTrue(f.TestArchive(true));
+					f.Close();
+				}
+
+				using (ZipFile f = new ZipFile(zipFile.Filename))
+				{
+					Assert.AreEqual(1, f.Count);
+					using (var sr = new StreamReader(f.GetInputStream(f[0])))
+					{
+						var outputContent = sr.ReadToEnd();
+						Assert.AreEqual(inputContent, outputContent, "extracted content does not match source content");
+					}
+				}
+			}
+		}
+
 		/// <summary>
 		/// Check that ZipFile finds entries when its got a long comment
 		/// </summary>
@@ -1089,8 +1120,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				var names = new string[]
 				{
 					"\u030A\u03B0",     // Greek
-                    "\u0680\u0685"      // Arabic
-                };
+					"\u0680\u0685"      // Arabic
+				};
 
 				foreach (string name in names)
 				{


### PR DESCRIPTION
Since #225 added forced flushing to `DeflaterOutputStream` it will run the deflate state machine even if it's not supposed to be used. This did not happen before since it were always in a state where it did not need more data when using `CompressionMethod.Stored`.

By overriding the `Flush()` method in `ZipOutputStream` we can skip the forced deflate flush when it isn't used.

Should fix #398 and #391 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
