### PR TITLE
Add a ZipCrypto/7zip interop test to the ZipEncryptionHandling tests

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -15,33 +15,31 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Test]
 		[Category("Encryption")]
 		[Category("Zip")]
-		public void Aes128Encryption()
+		[TestCase(CompressionMethod.Stored)]
+		[TestCase(CompressionMethod.Deflated)]
+		public void Aes128Encryption(CompressionMethod compressionMethod)
 		{
-			CreateZipWithEncryptedEntries("foo", 128);
+			CreateZipWithEncryptedEntries("foo", 128, compressionMethod);
 		}
 
 		[Test]
 		[Category("Encryption")]
 		[Category("Zip")]
-		public void Aes128EncryptionStored()
+		[TestCase(CompressionMethod.Stored)]
+		[TestCase(CompressionMethod.Deflated)]
+		public void Aes256Encryption(CompressionMethod compressionMethod)
 		{
-			CreateZipWithEncryptedEntries("foo", 128, CompressionMethod.Stored);
+			CreateZipWithEncryptedEntries("foo", 256, compressionMethod);
 		}
 
 		[Test]
 		[Category("Encryption")]
 		[Category("Zip")]
-		public void Aes256Encryption()
+		[TestCase(CompressionMethod.Stored)]
+		[TestCase(CompressionMethod.Deflated)]
+		public void ZipCryptoEncryption(CompressionMethod compressionMethod)
 		{
-			CreateZipWithEncryptedEntries("foo", 256);
-		}
-
-		[Test]
-		[Category("Encryption")]
-		[Category("Zip")]
-		public void Aes256EncryptionStored()
-		{
-			CreateZipWithEncryptedEntries("foo", 256, CompressionMethod.Stored);
+			CreateZipWithEncryptedEntries("foo", 0, compressionMethod);
 		}
 
 		[Test]


### PR DESCRIPTION
I noticed when looking at #427 that the encryption unit tests that test created archives with 7-zip test AES encryption, but not ZipCrypto encryption.

Any reason not to test both?

Also refactors the tests a little to turn the stored/deflated tests into test cases instead of duplicating the tests.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
