### PR TITLE
Fix some unit test asserts

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/BZip2/Bzip2Tests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/BZip2/Bzip2Tests.cs
@@ -80,7 +80,7 @@ namespace ICSharpCode.SharpZipLib.Tests.BZip2
 					pos += numRead;
 				}
 
-				Assert.AreEqual(pos, 0);
+				Assert.Zero(pos);
 			}
 		}
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
@@ -35,7 +35,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 			}
 
 			Assert.IsTrue(ms.GetBuffer().Length > 0, "Archive size must be > zero");
-			Assert.AreEqual(ms.GetBuffer().Length % recordSize, 0, "Archive size must be a multiple of record size");
+			Assert.Zero(ms.GetBuffer().Length % recordSize, "Archive size must be a multiple of record size");
 
 			var ms2 = new MemoryStream();
 			ms2.Write(ms.GetBuffer(), 0, ms.GetBuffer().Length);
@@ -769,7 +769,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 					var tis = new TarInputStream(bs);
 					var entry = tis.GetNextEntry();
 
-					Assert.AreEqual(entry.Name, EntryName);
+					Assert.AreEqual(EntryName, entry.Name);
 					return tis;
 				},
 				output: bs =>

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
@@ -188,7 +188,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				}
 			}
 			inStream.Close();
-			Assert.AreEqual(extractCount, 0, "No data should be read from empty entries");
+			Assert.Zero(extractCount, "No data should be read from empty entries");
 		}
 
 		[Test]
@@ -360,7 +360,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					var zis = new ZipInputStream(bs);
 					var entry = zis.GetNextEntry();
 
-					Assert.AreEqual(entry.Name, EntryName);
+					Assert.AreEqual(EntryName, entry.Name);
 					Assert.IsTrue((entry.Flags & (int)GeneralBitFlags.Descriptor) != 0);
 					return zis;
 				},


### PR DESCRIPTION
Rather trivial but: the NUnit analyzer suggests that a few asserts have the expected/actual values backwards.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
