### PR TITLE
Add a variant of FastZip.CreateZip with a leaveOpen parameter to control output stream disposal

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -362,12 +362,27 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <remarks>The <paramref name="outputStream"/> is closed after creation.</remarks>
 		public void CreateZip(Stream outputStream, string sourceDirectory, bool recurse, string fileFilter, string directoryFilter)
 		{
+			CreateZip(outputStream, sourceDirectory, recurse, fileFilter, directoryFilter, false);
+		}
+
+		/// <summary>
+		/// Create a zip archive sending output to the <paramref name="outputStream"/> passed.
+		/// </summary>
+		/// <param name="outputStream">The stream to write archive data to.</param>
+		/// <param name="sourceDirectory">The directory to source files from.</param>
+		/// <param name="recurse">True to recurse directories, false for no recursion.</param>
+		/// <param name="fileFilter">The <see cref="PathFilter">file filter</see> to apply.</param>
+		/// <param name="directoryFilter">The <see cref="PathFilter">directory filter</see> to apply.</param>
+		/// <param name="leaveOpen">true to leave <paramref name="outputStream"/> open after the zip has been created, false to dispose it.</param>
+		public void CreateZip(Stream outputStream, string sourceDirectory, bool recurse, string fileFilter, string directoryFilter, bool leaveOpen)
+		{
 			NameTransform = new ZipNameTransform(sourceDirectory);
 			sourceDirectory_ = sourceDirectory;
 
 			using (outputStream_ = new ZipOutputStream(outputStream))
 			{
 				outputStream_.SetLevel((int)CompressionLevel);
+				outputStream_.IsStreamOwner = !leaveOpen;
 
 				if (password_ != null)
 				{


### PR DESCRIPTION
refs #78, #124 

Add a variant of FastZip.CreateZip that takes a 'leaveOpen' parameter which controls whether the outputStream is disposed.

We can't really change the behaviour of the existing CreateZip stream variant at this point as it would be a breaking change, so this seems next best?

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
