### PR TITLE
Add multistream support to BZip2

### DIFF
--- a/src/ICSharpCode.SharpZipLib/BZip2/BZip2.cs
+++ b/src/ICSharpCode.SharpZipLib/BZip2/BZip2.cs
@@ -15,7 +15,8 @@ namespace ICSharpCode.SharpZipLib.BZip2
 		/// <param name="inStream">The readable stream containing data to decompress.</param>
 		/// <param name="outStream">The output stream to receive the decompressed data.</param>
 		/// <param name="isStreamOwner">Both streams are closed on completion if true.</param>
-		public static void Decompress(Stream inStream, Stream outStream, bool isStreamOwner)
+		/// <param name="multiStream">Whether to attempt to continue reading after stream end.</param>
+		public static void Decompress(Stream inStream, Stream outStream, bool isStreamOwner, bool multiStream)
 		{
 			if (inStream == null || outStream == null)
 			{
@@ -24,7 +25,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 
 			try
 			{
-				using (BZip2InputStream bzipInput = new BZip2InputStream(inStream))
+				using (BZip2InputStream bzipInput = new BZip2InputStream(inStream, multiStream))
 				{
 					bzipInput.IsStreamOwner = isStreamOwner;
 					Core.StreamUtils.Copy(bzipInput, outStream, new byte[4096]);
@@ -39,6 +40,16 @@ namespace ICSharpCode.SharpZipLib.BZip2
 				}
 			}
 		}
+
+		/// <summary>
+		/// Decompress the <paramref name="inStream">input</paramref> writing
+		/// uncompressed data to the <paramref name="outStream">output stream</paramref>
+		/// </summary>
+		/// <param name="inStream">The readable stream containing data to decompress.</param>
+		/// <param name="outStream">The output stream to receive the decompressed data.</param>
+		/// <param name="isStreamOwner">Both streams are closed on completion if true.</param>
+		public static void Decompress(Stream inStream, Stream outStream, bool isStreamOwner)
+			=> Decompress(inStream, outStream, isStreamOwner, true);
 
 		/// <summary>
 		/// Compress the <paramref name="inStream">input stream</paramref> sending

--- a/src/ICSharpCode.SharpZipLib/BZip2/BZip2Constants.cs
+++ b/src/ICSharpCode.SharpZipLib/BZip2/BZip2Constants.cs
@@ -3,7 +3,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// <summary>
 	/// Defines internal values for both compression and decompression
 	/// </summary>
-	internal sealed class BZip2Constants
+	internal static class BZip2Constants
 	{
 		/// <summary>
 		/// Random numbers used to randomise repetitive blocks
@@ -114,8 +114,16 @@ namespace ICSharpCode.SharpZipLib.BZip2
 		/// </summary>
 		public const int OvershootBytes = 20;
 
-		private BZip2Constants()
-		{
-		}
+		/// <summary>
+		/// 48 bit magic number used to identify stream footer
+		/// </summary>
+		/// <remarks>Square root of Pi in BCD</remarks>
+		public const ulong MagicFooter = 0x177245385090UL;
+
+		/// <summary>
+		/// 48 bit magic number used to identify stream header
+		/// </summary>
+		/// <remarks>Pi in BCD</remarks>
+		public const ulong MagicHeader = 0x314159265359UL;
 	}
 }


### PR DESCRIPTION
Fixes #413 and #162

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
