### PR TITLE
Allow Descriptor flag for Stored method

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -484,24 +484,24 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public static string ConvertToString(byte[] data)
 			=> ZipStrings.ConvertToString(data);
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToStringExt(int, byte[], int)"/></summary>
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToStringExt(GeneralBitFlags, byte[], int)"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToStringExt instead")]
 		public static string ConvertToStringExt(int flags, byte[] data, int count)
-			=> ZipStrings.ConvertToStringExt(flags, data, count);
+			=> ZipStrings.ConvertToStringExt((GeneralBitFlags)flags, data, count);
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToStringExt(int, byte[])"/></summary>
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToStringExt(GeneralBitFlags, byte[])"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToStringExt instead")]
 		public static string ConvertToStringExt(int flags, byte[] data)
-			=> ZipStrings.ConvertToStringExt(flags, data);
+			=> ZipStrings.ConvertToStringExt((GeneralBitFlags)flags, data);
 
 		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToArray(string)"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToArray instead")]
 		public static byte[] ConvertToArray(string str)
 			=> ZipStrings.ConvertToArray(str);
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToArray(int, string)"/></summary>
+		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToArray(GeneralBitFlags, string)"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToArray instead")]
 		public static byte[] ConvertToArray(int flags, string str)
-			=> ZipStrings.ConvertToArray(flags, str);
+			=> ZipStrings.ConvertToArray((GeneralBitFlags)flags, str);
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -366,15 +366,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </remarks>
 		/// <seealso cref="IsUnicodeText"></seealso>
 		/// <seealso cref="IsCrypted"></seealso>
-		public int Flags
+		public GeneralBitFlags Flags
 		{
 			get
 			{
-				return flags;
+				return (GeneralBitFlags)flags;
 			}
 			set
 			{
-				flags = value;
+				flags = (int)value;
 			}
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
@@ -192,7 +192,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			WriteLEInt(ZipConstants.LocalHeaderSignature);
 
 			WriteLEShort(entry.Version);
-			WriteLEShort(entry.Flags);
+			WriteLEShort((int)entry.Flags);
 			WriteLEShort((byte)method);
 			WriteLEInt((int)entry.DosTime);
 
@@ -562,7 +562,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			int result = 0;
 
 			// Add data descriptor if flagged as required
-			if ((entry.Flags & (int)GeneralBitFlags.Descriptor) != 0)
+			if (entry.Flags.HasFlag(GeneralBitFlags.Descriptor))
 			{
 				// The signature is not PKZIP originally but is now described as optional
 				// in the PKZIP Appnote documenting trhe format.

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -232,7 +232,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			int compressionLevel = defaultCompressionLevel;
 
 			// Clear flags that the library manages internally
-			entry.Flags &= (int)GeneralBitFlags.UnicodeText;
+			entry.Flags &= GeneralBitFlags.UnicodeText;
 			patchEntryHeader = false;
 
 			bool headerInfoAvailable;
@@ -257,8 +257,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 						if (!CanPatchEntries)
 						{
 							// Can't patch entries so storing is not possible.
-							method = CompressionMethod.Deflated;
-							compressionLevel = 0;
+							// Update: support for GeneralBitFlags.Descriptor on non-deflate methods
+							//         have been present in PKZIP for ~20 years now
+							//method = CompressionMethod.Deflated;
+							//compressionLevel = 0;
+
 						}
 					}
 					else // entry.size must be > 0
@@ -277,7 +280,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					// after compressed data.
 
 					// Stored entries of this form have already been converted to deflating.
-					entry.Flags |= 8;
+					entry.Flags |= GeneralBitFlags.Descriptor;
 				}
 				else
 				{
@@ -293,7 +296,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					// Need to append a data descriptor as the crc isnt available for use
 					// with encryption, the date is used instead.  Setting the flag
 					// indicates this to the decompressor.
-					entry.Flags |= 8;
+					entry.Flags |= GeneralBitFlags.Descriptor;
 				}
 			}
 
@@ -312,7 +315,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			WriteLeInt(ZipConstants.LocalHeaderSignature);
 
 			WriteLeShort(entry.Version);
-			WriteLeShort(entry.Flags);
+			WriteLeShort((int)entry.Flags);
 			WriteLeShort((byte)entry.CompressionMethodForHeader);
 			WriteLeInt((int)entry.DosTime);
 
@@ -569,7 +572,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 
 			// Add data descriptor if flagged as required
