### PR TITLE
Make InvalidHeaderException serializable

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/InvalidHeaderException.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/InvalidHeaderException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace ICSharpCode.SharpZipLib.Tar
 {
@@ -6,6 +7,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// This exception is used to indicate that there is a problem
 	/// with a TAR archive header.
 	/// </summary>
+	[Serializable]
 	public class InvalidHeaderException : TarException
 	{
 		/// <summary>
@@ -31,6 +33,22 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="exception">The exception that is the cause of the current exception.</param>
 		public InvalidHeaderException(string message, Exception exception)
 			: base(message, exception)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the InvalidHeaderException class with serialized data.
+		/// </summary>
+		/// <param name="info">
+		/// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+		/// object data about the exception being thrown.
+		/// </param>
+		/// <param name="context">
+		/// The System.Runtime.Serialization.StreamingContext that contains contextual information
+		/// about the source or destination.
+		/// </param>
+		protected InvalidHeaderException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
 		{
 		}
 	}

--- a/test/ICSharpCode.SharpZipLib.Tests/Serialization/SerializationTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Serialization/SerializationTests.cs
@@ -23,6 +23,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Serialization
         [Category("Serialization")]
         [TestCase(typeof(BZip2Exception))]
         [TestCase(typeof(GZipException))]
+        [TestCase(typeof(InvalidHeaderException))]
         [TestCase(typeof(InvalidNameException))]
         [TestCase(typeof(LzwException))]
         [TestCase(typeof(SharpZipBaseException))]


### PR DESCRIPTION
I was looking at some code analyzer results of the build, and one of the things it suggested was that InvalidHeaderException should be [Serializable], given that it derives from a serializable type (TarException).

I don't know why this wasn't done along with the others, aside from having been overlooked?

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
