### PR TITLE
Allow ZipFile to accept empty strings as passwords when decrypting AES entries

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -367,9 +367,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 				else
 				{
-					rawPassword_ = value;
 					key = PkzipClassic.GenerateKeys(ZipStrings.ConvertToArray(value));
 				}
+
+				rawPassword_ = value;
 			}
 		}
 
@@ -3612,9 +3613,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				if (entry.Version >= ZipConstants.VERSION_AES)
 				{
-					//
+					// Issue #471 - accept an empty string as a password, but reject null.
 					OnKeysRequired(entry.Name);
-					if (HaveKeys == false)
+					if (rawPassword_ == null)
 					{
 						throw new ZipException("No password available for AES encrypted stream");
 					}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -365,15 +365,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 		}
 
-
 		// This is a zip file with one AES encrypted entry, whose password in an empty string.
-		const string TestFileWithEmptyPassword = @"UEsDBDMACQBjABOayVAgyeOe//////////8EAB8AdGVzdAEAEACSAQAA
-			AAAAAA8BAAAAAAAAAZkHAAIAQUUDCADkSZYB7gbGRd9gGmKycLzgEl/poo7qKRcr37DC8/6BZdhEGVPdw4GBHnJ7Ub961XG
-			hogr33RCFVe99Oia31haQ9J+B0LGl/e64kxneuY2fZ4BtyaOw43SZTcuO3SUWPTZIhfUIzmeqUvw7HBkGvR67OyCSOD/Eu
-			3mXsI4PGloUmCllL9oSuF6L6f571mX9rgIoFl6MmJZZDLR7tQAcDvwZ0jaXU8lN+rufh3VyDzHxJqecRrPy/8XJW73frCI
-			/ulHo1r4Dp3cUOIFYO+jAlUBr2B1Rqth9IUKYKBVt0fwMWeJk39LBKQEpzYMfcUOu5+2CDQKQ1f/z4TCKJmbZ+PDQ1Sx8C
-			UQmyavlP/4g8x2UUEsHCCDJ454PAQAAAAAAAJIBAAAAAAAAUEsBAjMAMwAJAGMAE5rJUCDJ457//////////wQAHwAAAAA
-			AAAAAAAAAAAAAAHRlc3QBABAAkgEAAAAAAAAPAQAAAAAAAAGZBwACAEFFAwgAUEsFBgAAAAABAAEAUQAAAGgBAAAAAA==";
+		const string TestFileWithEmptyPassword = @"UEsDBDMACQBjACaj0FAyKbop//////////8EAB8AdGVzdAEAEAA4AAAA
+			AAAAAFIAAAAAAAAAAZkHAAIAQUUDCABADvo3YqmCtIE+lhw26kjbqkGsLEOk6bVA+FnSpVD4yGP4Mr66Hs14aTtsPUaANX2
+            Z6qZczEmwoaNQpNBnKl7p9YOG8GSHDfTCUU/AZvT4yGFhUEsHCDIpuilSAAAAAAAAADgAAAAAAAAAUEsBAjMAMwAJAGMAJq
+            PQUDIpuin//////////wQAHwAAAAAAAAAAAAAAAAAAAHRlc3QBABAAOAAAAAAAAABSAAAAAAAAAAGZBwACAEFFAwgAUEsFBgAAAAABAAEAUQAAAKsAAAAAAA==";
 
 		/// <summary>
 		/// Test reading an AES encrypted entry whose password is an empty string.
@@ -398,7 +394,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				using (var sr = new StreamReader(inputStream, Encoding.UTF8))
 				{
 					var content = sr.ReadToEnd();
-					Assert.That(content, Is.EqualTo(DummyDataString), "Decompressed content does not match expected data");
+					Assert.That(content, Is.EqualTo("Lorem ipsum dolor sit amet, consectetur adipiscing elit."), "Decompressed content does not match expected data");
 				}
 			}
 		}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -365,6 +365,44 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 		}
 
+
+		// This is a zip file with one AES encrypted entry, whose password in an empty string.
+		const string TestFileWithEmptyPassword = @"UEsDBDMACQBjABOayVAgyeOe//////////8EAB8AdGVzdAEAEACSAQAA
+			AAAAAA8BAAAAAAAAAZkHAAIAQUUDCADkSZYB7gbGRd9gGmKycLzgEl/poo7qKRcr37DC8/6BZdhEGVPdw4GBHnJ7Ub961XG
+			hogr33RCFVe99Oia31haQ9J+B0LGl/e64kxneuY2fZ4BtyaOw43SZTcuO3SUWPTZIhfUIzmeqUvw7HBkGvR67OyCSOD/Eu
+			3mXsI4PGloUmCllL9oSuF6L6f571mX9rgIoFl6MmJZZDLR7tQAcDvwZ0jaXU8lN+rufh3VyDzHxJqecRrPy/8XJW73frCI
+			/ulHo1r4Dp3cUOIFYO+jAlUBr2B1Rqth9IUKYKBVt0fwMWeJk39LBKQEpzYMfcUOu5+2CDQKQ1f/z4TCKJmbZ+PDQ1Sx8C
+			UQmyavlP/4g8x2UUEsHCCDJ454PAQAAAAAAAJIBAAAAAAAAUEsBAjMAMwAJAGMAE5rJUCDJ457//////////wQAHwAAAAA
+			AAAAAAAAAAAAAAHRlc3QBABAAkgEAAAAAAAAPAQAAAAAAAAGZBwACAEFFAwgAUEsFBgAAAAABAAEAUQAAAGgBAAAAAA==";
+
+		/// <summary>
+		/// Test reading an AES encrypted entry whose password is an empty string.
+		/// </summary>
+		/// <remarks>
+		/// Test added for https://github.com/icsharpcode/SharpZipLib/issues/471.
+		/// </remarks>
+		[Test]
+		[Category("Zip")]
+		public void ZipFileAESReadWithEmptyPassword()
+		{
+			var fileBytes = Convert.FromBase64String(TestFileWithEmptyPassword);
+
+			using (var ms = new MemoryStream(fileBytes))
+			using (var zipFile = new ZipFile(ms, leaveOpen: true))
+			{
+				zipFile.Password = string.Empty;
+
+				var entry = zipFile.FindEntry("test", true);
+
+				using (var inputStream = zipFile.GetInputStream(entry))
+				using (var sr = new StreamReader(inputStream, Encoding.UTF8))
+				{
+					var content = sr.ReadToEnd();
+					Assert.That(content, Is.EqualTo(DummyDataString), "Decompressed content does not match expected data");
+				}
+			}
+		}
+
 		private static readonly string[] possible7zPaths = new[] {
 			// Check in PATH
 			"7z", "7za",


### PR DESCRIPTION
refs #471 

Two changes:

1) In the current setter for ```ZipFile.Password```, it only updates the ```rawPassword_``` member if the new value isn't null or empty.
That seems wrong to me in general, as it means that setting the password to a value and then setting it to null would leave the member set to the old value?
This PR changes it to always just save the new value in ```rawPassword_```.


2) In CreateAndInitDecryptionStream, throw if the string password is null, but proceed to try to use it if the string is empty.

The current code uses ```HasKeys``` to check that it has the keys, but then uses the password instead, which doesn't sound quite right? (though looking at the way ```KeysRequired```/```OnKeysRequired``` I'm not sure if it works to get the password (rather than the keys') for decrypting AES entries?


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
