### PR TITLE
trim strings with string.Trim

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipNameTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipNameTransform.cs
@@ -95,17 +95,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 				name = name.Replace(@"\", "/");
 				name = WindowsPathUtils.DropPathRoot(name);
 
-				// Drop any leading slashes.
-				while ((name.Length > 0) && (name[0] == '/'))
-				{
-					name = name.Remove(0, 1);
-				}
-
-				// Drop any trailing slashes.
-				while ((name.Length > 0) && (name[name.Length - 1] == '/'))
-				{
-					name = name.Remove(name.Length - 1, 1);
-				}
+				// Drop any leading and trailing slashes.
+				name = name.Trim('/');
 
 				// Convert consecutive // characters to /
 				int index = name.IndexOf("//", StringComparison.Ordinal);


### PR DESCRIPTION
Is there a need to remove leading/trailing slashes with manual loops rather than using string.Trim to do both at once?

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
