### PR TITLE
When searching for the Zip64 end of central directory locator, pay attention to its fixed size.

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -345,6 +345,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 		[Obsolete("Use CryptoHeaderSize instead")]
 		public const int CRYPTO_HEADER_SIZE = 12;
 
+		/// <summary>
+		/// The size of the Zip64 central directory locator.
+		/// </summary>
+		public const int Zip64EndOfCentralDirectoryLocatorSize = 20;
+
 		#endregion Header Sizes
 
 		#region Header Signatures

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -3422,8 +3422,16 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 
 			// #357 - always check for the existance of the Zip64 central directory.
-			long locatedZip64EndOfCentralDir = LocateBlockWithSignature(ZipConstants.Zip64CentralDirLocatorSignature, locatedEndOfCentralDir, 0, 0x1000);
-			if (locatedZip64EndOfCentralDir < 0)
+			// #403 - Take account of the fixed size of the locator when searching.
+			//    Subtract from locatedEndOfCentralDir so that the endLocation is the location of EndOfCentralDirectorySignature,
+			//    rather than the data following the signature.
+			long locatedZip64EndOfCentralDirLocator = LocateBlockWithSignature(
+				ZipConstants.Zip64CentralDirLocatorSignature,
+				locatedEndOfCentralDir - 4,
+				ZipConstants.Zip64EndOfCentralDirectoryLocatorSize,
+				0);
+
+			if (locatedZip64EndOfCentralDirLocator < 0)
 			{
 				if (requireZip64)
 				{


### PR DESCRIPTION
#403 / #375 - the Zip64 end of central directory locator has a fixed 20 byte length, but the calls to LocateBlockWithSignature were specifying a fixed size of 0 and a dynamic size of 0x1000, which meant that the signature bytes could incorrectly be matched in a location other than where they should be (20 bytes prior to the end of central directory signature)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
