### PR TITLE
Dispose of entry streams returned by ZipFile.GetInputStream

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -621,14 +621,18 @@ namespace ICSharpCode.SharpZipLib.Zip
 							{
 								buffer_ = new byte[4096];
 							}
-							if ((events_ != null) && (events_.Progress != null))
+
+							using (var inputStream = zipFile_.GetInputStream(entry))
 							{
-								StreamUtils.Copy(zipFile_.GetInputStream(entry), outputStream, buffer_,
-									events_.Progress, events_.ProgressInterval, this, entry.Name, entry.Size);
-							}
-							else
-							{
-								StreamUtils.Copy(zipFile_.GetInputStream(entry), outputStream, buffer_);
+								if ((events_ != null) && (events_.Progress != null))
+								{
+									StreamUtils.Copy(inputStream, outputStream, buffer_,
+										events_.Progress, events_.ProgressInterval, this, entry.Name, entry.Size);
+								}
+								else
+								{
+									StreamUtils.Copy(inputStream, outputStream, buffer_);
+								}
 							}
 
 							if (events_ != null)


### PR DESCRIPTION
Another offshoot of #449 - When extracting a zip with FastZip, dispose of the streams returned from ZipFile.GetInputStream().

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
