### PR TITLE
Improve the ZipFileStoreAesPartialRead test to test multiple block sizes

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -150,7 +150,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Test]
 		[Category("Encryption")]
 		[Category("Zip")]
-		public void ZipFileStoreAesPartialRead()
+		public void ZipFileStoreAesPartialRead([Values(1, 7, 17)] int readSize)
 		{
 			string password = "password";
 
@@ -179,16 +179,16 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					{
 						using (var zis = zipFile.GetInputStream(entry))
 						{
-							byte[] buffer = new byte[1];
+							byte[] buffer = new byte[readSize];
 
 							while (true)
 							{
-								int b = zis.ReadByte();
+								int read = zis.Read(buffer, 0, readSize);
 
-								if (b == -1)
+								if (read == 0)
 									break;
 
-								ms.WriteByte((byte)b);
+								ms.Write(buffer, 0, read);
 							}
 						}
 


### PR DESCRIPTION
A test for the issue from #465 - test with several read sizes, both smaller and larger than the AES block size

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
