### PR TITLE
multi-target the unit tests as .NET Core 2.0 and .NET 4.6

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
+++ b/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+		<TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>
@@ -18,6 +18,7 @@
     <PackageReference Include="PublishCoverity" Version="0.11.0" />
     <PackageReference Include="ReportGenerator" Version="2.5.10" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -223,7 +223,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 						Assert.AreEqual(name, entry.Name);
 
-						var nameBytes = string.Join(' ', Encoding.BigEndianUnicode.GetBytes(entry.Name).Select(b => b.ToString("x2")));
+						var nameBytes = string.Join(" ", Encoding.BigEndianUnicode.GetBytes(entry.Name).Select(b => b.ToString("x2")));
 
 						Console.WriteLine($" - Zip entry: {entry.Name} ({nameBytes})");
 					}


### PR DESCRIPTION
refs #434 - multi-target the unit test project such that the unit tests can be run against both .NET and .NET Core.

It targets net 4.6 rather than 4.5 (to match the library build) because the System.Text.Encoding.CodePages package doesn't contain a 4.5 build.

An alternative there might be to only import the package in the Core build and ifdef the calls to Encoding.RegisterProvider, as the extra code pages should be available on the full framework by default anyway?

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
