### PR TITLE
Fixed bug in ZipAESStream.ReadBufferedData.

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -163,7 +163,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		{
 			int copyCount = Math.Min(count, _transformBufferFreePos - _transformBufferStartPos);
 
-			Array.Copy(_transformBuffer, _transformBufferStartPos, buffer, offset, count);
+			Array.Copy(_transformBuffer, _transformBufferStartPos, buffer, offset, copyCount);
 			_transformBufferStartPos += copyCount;
 
 			return copyCount;


### PR DESCRIPTION
copyCount was being computed but not passed to Array.Copy(), which caused an
exception to be thrown when enough bytes were read from an encrypted stream.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
