### PR TITLE
Add [MemoryDiagnoser] to the zip input/output stream benchmark classes

### DIFF
--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipInputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipInputStream.cs
@@ -4,6 +4,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 {
+	[MemoryDiagnoser]
 	[Config(typeof(MultipleRuntimes))]
 	public class ZipInputStream
 	{
@@ -12,6 +13,7 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 		private const int N = ChunkCount * ChunkSize;
 
 		byte[] zippedData;
+		byte[] readBuffer = new byte[4096];
 
 		public ZipInputStream()
 		{
@@ -40,10 +42,9 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 			{
 				using (var zipInputStream = new SharpZipLib.Zip.ZipInputStream(memoryStream))
 				{
-					var buffer = new byte[4096];
 					var entry = zipInputStream.GetNextEntry();
 
-					while (zipInputStream.Read(buffer, 0, buffer.Length) > 0)
+					while (zipInputStream.Read(readBuffer, 0, readBuffer.Length) > 0)
 					{
 
 					}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
@@ -4,6 +4,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 {
+	[MemoryDiagnoser]
 	[Config(typeof(MultipleRuntimes))]
 	public class ZipOutputStream
 	{


### PR DESCRIPTION
(And move the allocation of the read buffer out of the benchmark function).

This enables memory allocation diagnostics in the result output, e.g.

```
|               Method |        Job |     Toolchain |     Mean |   Error |  StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |----------- |-------------- |---------:|--------:|--------:|------:|------:|------:|------:|----------:|
| WriteZipOutputStream | Job-ZVUVIV | .NET Core 2.1 | 700.4 ms | 3.39 ms | 3.18 ms |  1.00 |     - |     - |     - | 354.09 KB |
| WriteZipOutputStream | Job-DWFYDH | .NET Core 3.1 | 716.9 ms | 4.67 ms | 3.90 ms |  1.02 |     - |     - |     - | 354.08 KB |
| WriteZipOutputStream | Job-RVPCBW |        net461 | 701.0 ms | 1.57 ms | 1.47 ms |  1.00 |     - |     - |     - | 360.28 KB |
```

which can be useful for comparing effects of changes/optimizations etc

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
