### PR TITLE
In ZipFile.GetOutputStream, ensure that any created crypto streams are disposed

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -2621,13 +2621,20 @@ namespace ICSharpCode.SharpZipLib.Zip
 			switch (entry.CompressionMethod)
 			{
 				case CompressionMethod.Stored:
-					result = new UncompressedStream(result);
+					if (!entry.IsCrypted)
+					{
+						// If there is an encryption stream in use, that can be returned directly
+						// otherwise, wrap the base stream in an UncompressedStream instead of returning it directly
+						result = new UncompressedStream(result);
+					}
 					break;
 
 				case CompressionMethod.Deflated:
 					var dos = new DeflaterOutputStream(result, new Deflater(9, true))
 					{
-						IsStreamOwner = false
+						// If there is an encryption stream in use, then we want that to be disposed when the deflator stream is disposed
+						// If not, then we don't want it to dispose the base stream
+						IsStreamOwner = entry.IsCrypted
 					};
 					result = dos;
 					break;


### PR DESCRIPTION
When looking at #443 I noticed that the encryption streams created in ZipFile.GetOutputStream didn't seem to be getting disposed.

In order to ensure that they are, I think we need to

1) In the CompressionMethod.Deflated case, make the DeflaterOutputStream own the encryption stream, so that they get disposed together.

2) In the CompressionMethod.Stored case, I think it should be safe to return the encryption stream directly in this case rather than creating an intermediate UncompressedStream? (The stream is only used internally so there should be minimum scope for unexpected uses of it).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
