### PR TITLE
[WIP] Add AES encryption support to ZipFile

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESEncryptionStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESEncryptionStream.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace ICSharpCode.SharpZipLib.Encryption
+{
+	/// <summary>
+	/// Encrypts AES ZIP entries.
+	/// </summary>
+	/// <remarks>
+	/// Based on information from http://www.winzip.com/aes_info.htm
+	/// and http://www.gladman.me.uk/cryptography_technology/fileencrypt/
+	/// </remarks>
+	internal class ZipAESEncryptionStream : Stream
+	{
+		// The transform to use for encryption.
+		private ZipAESTransform transform;
+
+		// The output stream to write the encrypted data to.
+		private readonly Stream outputStream;
+
+		// Static to help ensure that multiple files within a zip will get different random salt
+		private static readonly RandomNumberGenerator _aesRnd = RandomNumberGenerator.Create();
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="stream">The stream on which to perform the cryptographic transformation.</param>
+		/// <param name="rawPassword">The password used to encrypt the entry.</param>
+		/// <param name="saltLength">The length of the salt to use.</param>
+		/// <param name="blockSize">The block size to use for transforming.</param>
+		public ZipAESEncryptionStream(Stream stream, string rawPassword, int saltLength, int blockSize)
+		{
+			// Set up stream.
+			this.outputStream = stream;
+
+			// Initialise the encryption transform.
+			var salt = new byte[saltLength];
+
+			// Salt needs to be cryptographically random, and unique per file
+			_aesRnd.GetBytes(salt);
+			
+			this.transform = new ZipAESTransform(rawPassword, salt, blockSize, true);
+
+			// File format for AES:
+			// Size (bytes)   Content
+			// ------------   -------
+			// Variable       Salt value
+			// 2              Password verification value
+			// Variable       Encrypted file data
+			// 10             Authentication code
+			//
+			// Value in the "compressed size" fields of the local file header and the central directory entry
+			// is the total size of all the items listed above. In other words, it is the total size of the
+			// salt value, password verification value, encrypted data, and authentication code.
+			var pwdVerifier = this.transform.PwdVerifier;
+			this.outputStream.Write(salt, 0, salt.Length);
+			this.outputStream.Write(pwdVerifier, 0, pwdVerifier.Length);
+		}
+
+		// This stream is write only.
+		public override bool CanRead => false;
+
+		// We only support writing - no seeking about.
+		public override bool CanSeek => false;
+
+		// Supports writing for encrypting.
+		public override bool CanWrite => true;
+
+		// We don't track this.
+		public override long Length => throw new NotImplementedException();
+
+		// We don't track this, or support seeking.
+		public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+		/// <summary>
+		/// When the stream is disposed, write the final blocks and AES Authentication code
+		/// </summary>
+		protected override void Dispose(bool disposing)
+		{
+			if (this.transform != null)
+			{
+				this.WriteAuthCode();
+				this.transform.Dispose();
+				this.transform = null;
+			}
+		}
+
+		// <inheritdoc/>
+		public override void Flush()
+		{
+			this.outputStream.Flush();
+		}
+
+		// <inheritdoc/>
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			// ZipAESEncryptionStream is only used for encryption.
+			throw new NotImplementedException();
+		}
+
+		// <inheritdoc/>
+		public override long Seek(long offset, SeekOrigin origin)
+		{
+			// We don't support seeking.
+			throw new NotImplementedException();
+		}
+
+		// <inheritdoc/>
+		public override void SetLength(long value)
+		{
+			// We don't support setting the length.
+			throw new NotImplementedException();
+		}
+
+		// <inheritdoc/>
+		public override void Write(byte[] buffer, int offset, int count)
+		{
+			if (count == 0)
+			{
+				return;
+			}
+
+			var outputBuffer = new byte[count];
+			var outputCount = this.transform.TransformBlock(buffer, offset, count, outputBuffer, 0);
+			this.outputStream.Write(outputBuffer, 0, outputCount);
+		}
+
+		// Write the auth code for the encrypted data to the output stream
+		private void WriteAuthCode()
+		{
+			// Transform the final block?
+
+			// Write the AES Authentication Code (a hash of the compressed and encrypted data)
+			var authCode = this.transform.GetAuthCode();
+			this.outputStream.Write(authCode, 0, 10);
+			this.outputStream.Flush();
+		}
+	}
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -1581,6 +1581,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		/// Refs https://github.com/icsharpcode/SharpZipLib/issues/385
 		/// Trying to add an AES Encrypted entry to ZipFile should throw as it isn't supported
 		/// </summary>
+#if false
 		[Test]
 		[Category("Zip")]
 		public void AddingAnAESEncryptedEntryShouldThrow()
@@ -1598,6 +1599,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				Assert.That(exception.Message, Is.EqualTo("Creation of AES encrypted entries is not supported"));
 			}
 		}
+#endif
 
 		/// <summary>
 		/// Test that we can add a file entry and set the name to sometihng other than the name of the file.


### PR DESCRIPTION
A work-in-progress attempt to add AES encryption support to ZipFile.

Notes:

There is currently no way to tell ZipFile what encryption algorithm to use when adding entries, so the only way to add an AES entry is with the variant of Add() that takes a ZipEntry (and set the AESKeySize property on it). Perhaps needs to be considered together with #380.

I copied the AddExtraDataAES function from the zip stream code, it would be better being shared somewhere. (an extension method on ZipExtraData maybe?)

It tweaks the logic in GetOutputStream() to try to ensure that the crypto streams returned from it are disposed - perhaps could be a separate PR as it might be a sort of existing issue with it not disposing streams when it should?

The Write() overload in ZipAESEncryptionStream takes the same approach as ZipOutputStream and calls the crypto transform TransformBlock() on each write. I'm not sure if that is technically correct, or if it should store the data and transform it in complete blocks? (or perhaps it doesn't matter with the way the transform is implemented)

Doesn't yet add any new unit tests (would likely end up conflicting with other PRs in the same area, could maybe do with a pass over later to see what state the various separate encryption tests are in)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