-			if ((curEntry.Flags & 8) != 0)
+			if (curEntry.Flags.HasFlag(GeneralBitFlags.Descriptor))
 			{
 				WriteLeInt(ZipConstants.DataDescriptorSignature);
 				WriteLeInt(unchecked((int)curEntry.Crc));
@@ -752,7 +755,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				WriteLeInt(ZipConstants.CentralHeaderSignature);
 				WriteLeShort((entry.HostSystem << 8) | entry.VersionMadeBy);
 				WriteLeShort(entry.Version);
-				WriteLeShort(entry.Flags);
+				WriteLeShort((short)entry.Flags);
 				WriteLeShort((short)entry.CompressionMethodForHeader);
 				WriteLeInt((int)entry.DosTime);
 				WriteLeInt((int)entry.Crc);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -124,8 +124,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public static string ConvertToString(byte[] data)
 			=> ConvertToString(data, data.Length);
 
-		private static Encoding EncodingFromFlag(int flags)
-			=> ((flags & (int)GeneralBitFlags.UnicodeText) != 0)
+		private static Encoding EncodingFromFlag(GeneralBitFlags flags)
+			=> (flags.HasFlag(GeneralBitFlags.UnicodeText))
 				? Encoding.UTF8
 				: Encoding.GetEncoding(
 					// if CodePage wasn't set manually and no utf flag present
@@ -147,7 +147,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <returns>
 		/// <paramref name="data">data</paramref>converted to a string
 		/// </returns>
-		public static string ConvertToStringExt(int flags, byte[] data, int count)
+		public static string ConvertToStringExt(GeneralBitFlags flags, byte[] data, int count)
 			=> (data == null)
 				? string.Empty
 				: EncodingFromFlag(flags).GetString(data, 0, count);
@@ -162,7 +162,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <returns>
 		/// <paramref name="data">data</paramref>converted to a string
 		/// </returns>
-		public static string ConvertToStringExt(int flags, byte[] data)
+		public static string ConvertToStringExt(GeneralBitFlags flags, byte[] data)
 			=> ConvertToStringExt(flags, data, data.Length);
 
 		/// <summary>
@@ -185,7 +185,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// String to convert to an array
 		/// </param>
 		/// <returns>Converted array</returns>
-		public static byte[] ConvertToArray(int flags, string str)
+		public static byte[] ConvertToArray(GeneralBitFlags flags, string str)
 			=> (string.IsNullOrEmpty(str))
 				? new byte[0]
 				: EncodingFromFlag(flags).GetBytes(str);

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
@@ -47,7 +47,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 				ZipEntry entry2 = inStream.GetNextEntry();
 
-				if ((entry2.Flags & 8) == 0)
+				if (!entry2.Flags.HasFlag(GeneralBitFlags.Descriptor))
 				{
 					Assert.AreEqual(size, entry2.Size, "Entry size invalid");
 				}
@@ -894,14 +894,14 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			string converted = ZipStrings.ConvertToStringExt(0, rawData);
 			Assert.AreEqual(sample, converted);
 
-			converted = ZipStrings.ConvertToStringExt((int)GeneralBitFlags.UnicodeText, rawData);
+			converted = ZipStrings.ConvertToStringExt(GeneralBitFlags.UnicodeText, rawData);
 			Assert.AreEqual(sample, converted);
 
 			// This time use some greek characters
 			sample = "\u03A5\u03d5\u03a3";
 			rawData = Encoding.UTF8.GetBytes(sample);
 
-			converted = ZipStrings.ConvertToStringExt((int)GeneralBitFlags.UnicodeText, rawData);
+			converted = ZipStrings.ConvertToStringExt(GeneralBitFlags.UnicodeText, rawData);
 			Assert.AreEqual(sample, converted);
 		}
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
@@ -313,7 +313,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					var entry = zis.GetNextEntry();
 
 					Assert.AreEqual(entry.Name, EntryName);
-					Assert.IsTrue((entry.Flags & (int)GeneralBitFlags.Descriptor) != 0);
+					Assert.IsTrue(entry.Flags.HasFlag(GeneralBitFlags.Descriptor));
 					return zis;
 				},
 				output: bs =>

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEntryHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEntryHandling.cs
@@ -79,7 +79,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			long testCompressedSize = 72347;
 			var testExtraData = new byte[] { 0x00, 0x01, 0x00, 0x02, 0x0EF, 0xFE };
 			string testName = "Namu";
-			int testFlags = 4567;
+			var testFlags = (GeneralBitFlags)4567;
 			long testDosTime = 23434536;
 			CompressionMethod testMethod = CompressionMethod.Deflated;
 
@@ -114,7 +114,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			long testCompressedSize = 72347;
 			var testExtraData = new byte[] { 0x00, 0x01, 0x00, 0x02, 0x0EF, 0xFE };
 			string testName = "Namu";
-			int testFlags = 4567;
+			var testFlags = (GeneralBitFlags)4567;
 			long testDosTime = 23434536;
 			CompressionMethod testMethod = CompressionMethod.Deflated;
 


### PR DESCRIPTION
Fixes #384 

Tests needs fixing, and some more tests needs to be added. There might also be some Descriptor-related code that is disabled due to a Deflate guard.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
