### PR TITLE
fix a couple of exception doc comments

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -584,7 +584,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <returns>
 		/// The number of bytes read (this may be less than the length requested, even before the end of stream), or 0 on end of stream.
 		/// </returns>
-		/// <exception name="IOException">
+		/// <exception cref="IOException">
 		/// An i/o error occured.
 		/// </exception>
 		/// <exception cref="ZipException">

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -95,7 +95,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="comment">
 		/// The comment text for the entire archive.
 		/// </param>
-		/// <exception name ="ArgumentOutOfRangeException">
+		/// <exception cref="ArgumentOutOfRangeException">
 		/// The converted comment is longer than 0xffff bytes.
 		/// </exception>
 		public void SetComment(string comment)


### PR DESCRIPTION
Found by accident - a couple of doc comments have exception elements with a 'name' attribute rather than 'cref' attribute.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
