### PR TITLE
In InflaterDeflaterTestSuite, use the Range attribute to test different compression levels

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Base/InflaterDeflaterTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Base/InflaterDeflaterTests.cs
@@ -104,12 +104,9 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 		/// </summary>
 		[Test]
 		[Category("Base")]
-		public void InflateDeflateZlib()
+		public void InflateDeflateZlib([Range(0, 9)] int level)
 		{
-			for (int level = 0; level < 10; ++level)
-			{
-				RandomDeflateInflate(100000, level, true);
-			}
+			RandomDeflateInflate(100000, level, true);
 		}
 
 		private delegate void RunCompress(byte[] buffer);
@@ -167,13 +164,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Base
 		/// </summary>
 		[Test]
 		[Category("Base")]
-		public void InflateDeflateNonZlib()
+		public void InflateDeflateNonZlib([Range(0, 9)] int level)
 		{
-			for (int level = 0; level < 10; ++level)
-			{
-				RandomDeflateInflate(100000, level, false);
-			}
+			RandomDeflateInflate(100000, level, false);
 		}
+
 
 		[Test]
 		[Category("Base")]


### PR DESCRIPTION
A small piece of #457 that isn't related to async tests, split off for easier review - use the NUnit [Range] attribute to create a set of tests for different compression levels, rather than just having one test that loops itself internally.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
