### PR TITLE
add some basic async unit tests for the inflator/deflator streams

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Base/InflaterDeflaterTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Base/InflaterDeflaterTests.cs
@@ -16,31 +16,6 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 	[TestFixture]
 	public class InflaterDeflaterTestSuite
 	{
-		private void VerifyInflatedData(byte[] original, byte[] buf2, int level, bool zlib)
-		{
-			for (int i = 0; i < original.Length; ++i)
-			{
-				if (buf2[i] != original[i])
-				{
-					string description = string.Format("Difference at {0} level {1} zlib {2} ", i, level, zlib);
-					if (original.Length < 2048)
-					{
-						var builder = new StringBuilder(description);
-						for (int d = 0; d < original.Length; ++d)
-						{
-							builder.AppendFormat("{0} ", original[d]);
-						}
-
-						Assert.Fail(builder.ToString());
-					}
-					else
-					{
-						Assert.Fail(description);
-					}
-				}
-			}
-		}
-
 		private static InflaterInputStream GetInflaterInputStream(Stream compressedStream, bool zlib)
 		{
 			compressedStream.Seek(0, SeekOrigin.Begin);
@@ -156,6 +131,31 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 
 			MemoryStream ms = await DeflateAsync(buffer, level, zlib);
 			await InflateAsync(ms, buffer, level, zlib);
+		}
+		
+		private void VerifyInflatedData(byte[] original, byte[] buf2, int level, bool zlib)
+		{
+			for (int i = 0; i < original.Length; ++i)
+			{
+				if (buf2[i] != original[i])
+				{
+					string description = string.Format("Difference at {0} level {1} zlib {2} ", i, level, zlib);
+					if (original.Length < 2048)
+					{
+						var builder = new StringBuilder(description);
+						for (int d = 0; d < original.Length; ++d)
+						{
+							builder.AppendFormat("{0} ", original[d]);
+						}
+
+						Assert.Fail(builder.ToString());
+					}
+					else
+					{
+						Assert.Fail(description);
+					}
+				}
+			}
 		}
 
 		/// <summary>

--- a/test/ICSharpCode.SharpZipLib.Tests/Base/InflaterDeflaterTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Base/InflaterDeflaterTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Security;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.SharpZipLib.Tests.Base
 {
@@ -15,42 +16,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 	[TestFixture]
 	public class InflaterDeflaterTestSuite
 	{
-		private void Inflate(MemoryStream ms, byte[] original, int level, bool zlib)
+		private void VerifyInflatedData(byte[] original, byte[] buf2, int level, bool zlib)
 		{
-			ms.Seek(0, SeekOrigin.Begin);
-
-			var inflater = new Inflater(!zlib);
-			var inStream = new InflaterInputStream(ms, inflater);
-			byte[] buf2 = new byte[original.Length];
-
-			int currentIndex = 0;
-			int count = buf2.Length;
-
-			try
-			{
-				while (true)
-				{
-					int numRead = inStream.Read(buf2, currentIndex, count);
-					if (numRead <= 0)
-					{
-						break;
-					}
-					currentIndex += numRead;
-					count -= numRead;
-				}
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine("Unexpected exception - '{0}'", ex.Message);
-				throw;
-			}
-
-			if (currentIndex != original.Length)
-			{
-				Console.WriteLine("Original {0}, new {1}", original.Length, currentIndex);
-				Assert.Fail("Lengths different");
-			}
-
 			for (int i = 0; i < original.Length; ++i)
 			{
 				if (buf2[i] != original[i])
@@ -74,6 +41,68 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 			}
 		}
 
+		private static InflaterInputStream GetInflaterInputStream(Stream compressedStream, bool zlib)
+		{
+			compressedStream.Seek(0, SeekOrigin.Begin);
+
+			var inflater = new Inflater(!zlib);
+			var inStream = new InflaterInputStream(compressedStream, inflater);
+
+			return inStream;
+		}
+
+		private void Inflate(MemoryStream ms, byte[] original, int level, bool zlib)
+		{
+			byte[] buf2 = new byte[original.Length];
+
+			using (var inStream = GetInflaterInputStream(ms, zlib))
+			{
+				int currentIndex = 0;
+				int count = buf2.Length;
+
+				while (true)
+				{
+					int numRead = inStream.Read(buf2, currentIndex, count);
+					if (numRead <= 0)
+					{
+						break;
+					}
+					currentIndex += numRead;
+					count -= numRead;
+				}
+
+				Assert.That(currentIndex, Is.EqualTo(original.Length), "Decompressed data must have the same length as the original data");
+			}
+
+			VerifyInflatedData(original, buf2, level, zlib);
+		}
+
+		private async Task InflateAsync(MemoryStream ms, byte[] original, int level, bool zlib)
+		{
+			byte[] buf2 = new byte[original.Length];
+
+			using (var inStream = GetInflaterInputStream(ms, zlib))
+			{
+				int currentIndex = 0;
+				int count = buf2.Length;
+
+				while (true)
+				{
+					int numRead = await inStream.ReadAsync(buf2, currentIndex, count);
+					if (numRead <= 0)
+					{
+						break;
+					}
+					currentIndex += numRead;
+					count -= numRead;
+				}
+
+				Assert.That(currentIndex, Is.EqualTo(original.Length), "Decompressed data must have the same length as the original data");
+			}
+
+			VerifyInflatedData(original, buf2, level, zlib);
+		}
+
 		private MemoryStream Deflate(byte[] data, int level, bool zlib)
 		{
 			var memoryStream = new MemoryStream();
@@ -89,14 +118,44 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 			return memoryStream;
 		}
 
-		private void RandomDeflateInflate(int size, int level, bool zlib)
+		private async Task<MemoryStream> DeflateAsync(byte[] data, int level, bool zlib)
+		{
+			var memoryStream = new MemoryStream();
+
+			var deflater = new Deflater(level, !zlib);
+			using (DeflaterOutputStream outStream = new DeflaterOutputStream(memoryStream, deflater))
+			{
+				outStream.IsStreamOwner = false;
+				await outStream.WriteAsync(data, 0, data.Length);
+				await outStream.FlushAsync();
+				outStream.Finish();
+			}
+			return memoryStream;
+		}
+
+		private static byte[] GetRandomTestData(int size)
 		{
 			byte[] buffer = new byte[size];
 			var rnd = new Random();
 			rnd.NextBytes(buffer);
 
+			return buffer;
+		}
+
+		private void RandomDeflateInflate(int size, int level, bool zlib)
+		{
+			byte[] buffer = GetRandomTestData(size);
+
 			MemoryStream ms = Deflate(buffer, level, zlib);
 			Inflate(ms, buffer, level, zlib);
+		}
+
+		private async Task RandomDeflateInflateAsync(int size, int level, bool zlib)
+		{
+			byte[] buffer = GetRandomTestData(size);
+
+			MemoryStream ms = await DeflateAsync(buffer, level, zlib);
+			await InflateAsync(ms, buffer, level, zlib);
 		}
 
 		/// <summary>
@@ -109,12 +168,23 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 			RandomDeflateInflate(100000, level, true);
 		}
 
+		/// <summary>
+		/// Basic async inflate/deflate test
+		/// </summary>
+		[Test]
+		[Category("Base")]
+		[Category("Async")]
+		public async Task InflateDeflateZlibAsync([Range(0, 9)] int level)
+		{
+			await RandomDeflateInflateAsync(100000, level, true);
+		}
+
 		private delegate void RunCompress(byte[] buffer);
 
 		private int runLevel;
 		private bool runZlib;
 		private long runCount;
-		private Random runRandom = new Random(5);
+		private readonly Random runRandom = new Random(5);
 
 		private void DeflateAndInflate(byte[] buffer)
 		{
@@ -167,6 +237,17 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 		public void InflateDeflateNonZlib([Range(0, 9)] int level)
 		{
 			RandomDeflateInflate(100000, level, false);
+		}
+
+		/// <summary>
+		/// Basic async inflate/deflate test
+		/// </summary>
+		[Test]
+		[Category("Base")]
+		[Category("Async")]
+		public async Task InflateDeflateNonZlibAsync([Range(0, 9)] int level)
+		{
+			await RandomDeflateInflateAsync(100000, level, false);
 		}
 
 


### PR DESCRIPTION
refs #223 

Basically just adds async versions of the 'InflateDeflateZlib' and 'InflateDeflateNonZlib' tests and shuffles some things about to share some of the test code instead of duplicating it all.

Also changes the tests to use the NUnit 'Range' attribute for testing the different compression levels instead of having one test that loops over all the levels internally (makes the test a bit simpler, also makes each level appear as a seperate test in the results)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
