### PR TITLE
Change ZipOutputStream.PutNextEntry to explicity validate the requested compression method

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -206,6 +206,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// Entry name is too long<br/>
 		/// Finish has already been called<br/>
 		/// </exception>
+		/// <exception cref="System.NotImplementedException">
+		/// The Compression method specified for the entry is unsupported.
+		/// </exception>
 		public void PutNextEntry(ZipEntry entry)
 		{
 			if (entry == null)
@@ -229,6 +232,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 
 			CompressionMethod method = entry.CompressionMethod;
+
+			// Check that the compression is one that we support
+			if (method != CompressionMethod.Deflated && method != CompressionMethod.Stored)
+			{
+				throw new NotImplementedException("Compression method not supported");
+			}
+
 			int compressionLevel = defaultCompressionLevel;
 
 			// Clear flags that the library manages internally


### PR DESCRIPTION
Equivalent of #421, but for ZipOutputStream.

I added this to throw NotImplementedException, and then wondered again if it should be that or NotSupportedException :-(.

PR Doesn't add a unit test as the CompressionMethod property setter on ZipEntry currently prevents it, so the only way to try it would be to use a ZipEntry with a different type from an existing file.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
