### PR TITLE
Suppress CA1707 warnings from LzwConstants

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Lzw/LzwConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Lzw/LzwConstants.cs
@@ -3,6 +3,7 @@ namespace ICSharpCode.SharpZipLib.Lzw
 	/// <summary>
 	/// This class contains constants used for LZW
 	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "kept for backwards compatibility")]
 	sealed public class LzwConstants
 	{
 		/// <summary>


### PR DESCRIPTION
The ```LzwConstants``` class has multiple CA1707 (```Identifiers should not contain underscores```) warnings from FxCop, but as they're public fields and renaming them would be a breaking change (and they might be named like thay because they're copied from some other spec?), this just suppresses the warning rather than doing anything with the names.

There are several similar analyzer warnings, but i'm putting this one in its own PR so i can also query about ```LzwConstants``` being a sealed class rather than a static class -> not sure if changing that would count as an ABI break, but #351 does that change in ```GZipConstants``` so.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
