### PR TITLE
Make ZipFile.Add throw NotSupportedException when trying to add an AES encrypted entry

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1850,6 +1850,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="dataSource">The source of the data for this entry.</param>
 		/// <param name="entry">The entry to add.</param>
 		/// <remarks>This can be used to add file entries with a custom data source.</remarks>
+		/// <exception cref="NotSupportedException">
+		/// The encryption method specified in <paramref name="entry"/> is unsupported.
+		/// </exception>
 		public void Add(IStaticDataSource dataSource, ZipEntry entry)
 		{
 			if (entry == null)
@@ -1860,6 +1863,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 			if (dataSource == null)
 			{
 				throw new ArgumentNullException(nameof(dataSource));
+			}
+
+			// We don't currently support adding entries with AES encryption, so throw
+			// up front instead of failing or falling back to ZipCrypto later on
+			if (entry.AESKeySize > 0)
+			{
+				throw new NotSupportedException("Creation of AES encrypted entries is not supported");
 			}
 
 			CheckUpdating();

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -1547,5 +1547,27 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				}
 			}
 		}
+
+		/// <summary>
+		/// Refs https://github.com/icsharpcode/SharpZipLib/issues/385
+		/// Trying to add an AES Encrypted entry to ZipFile should throw as it isn't supported
+		/// </summary>
+		[Test]
+		[Category("Zip")]
+		public void AddingAnAESEncryptedEntryShouldThrow()
+		{
+			var memStream = new MemoryStream();
+			using (ZipFile zof = new ZipFile(memStream))
+			{
+				var entry = new ZipEntry("test")
+				{
+					AESKeySize = 256
+				};
+
+				zof.BeginUpdate();
+				var exception = Assert.Throws<NotSupportedException>(() => zof.Add(new StringMemoryDataSource("foo"), entry));
+				Assert.That(exception.Message, Is.EqualTo("Creation of AES encrypted entries is not supported"));
+			}
+		}
 	}
 }


### PR DESCRIPTION
As suggested in #385, make the Add(IStaticDataSource dataSource, ZipEntry entry) function in ZipFile throw NotSupportedException if you try to add an entry with AES encryption set, rather that silently using ZipCrypto instead.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
