### PR TITLE
Give ZipOutputStream an INameTransform property, and use it to transform the names of newly added entries

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -383,6 +383,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				outputStream_.SetLevel((int)CompressionLevel);
 				outputStream_.IsStreamOwner = !leaveOpen;
+				outputStream_.NameTransform = null; // all required transforms handled by us
 
 				if (password_ != null)
 				{

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -782,6 +782,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				return name;
 			}
+
+			internal set
+			{
+				name = value;
+			}
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipNameTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipNameTransform.cs
@@ -238,4 +238,76 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 		#endregion Class Fields
 	}
+
+	/// <summary>
+	/// An implementation of INameTransform that transforms entry paths as per the Zip file naming convention.
+	/// Strips path roots and puts directory separators in the correct format ('/')
+	/// </summary>
+	public class PathTransformer : INameTransform
+	{
+		/// <summary>
+		/// Initialize a new instance of <see cref="PathTransformer"></see>
+		/// </summary>
+		public PathTransformer()
+		{
+		}
+
+		/// <summary>
+		/// Transform a windows directory name according to the Zip file naming conventions.
+		/// </summary>
+		/// <param name="name">The directory name to transform.</param>
+		/// <returns>The transformed name.</returns>
+		public string TransformDirectory(string name)
+		{
+			name = TransformFile(name);
+			
+			if (name.Length > 0)
+			{
+				if (!name.EndsWith("/", StringComparison.Ordinal))
+				{
+					name += "/";
+				}
+			}
+			else
+			{
+				throw new ZipException("Cannot have an empty directory name");
+			}
+
+			return name;
+		}
+
+		/// <summary>
+		/// Transform a windows file name according to the Zip file naming conventions.
+		/// </summary>
+		/// <param name="name">The file name to transform.</param>
+		/// <returns>The transformed name.</returns>
+		public string TransformFile(string name)
+		{
+			if (name != null)
+			{
+				// Put separators in the expected format.
+				name = name.Replace(@"\", "/");
+
+				// Remove the path root.
+				name = WindowsPathUtils.DropPathRoot(name);
+
+				// Drop any leading and trailing slashes.
+				name = name.Trim('/');
+
+				// Convert consecutive // characters to /
+				int index = name.IndexOf("//", StringComparison.Ordinal);
+				while (index >= 0)
+				{
+					name = name.Remove(index, 1);
+					index = name.IndexOf("//", StringComparison.Ordinal);
+				}
+			}
+			else
+			{
+				name = string.Empty;
+			}
+
+			return name;
+		}
+	}
 }


### PR DESCRIPTION
Ref: the discussions about name transforming/cleaning when creating zips:

An experiment into giving ZipOutputStream an INameTransform to (optionally) use to transform file paths, to see what it might look like.
A bit more heavyweight that just having a clean function to call, but more flexible (if that's useful), and fits in more with ZipFile and FastZip?

Defaults to a minimized transform that just strips path roots and puts slashes in the appropriate format (copied from the existing versions and trimmed a bit basically).

ZipEntry.Name is read-only after creation, so it ends up transforming the name twice when doing the local/central headers, rather than just doing it once.


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
