### PR TITLE
In ZipOutputStream.PutNextEntry, account for AES overhead when calculating compressed entry size

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -655,7 +655,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 					if ((versionToExtract == 0) && IsCrypted)
 					{
-						trueCompressedSize += ZipConstants.CryptoHeaderSize;
+						trueCompressedSize += (ulong)this.EncryptionOverheadSize;
 					}
 
 					// TODO: A better estimation of the true limit based on compression overhead should be used
@@ -1010,6 +1010,26 @@ namespace ICSharpCode.SharpZipLib.Zip
 				// Variable		Encrypted file data
 				//    10		Authentication code
 				return 12 + AESSaltLen;
+			}
+		}
+
+		/// <summary>
+		/// Number of extra bytes required to hold the encryption header fields.
+		/// </summary>
+		internal int EncryptionOverheadSize
+		{
+			get
+			{
+				// Entry is not encrypted - no overhead
+				if (!this.IsCrypted)
+					return 0;
+
+				// Entry is encrypted using ZipCrypto
+				if (_aesEncryptionStrength == 0)
+					return ZipConstants.CryptoHeaderSize;
+
+				// Entry is encrypted using AES
+				return this.AESOverheadSize;
 			}
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -337,7 +337,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 				else
 				{
-					WriteLeInt(entry.IsCrypted ? (int)entry.CompressedSize + ZipConstants.CryptoHeaderSize : (int)entry.CompressedSize);
+					WriteLeInt((int)entry.CompressedSize + entry.EncryptionOverheadSize);
 					WriteLeInt((int)entry.Size);
 				}
 			}
@@ -382,7 +382,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				if (headerInfoAvailable)
 				{
 					ed.AddLeLong(entry.Size);
-					ed.AddLeLong(entry.CompressedSize);
+					ed.AddLeLong(entry.CompressedSize + entry.EncryptionOverheadSize);
 				}
 				else
 				{
@@ -540,14 +540,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			if (curEntry.IsCrypted)
 			{
-				if (curEntry.AESKeySize > 0)
-				{
-					curEntry.CompressedSize += curEntry.AESOverheadSize;
-				}
-				else
-				{
-					curEntry.CompressedSize += ZipConstants.CryptoHeaderSize;
-				}
+				curEntry.CompressedSize += curEntry.EncryptionOverheadSize;
 			}
 
 			// Patch the header if possible


### PR DESCRIPTION
Found when looking at #454:

The code at:

https://github.com/icsharpcode/SharpZipLib/blob/f36ca373206340a25b1d3bb226acc7b679128a7c/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs#L330

for writing entries when the header information is known tries to take account of the crypto header overhead, but only does so for ZipCrypto encrypted entries - it uses the wrong values for AES entries.

Also, the code for building the Zip64 extra data at:

https://github.com/icsharpcode/SharpZipLib/blob/f36ca373206340a25b1d3bb226acc7b679128a7c/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs#L375

doesn't take account of that overhead at all, which seems to also produce incorrect archives.

~~The~~

```
// TODO: Refactor header writing.  Its done in several places.
```
~~becomes a bit more true with the simple change, as it duplicates a bit more logic that could perhaps do with being shared.~~

PR adds a set of test cases for different encryption/compression methds, with and without zip64, but only for 0 byte entries - something with populated entries whose size and crc are known upfront might be useful seperately.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
