### PR TITLE
Remove the link to the sharpdevelop forum from readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SharpZipLib (\#ziplib, formerly NZipLib) is a compression library that supports 
 
 SharpZipLib was originally ported from the [GNU Classpath](http://www.gnu.org/software/classpath/) java.util.zip library for use with [SharpDevelop](http://www.icsharpcode.net/OpenSource/SD), which needed gzip/zip compression. bzip2 compression and tar archiving were added later due to popular demand.
 
-The [SharpZipLib homepage](http://icsharpcode.github.io/SharpZipLib/) has precompiled libraries available for download, [API documentation](https://icsharpcode.github.io/SharpZipLib/help/api/index.html), [a link to the forum for support](http://community.sharpdevelop.net/forums/12/ShowForum.aspx), [release history](https://github.com/icsharpcode/SharpZipLib/wiki/Release-History), samples and more.
+The [SharpZipLib homepage](http://icsharpcode.github.io/SharpZipLib/) has precompiled libraries available for download, [API documentation](https://icsharpcode.github.io/SharpZipLib/help/api/index.html), [release history](https://github.com/icsharpcode/SharpZipLib/wiki/Release-History), samples and more.
 
 License
 -------


### PR DESCRIPTION
The forum at community.sharpdevelop.net doesn't seem to exist any more, so no need to retain a link to it in the documentation?

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
