### PR TITLE
Change the BZip2 Compress/Decompress functions to throw ArgumentNullxception rather than Exception when null stream parameters are provided

### DIFF
--- a/src/ICSharpCode.SharpZipLib/BZip2/BZip2.cs
+++ b/src/ICSharpCode.SharpZipLib/BZip2/BZip2.cs
@@ -17,10 +17,11 @@ namespace ICSharpCode.SharpZipLib.BZip2
 		/// <param name="isStreamOwner">Both streams are closed on completion if true.</param>
 		public static void Decompress(Stream inStream, Stream outStream, bool isStreamOwner)
 		{
-			if (inStream == null || outStream == null)
-			{
-				throw new Exception("Null Stream");
-			}
+			if (inStream == null)
+				throw new ArgumentNullException(nameof(inStream));
+
+			if (outStream == null)
+				throw new ArgumentNullException(nameof(outStream));
 
 			try
 			{
@@ -51,10 +52,11 @@ namespace ICSharpCode.SharpZipLib.BZip2
 		/// the lowest compression and 9 the highest.</param>
 		public static void Compress(Stream inStream, Stream outStream, bool isStreamOwner, int level)
 		{
-			if (inStream == null || outStream == null)
-			{
-				throw new Exception("Null Stream");
-			}
+			if (inStream == null)
+				throw new ArgumentNullException(nameof(inStream));
+
+			if (outStream == null)
+				throw new ArgumentNullException(nameof(outStream));
 
 			try
 			{


### PR DESCRIPTION
Pretty trivial, but just something I noticed while looking at the code - throwing a base Exception for a null parameter doesn't seem ideal - ArgumentNullException with the parameter name specified seems better?

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
