### PR TITLE
fix ZipStrings.UseUnicode

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -80,17 +80,17 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			get
 			{
-				return codePage == Encoding.UTF8.CodePage;
+				return CodePage == Encoding.UTF8.CodePage;
 			}
 			set
 			{
 				if (value)
 				{
-					codePage = Encoding.UTF8.CodePage;
+					CodePage = Encoding.UTF8.CodePage;
 				}
 				else
 				{
-					codePage = SystemDefaultCodePage;
+					CodePage = SystemDefaultCodePage;
 				}
 			}
 		}


### PR DESCRIPTION
use CodePage property instead of backing field so UseUnicode is set correct even if codePage is auto

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
