### PR TITLE
Fix the 7-zip interop tests in the .Net 4.6 test build

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -384,7 +384,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				{
 					var p = Process.Start(new ProcessStartInfo(testPath, "i")
 					{
-						RedirectStandardOutput = true
+						RedirectStandardOutput = true,
+						UseShellExecute = false
 					});
 					while (!p.StandardOutput.EndOfStream && (DateTime.Now - p.StartTime) < runTimeLimit)
 					{


### PR DESCRIPTION
I noticed that the 7-zip interop tests weren't running in the .Net 4.6 test run, with the error

```
"The Process object must have the UseShellExecute property set to false in order to redirect IO streams."
```
According to the Microsoft docs @ https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.useshellexecute?view=netframework-4.8, UseShellExecute is false by default on .Net Core but true on .Net, so - may as well set if to false all the time ourselves.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
