### PR TITLE
Fix CA1200 code analyzer warnings

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/NameFilter.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/NameFilter.cs
@@ -106,7 +106,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// Split a string into its component pieces
 		/// </summary>
 		/// <param name="original">The original string</param>
-		/// <returns>Returns an array of <see cref="T:System.String"/> values containing the individual filter elements.</returns>
+		/// <returns>Returns an array of <see cref="System.String"/> values containing the individual filter elements.</returns>
 		public static string[] SplitQuoted(string original)
 		{
 			char escape = '\\';

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -4003,12 +4003,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// <returns>
 			/// The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
 			/// </returns>
-			/// <exception cref="T:System.ArgumentException">The sum of offset and count is larger than the buffer length. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support reading. </exception>
-			/// <exception cref="T:System.ArgumentNullException">buffer is null. </exception>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.ArgumentOutOfRangeException">offset or count is negative. </exception>
+			/// <exception cref="System.ArgumentException">The sum of offset and count is larger than the buffer length. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support reading. </exception>
+			/// <exception cref="System.ArgumentNullException">buffer is null. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.ArgumentOutOfRangeException">offset or count is negative. </exception>
 			public override int Read(byte[] buffer, int offset, int count)
 			{
 				return 0;
@@ -4018,13 +4018,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// Sets the position within the current stream.
 			/// </summary>
 			/// <param name="offset">A byte offset relative to the origin parameter.</param>
-			/// <param name="origin">A value of type <see cref="T:System.IO.SeekOrigin"></see> indicating the reference point used to obtain the new position.</param>
+			/// <param name="origin">A value of type <see cref="System.IO.SeekOrigin"></see> indicating the reference point used to obtain the new position.</param>
 			/// <returns>
 			/// The new position within the current stream.
 			/// </returns>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support seeking, such as if the stream is constructed from a pipe or console output. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support seeking, such as if the stream is constructed from a pipe or console output. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
 			public override long Seek(long offset, SeekOrigin origin)
 			{
 				return 0;
@@ -4034,9 +4034,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// Sets the length of the current stream.
 			/// </summary>
 			/// <param name="value">The desired length of the current stream in bytes.</param>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support both writing and seeking, such as if the stream is constructed from a pipe or console output. </exception>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support both writing and seeking, such as if the stream is constructed from a pipe or console output. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
 			public override void SetLength(long value)
 			{
 			}
@@ -4047,12 +4047,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// <param name="buffer">An array of bytes. This method copies count bytes from buffer to the current stream.</param>
 			/// <param name="offset">The zero-based byte offset in buffer at which to begin copying bytes to the current stream.</param>
 			/// <param name="count">The number of bytes to be written to the current stream.</param>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support writing. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
-			/// <exception cref="T:System.ArgumentNullException">buffer is null. </exception>
-			/// <exception cref="T:System.ArgumentException">The sum of offset and count is greater than the buffer length. </exception>
-			/// <exception cref="T:System.ArgumentOutOfRangeException">offset or count is negative. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support writing. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.ArgumentNullException">buffer is null. </exception>
+			/// <exception cref="System.ArgumentException">The sum of offset and count is greater than the buffer length. </exception>
+			/// <exception cref="System.ArgumentOutOfRangeException">offset or count is negative. </exception>
 			public override void Write(byte[] buffer, int offset, int count)
 			{
 				baseStream_.Write(buffer, offset, count);
@@ -4132,12 +4132,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// <returns>
 			/// The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
 			/// </returns>
-			/// <exception cref="T:System.ArgumentException">The sum of offset and count is larger than the buffer length. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support reading. </exception>
-			/// <exception cref="T:System.ArgumentNullException">buffer is null. </exception>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.ArgumentOutOfRangeException">offset or count is negative. </exception>
+			/// <exception cref="System.ArgumentException">The sum of offset and count is larger than the buffer length. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support reading. </exception>
+			/// <exception cref="System.ArgumentNullException">buffer is null. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.ArgumentOutOfRangeException">offset or count is negative. </exception>
 			public override int Read(byte[] buffer, int offset, int count)
 			{
 				lock (baseStream_)
@@ -4171,12 +4171,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// <param name="buffer">An array of bytes. This method copies count bytes from buffer to the current stream.</param>
 			/// <param name="offset">The zero-based byte offset in buffer at which to begin copying bytes to the current stream.</param>
 			/// <param name="count">The number of bytes to be written to the current stream.</param>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support writing. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
-			/// <exception cref="T:System.ArgumentNullException">buffer is null. </exception>
-			/// <exception cref="T:System.ArgumentException">The sum of offset and count is greater than the buffer length. </exception>
-			/// <exception cref="T:System.ArgumentOutOfRangeException">offset or count is negative. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support writing. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.ArgumentNullException">buffer is null. </exception>
+			/// <exception cref="System.ArgumentException">The sum of offset and count is greater than the buffer length. </exception>
+			/// <exception cref="System.ArgumentOutOfRangeException">offset or count is negative. </exception>
 			public override void Write(byte[] buffer, int offset, int count)
 			{
 				throw new NotSupportedException();
@@ -4186,9 +4186,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// When overridden in a derived class, sets the length of the current stream.
 			/// </summary>
 			/// <param name="value">The desired length of the current stream in bytes.</param>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support both writing and seeking, such as if the stream is constructed from a pipe or console output. </exception>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support both writing and seeking, such as if the stream is constructed from a pipe or console output. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
 			public override void SetLength(long value)
 			{
 				throw new NotSupportedException();
@@ -4198,13 +4198,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// When overridden in a derived class, sets the position within the current stream.
 			/// </summary>
 			/// <param name="offset">A byte offset relative to the origin parameter.</param>
-			/// <param name="origin">A value of type <see cref="T:System.IO.SeekOrigin"></see> indicating the reference point used to obtain the new position.</param>
+			/// <param name="origin">A value of type <see cref="System.IO.SeekOrigin"></see> indicating the reference point used to obtain the new position.</param>
 			/// <returns>
 			/// The new position within the current stream.
 			/// </returns>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support seeking, such as if the stream is constructed from a pipe or console output. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support seeking, such as if the stream is constructed from a pipe or console output. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
 			public override long Seek(long offset, SeekOrigin origin)
 			{
 				long newPos = readPos_;
@@ -4240,7 +4240,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// <summary>
 			/// Clears all buffers for this stream and causes any buffered data to be written to the underlying device.
 			/// </summary>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
 			public override void Flush()
 			{
 				// Nothing to do.
@@ -4251,9 +4251,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// </summary>
 			/// <value></value>
 			/// <returns>The current position within the stream.</returns>
-			/// <exception cref="T:System.IO.IOException">An I/O error occurs. </exception>
-			/// <exception cref="T:System.NotSupportedException">The stream does not support seeking. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.IO.IOException">An I/O error occurs. </exception>
+			/// <exception cref="System.NotSupportedException">The stream does not support seeking. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
 			public override long Position
 			{
 				get { return readPos_ - start_; }
@@ -4279,8 +4279,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 			/// </summary>
 			/// <value></value>
 			/// <returns>A long value representing the length of the stream in bytes.</returns>
-			/// <exception cref="T:System.NotSupportedException">A class derived from Stream does not support seeking. </exception>
-			/// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
+			/// <exception cref="System.NotSupportedException">A class derived from Stream does not support seeking. </exception>
+			/// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. </exception>
 			public override long Length
 			{
 				get { return length_; }


### PR DESCRIPTION
A spin off of #449 to fix some CA1200 "Avoid using cref tags with a prefix" warnings.

The prefixes in the code are all for simple system types, so going from the MS docs @ 
https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1200?view=vs-2019, they don't seen to be needed?

As well as fixing the warnings, it also makes VS intellisense display type information, where it doesn't before.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
