### PR TITLE
[WIP] Add FxCop to the build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,3 +37,9 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+# C# source
+[*.{cs}]
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = none

--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -31,6 +31,10 @@ Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.3.2 for mor
   </PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 	 


### PR DESCRIPTION
Add FxCop to the build to see what issues it finds.

Marked as WIP because it creates over a thousand warnings in the build.

Some of them look worth looking at (e.g. warnings about not disposing of things before they go out of scope), but a lot of them are things like passing string literals to exceptions rather than using resources, which are possibly not really useful. (so could be turned off)

(Note: #445 is something that was found by the analyzer)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
