### PR TITLE
Experiment with using ITaggedData for AES extra data handling

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -962,26 +962,21 @@ namespace ICSharpCode.SharpZipLib.Zip
 		// For AES the method in the entry is 99, and the real compression method is in the extradata
 		private void ProcessAESExtraData(ZipExtraData extraData)
 		{
-			if (extraData.Find(0x9901))
+			var aesData = extraData.GetData<WinZipAESTaggedData>();
+
+			if (aesData != null)
 			{
 				// Set version for Zipfile.CreateAndInitDecryptionStream
 				versionToExtract = ZipConstants.VERSION_AES;            // Ver 5.1 = AES see "Version" getter
 
-				//
-				// Unpack AES extra data field see http://www.winzip.com/aes_info.htm
-				int length = extraData.ValueLength;         // Data size currently 7
-				if (length < 7)
-					throw new ZipException("AES Extra Data Length " + length + " invalid.");
-				int ver = extraData.ReadShort();            // Version number (1=AE-1 2=AE-2)
-				int vendorId = extraData.ReadShort();       // 2-character vendor ID 0x4541 = "AE"
-				int encrStrength = extraData.ReadByte();    // encryption strength 1 = 128 2 = 192 3 = 256
-				int actualCompress = extraData.ReadShort(); // The actual compression method used to compress the file
-				_aesVer = ver;
-				_aesEncryptionStrength = encrStrength;
-				method = (CompressionMethod)actualCompress;
+				_aesVer = (int)aesData.Version;
+				_aesEncryptionStrength = aesData.EncryptionStrength;
+				method = aesData.CompressionMethod;
 			}
 			else
+			{
 				throw new ZipException("AES Extra Data missing");
+			}
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -706,18 +706,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 		private static void AddExtraDataAES(ZipEntry entry, ZipExtraData extraData)
 		{
-			// Vendor Version: AE-1 IS 1. AE-2 is 2. With AE-2 no CRC is required and 0 is stored.
-			const int VENDOR_VERSION = 2;
-			// Vendor ID is the two ASCII characters "AE".
-			const int VENDOR_ID = 0x4541; //not 6965;
-			extraData.StartNewEntry();
-			// Pack AES extra data field see http://www.winzip.com/aes_info.htm
-			//extraData.AddLeShort(7);							// Data size (currently 7)
-			extraData.AddLeShort(VENDOR_VERSION);               // 2 = AE-2
-			extraData.AddLeShort(VENDOR_ID);                    // "AE"
-			extraData.AddData(entry.AESEncryptionStrength);     //  1 = 128, 2 = 192, 3 = 256
-			extraData.AddLeShort((int)entry.CompressionMethod); // The actual compression method used to compress the file
-			extraData.AddNewEntry(0x9901);
+			var aesData = new WinZipAESTaggedData
+			{
+				CompressionMethod = entry.CompressionMethod,
+				EncryptionStrength = entry.AESEncryptionStrength,
+			};
+
+			extraData.AddEntry(aesData);
 		}
 
 		// Replaces WriteEncryptionHeader for AES


### PR DESCRIPTION
This is an experiment to use the ITaggedData machinery for handling the AES extra data, too see how it might effect things, and to think if it might be useful for #443 (to have the extra data handling in a central place).

Notes:

1) It changes the TagID property on ITaggedData from ```short``` to ```ushort``` to accomodate the 0x9901 value for the AES extra data. Some of the other apis use int rather than short so that might be more consistent, not sure if other places could be changed to keep it working with ```short``` though.

2) Not sure if using ZipHelperStream to unpack the data instead of reading array values is more extra overhead than would be ideal, though i think the read functions in ```ZipExtraData``` might already do more size checks than they really need to, so perhaps it could be tuned in general?

3) Similar on the ```GetData()``` side - building the fixed 7 byte array with a temporary stream and 7 calls to write byte is perhaps not the optimal approach there.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
