### PR TITLE
Update the benchmark project to BenchmarkDotNet 0.12.1

### DIFF
--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet">
-			<Version>0.11.4</Version>
+			<Version>0.12.1</Version>
 		</PackageReference>
 	</ItemGroup>
 

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
@@ -11,8 +11,8 @@ namespace ICSharpCode.SharpZipLib.Benchmark
 	{
 		public MultipleRuntimes()
 		{
-			Add(Job.Default.With(CsProjClassicNetToolchain.Net461).AsBaseline()); // NET 4.6.1
-			Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp21)); // .NET Core 2.1
+			AddJob(Job.Default.WithToolchain(CsProjClassicNetToolchain.Net461).AsBaseline()); // NET 4.6.1
+			AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp21)); // .NET Core 2.1
 			//Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp30)); // .NET Core 3.0
 		}
 	}


### PR DESCRIPTION
I was going to look at adding some direct benchmarks for the deflate streams, and thought I may as well update BenchmarkDotNet to the current version

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
