### PR TITLE
have a pass at fixing some spelling errors in comments

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Checksum/BZip2Crc.cs
+++ b/src/ICSharpCode.SharpZipLib/Checksum/BZip2Crc.cs
@@ -134,7 +134,7 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		{
 			get
 			{
-				// Tehcnically, the output should be:
+				// Technically, the output should be:
 				//return (long)(~checkValue ^ crcXor);
 				// but x ^ 0 = x, so there is no point in adding
 				// the XOR operation

--- a/src/ICSharpCode.SharpZipLib/Core/FileSystemScanner.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/FileSystemScanner.cs
@@ -78,7 +78,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		}
 
 		/// <summary>
-		/// Get set a value indicating wether scanning should continue or not.
+		/// Get set a value indicating whether scanning should continue or not.
 		/// </summary>
 		public bool ContinueRunning
 		{
@@ -209,7 +209,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		}
 
 		/// <summary>
-		/// Get / set a value indicating wether scanning should continue.
+		/// Get / set a value indicating whether scanning should continue.
 		/// </summary>
 		public bool ContinueRunning
 		{

--- a/src/ICSharpCode.SharpZipLib/Lzw/LzwInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Lzw/LzwInputStream.cs
@@ -485,7 +485,7 @@ namespace ICSharpCode.SharpZipLib.Lzw
 		/// Writes a sequence of bytes to stream and advances the current position
 		/// This method always throws a NotSupportedException
 		/// </summary>
-		/// <param name="buffer">Thew buffer containing data to write.</param>
+		/// <param name="buffer">The buffer containing data to write.</param>
 		/// <param name="offset">The offset of the first byte to write.</param>
 		/// <param name="count">The number of bytes to write.</param>
 		/// <exception cref="NotSupportedException">Any access</exception>

--- a/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
@@ -61,7 +61,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		}
 
 		/// <summary>
-		/// Initalise a TarArchive for input.
+		/// Initialise a TarArchive for input.
 		/// </summary>
 		/// <param name="stream">The <see cref="TarInputStream"/> to use for input.</param>
 		protected TarArchive(TarInputStream stream)

--- a/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -187,7 +187,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="count">The desired number of bytes to read.</param>
 		/// <returns>The total number of bytes read, or zero if at the end of the stream.
 		/// The number of bytes may be less than the <paramref name="count">count</paramref>
-		/// requested if data is not avialable.</returns>
+		/// requested if data is not available.</returns>
 		public override int Read(byte[] buffer, int offset, int count)
 		{
 			return outputStream.Read(buffer, offset, count);
@@ -250,7 +250,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		}
 
 		/// <summary>
-		/// Get a value indicating wether an entry is open, requiring more data to be written.
+		/// Get a value indicating whether an entry is open, requiring more data to be written.
 		/// </summary>
 		private bool IsEntryOpen
 		{
@@ -483,7 +483,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		private int assemblyBufferLength;
 
 		/// <summary>
-		/// Flag indicating wether this instance has been closed or not.
+		/// Flag indicating whether this instance has been closed or not.
 		/// </summary>
 		private bool isClosed;
 

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterEngine.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterEngine.cs
@@ -56,7 +56,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 
 		/// <summary>
 		/// Construct instance with pending buffer
-		/// Adler calculation will be peformed
+		/// Adler calculation will be performed
 		/// </summary>
 		/// <param name="pending">
 		/// Pending buffer to use

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -596,7 +596,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// Writes a sequence of bytes to stream and advances the current position
 		/// This method always throws a NotSupportedException
 		/// </summary>
-		/// <param name="buffer">Thew buffer containing data to write.</param>
+		/// <param name="buffer">The buffer containing data to write.</param>
 		/// <param name="offset">The offset of the first byte to write.</param>
 		/// <param name="count">The number of bytes to write.</param>
 		/// <exception cref="NotSupportedException">Any access</exception>
@@ -704,7 +704,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		protected long csize;
 
 		/// <summary>
-		/// Flag indicating wether this instance has been closed or not.
+		/// Flag indicating whether this instance has been closed or not.
 		/// </summary>
 		private bool isClosed;
 

--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -209,7 +209,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		#region Properties
 
 		/// <summary>
-		/// Get/set a value indicating wether empty directories should be created.
+		/// Get/set a value indicating whether empty directories should be created.
 		/// </summary>
 		public bool CreateEmptyDirectories
 		{
@@ -267,7 +267,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// read Zip64 archives. However it does avoid the situation were a large file
 		/// is added and cannot be completed correctly.
 		/// NOTE: Setting the size for entries before they are added is the best solution!
-		/// By default the EntryFactory used by FastZip will set fhe file size.
+		/// By default the EntryFactory used by FastZip will set the file size.
 		/// </remarks>
 		public UseZip64 UseZip64
 		{
@@ -276,7 +276,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get/set a value indicating wether file dates and times should
+		/// Get/set a value indicating whether file dates and times should
 		/// be restored when extracting files from an archive.
 		/// </summary>
 		/// <remarks>The default value is false.</remarks>
@@ -533,7 +533,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				try
 				{
-					// The open below is equivalent to OpenRead which gaurantees that if opened the
+					// The open below is equivalent to OpenRead which guarantees that if opened the
 					// file will not be changed by subsequent openers, but precludes opening in some cases
 					// were it could succeed. ie the open may fail as its already open for writing and the share mode should reflect that.
 					using (FileStream stream = File.Open(e.Name, FileMode.Open, FileAccess.Read, FileShare.Read))

--- a/src/ICSharpCode.SharpZipLib/Zip/WindowsNameTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/WindowsNameTransform.cs
@@ -81,7 +81,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating wether paths on incoming values should be removed.
+		/// Gets or sets a value indicating whether paths on incoming values should be removed.
 		/// </summary>
 		public bool TrimIncomingPaths
 		{

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -161,7 +161,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		Method = 0x0006,
 
 		/// <summary>
-		/// Bit 3 if set indicates a trailing data desciptor is appended to the entry data
+		/// Bit 3 if set indicates a trailing data descriptor is appended to the entry data
 		/// </summary>
 		Descriptor = 0x0008,
 
@@ -443,12 +443,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public const int ArchiveExtraDataSignature = 'P' | ('K' << 8) | (6 << 16) | (7 << 24);
 
 		/// <summary>
-		/// Central header digitial signature
+		/// Central header digital signature
 		/// </summary>
 		public const int CentralHeaderDigitalSignature = 'P' | ('K' << 8) | (5 << 16) | (5 << 24);
 
 		/// <summary>
-		/// Central header digitial signature
+		/// Central header digital signature
 		/// </summary>
 		[Obsolete("Use CentralHeaderDigitalSignaure instead")]
 		public const int CENDIGITALSIG = 'P' | ('K' << 8) | (5 << 16) | (5 << 24);
@@ -468,7 +468,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 		/// <summary>
 		/// Default encoding used for string conversion.  0 gives the default system OEM code page.
-		/// Using the default code page isnt the full solution neccessarily
+		/// Using the default code page isnt the full solution necessarily
 		/// there are many variable factors, codepage 850 is often a good choice for
 		/// European users, however be careful about compatability.
 		/// </summary>
@@ -479,32 +479,32 @@ namespace ICSharpCode.SharpZipLib.Zip
 			set => ZipStrings.CodePage = value;
 		}
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToString(byte[], int)"/></summary>
+		/// <summary> Deprecated wrapper for <see cref="ZipStrings.ConvertToString(byte[], int)"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToString instead")]
 		public static string ConvertToString(byte[] data, int count)
 			=> ZipStrings.ConvertToString(data, count);
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToString(byte[])"/></summary>
+		/// <summary> Deprecated wrapper for <see cref="ZipStrings.ConvertToString(byte[])"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToString instead")]
 		public static string ConvertToString(byte[] data)
 			=> ZipStrings.ConvertToString(data);
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToStringExt(int, byte[], int)"/></summary>
+		/// <summary> Deprecated wrapper for <see cref="ZipStrings.ConvertToStringExt(int, byte[], int)"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToStringExt instead")]
 		public static string ConvertToStringExt(int flags, byte[] data, int count)
 			=> ZipStrings.ConvertToStringExt(flags, data, count);
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToStringExt(int, byte[])"/></summary>
+		/// <summary> Deprecated wrapper for <see cref="ZipStrings.ConvertToStringExt(int, byte[])"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToStringExt instead")]
 		public static string ConvertToStringExt(int flags, byte[] data)
 			=> ZipStrings.ConvertToStringExt(flags, data);
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToArray(string)"/></summary>
+		/// <summary> Deprecated wrapper for <see cref="ZipStrings.ConvertToArray(string)"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToArray instead")]
 		public static byte[] ConvertToArray(string str)
 			=> ZipStrings.ConvertToArray(str);
 
-		/// <summary> Depracated wrapper for <see cref="ZipStrings.ConvertToArray(int, string)"/></summary>
+		/// <summary> Deprecated wrapper for <see cref="ZipStrings.ConvertToArray(int, string)"/></summary>
 		[Obsolete("Use ZipStrings.ConvertToArray instead")]
 		public static byte[] ConvertToArray(int flags, string str)
 			=> ZipStrings.ConvertToArray(flags, str);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -261,7 +261,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		#endregion Constructors
 
 		/// <summary>
-		/// Get a value indicating wether the entry has a CRC value available.
+		/// Get a value indicating whether the entry has a CRC value available.
 		/// </summary>
 		public bool HasCrc
 		{
@@ -296,7 +296,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get / set a flag indicating wether entry name and comment text are
+		/// Get / set a flag indicating whether entry name and comment text are
 		/// encoded in <a href="http://www.unicode.org">unicode UTF8</a>.
 		/// </summary>
 		/// <remarks>This is an assistant that interprets the <see cref="Flags">flags</see> property.</remarks>
@@ -606,7 +606,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// Get a value indicating whether this entry can be decompressed by the library.
 		/// </summary>
 		/// <remarks>This is based on the <see cref="Version"></see> and
-		/// wether the <see cref="IsCompressionMethodSupported()">compression method</see> is supported.</remarks>
+		/// whether the <see cref="IsCompressionMethodSupported()">compression method</see> is supported.</remarks>
 		public bool CanDecompress
 		{
 			get
@@ -630,7 +630,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get a value indicating wether Zip64 extensions were forced.
+		/// Get a value indicating whether Zip64 extensions were forced.
 		/// </summary>
 		/// <returns>A <see cref="bool"/> value of true if Zip64 extensions have been forced on; false if not.</returns>
 		public bool IsZip64Forced()
@@ -670,7 +670,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get a value indicating wether the central directory entry requires Zip64 extensions to be stored.
+		/// Get a value indicating whether the central directory entry requires Zip64 extensions to be stored.
 		/// </summary>
 		public bool CentralHeaderRequiresZip64
 		{
@@ -901,7 +901,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			get
 			{
-				// TODO: This is slightly safer but less efficient.  Think about wether it should change.
+				// TODO: This is slightly safer but less efficient.  Think about whether it should change.
 				//				return (byte[]) extra.Clone();
 				return extra;
 			}
@@ -1059,7 +1059,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				//		flag 13 is set indicating masking, the value stored for the
 				//		uncompressed size in the Local Header will be zero.
 				//
-				// Othewise there is problem with minizip implementation
+				// Otherwise there is problem with minizip implementation
 				if (size == uint.MaxValue)
 				{
 					size = (ulong)extraData.ReadLong();

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntryFactory.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntryFactory.cs
@@ -162,7 +162,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get set a value indicating wether unidoce text should be set on.
+		/// Get set a value indicating whether unidoce text should be set on.
 		/// </summary>
 		public bool IsUnicodeText
 		{

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
-	// TODO: Sort out wether tagged data is useful and what a good implementation might look like.
+	// TODO: Sort out whether tagged data is useful and what a good implementation might look like.
 	// Its just a sketch of an idea at the moment.
 
 	/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -191,7 +191,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get a value indicating wether the last entry test was valid.
+		/// Get a value indicating whether the last entry test was valid.
 		/// </summary>
 		public bool EntryValid
 		{
@@ -318,7 +318,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		#region KeyHandling
 
 		/// <summary>
-		/// Delegate for handling keys/password setting during compresion/decompression.
+		/// Delegate for handling keys/password setting during compression/decompression.
 		/// </summary>
 		public delegate void KeysRequiredEventHandler(
 			object sender,
@@ -375,7 +375,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get a value indicating wether encryption keys are currently available.
+		/// Get a value indicating whether encryption keys are currently available.
 		/// </summary>
 		private bool HaveKeys
 		{
@@ -654,7 +654,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
-		/// Get a value indicating wether
+		/// Get a value indicating whether
 		/// this archive is embedded in another file or not.
 		/// </summary>
 		public bool IsEmbeddedArchive
@@ -2094,7 +2094,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 						break;
 
 					case UseZip64.Off:
-						// Do nothing.  The entry itself may be using Zip64 independantly.
+						// Do nothing.  The entry itself may be using Zip64 independently.
 						break;
 				}
 			}
@@ -3395,7 +3395,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			//
 			// The search is limited to 64K which is the maximum size of a trailing comment field to aid speed.
 			// This should be compatible with both SFX and ZIP files but has only been tested for Zip files
-			// If a SFX file has the Zip data attached as a resource and there are other resources occuring later then
+			// If a SFX file has the Zip data attached as a resource and there are other resources occurring later then
 			// this could be invalid.
 			// Could also speed this up by reading memory in larger blocks.
 
@@ -4381,7 +4381,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	public class StaticDiskDataSource : IStaticDataSource
 	{
 		/// <summary>
-		/// Initialise a new instnace of <see cref="StaticDiskDataSource"/>
+		/// Initialise a new instance of <see cref="StaticDiskDataSource"/>
 		/// </summary>
 		/// <param name="fileName">The name of the file to obtain data from.</param>
 		public StaticDiskDataSource(string fileName)
@@ -4394,7 +4394,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Get a <see cref="Stream"/> providing data.
 		/// </summary>
-		/// <returns>Returns a <see cref="Stream"/> provising data.</returns>
+		/// <returns>Returns a <see cref="Stream"/> providing data.</returns>
 		public Stream GetSource()
 		{
 			return File.Open(fileName_, FileMode.Open, FileAccess.Read, FileShare.Read);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
@@ -95,7 +95,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		#endregion Constructors
 
 		/// <summary>
-		/// Get / set a value indicating wether the the underlying stream is owned or not.
+		/// Get / set a value indicating whether the the underlying stream is owned or not.
 		/// </summary>
 		/// <remarks>If the stream is owned it is closed when this instance is closed.</remarks>
 		public bool IsStreamOwner
@@ -303,7 +303,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="endLocation">Location, marking the end of block.</param>
 		/// <param name="minimumBlockSize">Minimum size of the block.</param>
 		/// <param name="maximumVariableData">The maximum variable data.</param>
-		/// <returns>Eeturns the offset of the first byte after the signature; -1 if not found</returns>
+		/// <returns>Returns the offset of the first byte after the signature; -1 if not found</returns>
 		public long LocateBlockWithSignature(int signature, long endLocation, int minimumBlockSize, int maximumVariableData)
 		{
 			long pos = endLocation - minimumBlockSize;
@@ -332,7 +332,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </summary>
 		/// <param name="noOfEntries">The number of entries in the central directory.</param>
 		/// <param name="sizeEntries">The size of entries in the central directory.</param>
-		/// <param name="centralDirOffset">The offset of the dentral directory.</param>
+		/// <param name="centralDirOffset">The offset of the central directory.</param>
 		public void WriteZip64EndOfCentralDirectory(long noOfEntries, long sizeEntries, long centralDirOffset)
 		{
 			long centralSignatureOffset = centralDirOffset + sizeEntries;

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -585,7 +585,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// The number of bytes read (this may be less than the length requested, even before the end of stream), or 0 on end of stream.
 		/// </returns>
 		/// <exception cref="IOException">
-		/// An i/o error occured.
+		/// An i/o error occurred.
 		/// </exception>
 		/// <exception cref="ZipException">
 		/// The deflated stream is corrupted.

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -66,7 +66,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public static int SystemDefaultCodePage { get; }
 
 		/// <summary>
-		/// Get wether the default codepage is set to UTF-8. Setting this property to false will
+		/// Get whether the default codepage is set to UTF-8. Setting this property to false will
 		/// set the <see cref="CodePage"/> to <see cref="SystemDefaultCodePage"/>
 		/// </summary>
 		/// <remarks>


### PR DESCRIPTION
A quick pass at fixing a few things shown by a visual studio spell checker addon (probably not all of them as there's a lot of noise from variable names, peoples names, etc), plus some might depend on which english dictionary is being used!

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
