### PR TITLE
Fix TestArchive for AES encrypted files

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1216,7 +1216,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					}
 
 					// Central header compression method matches local entry
-					if (entry.CompressionMethod != (CompressionMethod)compressionMethod)
+					if (entry.CompressionMethodForHeader != (CompressionMethod)compressionMethod)
 					{
 						throw new ZipException("Central header/local header compression method mismatch");
 					}


### PR DESCRIPTION
Should at least partly fix #317.
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
