### PR TITLE
Unit test for FastZip adding empty folders to archives

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -93,6 +93,45 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			Assert.IsTrue(Directory.Exists(targetDir), "Empty directory should be created");
 		}
 
+		/// <summary>
+		/// Test that FastZip can create empty directory entries in archives.
+		/// </summary>
+		[TestCase(null)]
+		[TestCase("password")]
+		[Category("Zip")]
+		[Category("CreatesTempFile")]
+		public void CreateEmptyDirectories(string password)
+		{
+			using (var tempFilePath = new Utils.TempDir())
+			{
+				string name = Path.Combine(tempFilePath.Fullpath, "x.zip");
+
+				// Create empty test folders (The folder that we'll zip, and the test sub folder).
+				string archiveRootDir = Path.Combine(tempFilePath.Fullpath, ZipTempDir);
+				string targetDir = Path.Combine(archiveRootDir, "floyd");
+				Directory.CreateDirectory(targetDir);
+
+				// Create the archive with FastZip
+				var fastZip = new FastZip
+				{
+					CreateEmptyDirectories = true,
+					Password = password,
+				};
+				fastZip.CreateZip(name, archiveRootDir, true, null);
+
+				// Test that the archive contains the empty folder entry
+				using (var zipFile = new ZipFile(name))
+				{
+					Assert.That(zipFile.Count, Is.EqualTo(1), "Should only be one entry in the file");
+
+					var folderEntry = zipFile.GetEntry("floyd/");
+					Assert.That(folderEntry.IsDirectory, Is.True, "The entry must be a folder");
+
+					Assert.IsTrue(zipFile.TestArchive(true));
+				}
+			}
+		}
+
 		[Test]
 		[Category("Zip")]
 		[Category("CreatesTempFile")]


### PR DESCRIPTION
When I was looking at #454 I noticed there didn't seem to be a unit test for adding empty folders to new archives in FastZip (there is one for extracting empty folders), so I added a simple one.

(test tries it with both encrypted and non-encrypted archives)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
