### PR TITLE
Restore directory timestamps when extracting with FastZip

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -708,6 +708,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 					try
 					{
 						Directory.CreateDirectory(dirName);
+
+						if (entry.IsDirectory && restoreDateTimeOnExtract_)
+						{
+							Directory.SetLastWriteTime(dirName, entry.DateTime);
+						}
 					}
 					catch (Exception ex)
 					{

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -529,5 +529,62 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			// test folder should not have been created on error
 			Assert.That(Directory.Exists(tempFolderPath), Is.False, "Temp folder path should still not exist");
 		}
+
+		/// <summary>
+		/// #426 - set the modified date for created directory entries if the RestoreDateTimeOnExtract option is enabled
+		/// </summary>
+		[Test]
+		[Category("Zip")]
+		[Category("CreatesTempFile")]
+		public void SetDirectoryModifiedDate()
+		{
+			string tempFilePath = GetTempFilePath();
+			Assert.IsNotNull(tempFilePath, "No permission to execute this test?");
+
+			string zipName = Path.Combine(tempFilePath, $"{nameof(SetDirectoryModifiedDate)}.zip");
+
+			EnsureTestDirectoryIsEmpty(tempFilePath);
+
+			var modifiedTime = new DateTime(2001, 1, 2);
+			string targetDir = Path.Combine(tempFilePath, ZipTempDir, nameof(SetDirectoryModifiedDate));
+			using (FileStream fs = File.Create(zipName))
+			{
+				using (ZipOutputStream zOut = new ZipOutputStream(fs))
+				{
+					// Add an empty directory entry, with a specified time field
+					var entry = new ZipEntry("emptyFolder/")
+					{
+						DateTime = modifiedTime
+					};
+					zOut.PutNextEntry(entry);
+				}
+			}
+
+			try
+			{
+				// extract the zip
+				var fastZip = new FastZip
+				{
+					CreateEmptyDirectories = true,
+					RestoreDateTimeOnExtract = true
+				};
+				fastZip.ExtractZip(zipName, targetDir, "zz");
+
+				File.Delete(zipName);
+
+				// Check that the empty sub folder exists and has the expected modlfied date
+				string emptyTargetDir = Path.Combine(targetDir, "emptyFolder");
+
+				Assert.That(Directory.Exists(emptyTargetDir), Is.True, "Empty directory should be created");
+
+				var extractedFolderTime = Directory.GetLastWriteTime(emptyTargetDir);
+				Assert.That(extractedFolderTime, Is.EqualTo(modifiedTime));
+			}
+			finally
+			{
+				// Tidy up
+				Directory.Delete(targetDir, true);
+			}
+		}
 	}
 }


### PR DESCRIPTION
When extracting a zip with FastZip with the RestoreDateTimeOnExtract set to true, restore the LastWriteTime on directories as well as files.

Only resets the timestamp on folders that it creates itself, not if extracting into an already existant folder structure.

refs #426 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
