### PR TITLE
[experiment] In ZipOutputStream, optionally transform the names of added entries with a simple fixed transform function.

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -368,6 +368,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			using (outputStream_ = new ZipOutputStream(outputStream))
 			{
 				outputStream_.SetLevel((int)CompressionLevel);
+				outputStream_.TransformEntryNames = false; // all required transforms handled by us
 
 				if (password_ != null)
 				{


### PR DESCRIPTION
Alternate spin off of #497 with an inline transform function instead of a swappable NameTransform.

Keeps all the code local to ZipOutputStream rather than changing anything else, scope there for sharing the utility code.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
