### PR TITLE
Fix tests and ZipEntry DateTime Kind

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -696,12 +696,14 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 				else
 				{
-					var year = (uint)DateTime.Year;
-					var month = (uint)DateTime.Month;
-					var day = (uint)DateTime.Day;
-					var hour = (uint)DateTime.Hour;
-					var minute = (uint)DateTime.Minute;
-					var second = (uint)DateTime.Second;
+					var utcDate = this.DateTime.ToUniversalTime();
+
+					var year = (uint)utcDate.Year;
+					var month = (uint)utcDate.Month;
+					var day = (uint)utcDate.Day;
+					var hour = (uint)utcDate.Hour;
+					var minute = (uint)utcDate.Minute;
+					var second = (uint)utcDate.Second;
 
 					if (year < 1980)
 					{

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -696,14 +696,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 				else
 				{
-					var utcDate = this.DateTime.ToUniversalTime();
-
-					var year = (uint)utcDate.Year;
-					var month = (uint)utcDate.Month;
-					var day = (uint)utcDate.Day;
-					var hour = (uint)utcDate.Hour;
-					var minute = (uint)utcDate.Minute;
-					var second = (uint)utcDate.Second;
+					var year = (uint)DateTime.Year;
+					var month = (uint)DateTime.Month;
+					var day = (uint)DateTime.Day;
+					var hour = (uint)DateTime.Hour;
+					var minute = (uint)DateTime.Minute;
+					var second = (uint)DateTime.Second;
 
 					if (year < 1980)
 					{
@@ -744,7 +742,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					uint mon = Math.Max(1, Math.Min(12, ((uint)(value >> 21) & 0xf)));
 					uint year = ((dosTime >> 25) & 0x7f) + 1980;
 					int day = Math.Max(1, Math.Min(DateTime.DaysInMonth((int)year, (int)mon), (int)((value >> 16) & 0x1f)));
-					DateTime = new DateTime((int)year, (int)mon, day, (int)hrs, (int)min, (int)sec, DateTimeKind.Utc);
+					DateTime = new DateTime((int)year, (int)mon, day, (int)hrs, (int)min, (int)sec, DateTimeKind.Unspecified);
 				}
 			}
 		}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/WindowsNameTransformHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/WindowsNameTransformHandling.cs
@@ -2,12 +2,20 @@
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
 	[TestFixture]
 	public class WindowsNameTransformHandling : TransformBase
 	{
+		[OneTimeSetUp]
+		public void TestInit() {
+			if (Path.DirectorySeparatorChar != '\\') {
+				Assert.Inconclusive("WindowsNameTransform will not work on platforms not using '\\' directory separators");
+			}
+		}
+
 		[Test]
 		public void BasicFiles()
 		{

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEntryFactoryHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEntryFactoryHandling.cs
@@ -106,6 +106,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					var lastAccessTime = new DateTime(2050, 11, 3, 0, 42, 12);
 
 					string tempFile = Path.Combine(tempDir, "SharpZipTest.Zip");
+					
 					using (FileStream f = File.Create(tempFile, 1024))
 					{
 						f.WriteByte(0);

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipNameTransformHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipNameTransformHandling.cs
@@ -80,10 +80,16 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Category("Zip")]
 		public void FilenameCleaning()
 		{
-			Assert.AreEqual(0, string.Compare(ZipEntry.CleanName("hello"), "hello", StringComparison.Ordinal));
-			Assert.AreEqual(0, string.Compare(ZipEntry.CleanName(@"z:\eccles"), "eccles", StringComparison.Ordinal));
-			Assert.AreEqual(0, string.Compare(ZipEntry.CleanName(@"\\server\share\eccles"), "eccles", StringComparison.Ordinal));
-			Assert.AreEqual(0, string.Compare(ZipEntry.CleanName(@"\\server\share\dir\eccles"), "dir/eccles", StringComparison.Ordinal));
+			Assert.AreEqual(ZipEntry.CleanName("hello"), "hello");
+			if(Environment.OSVersion.Platform == PlatformID.Win32NT) 
+			{
+				Assert.AreEqual(ZipEntry.CleanName(@"z:\eccles"), "eccles");
+				Assert.AreEqual(ZipEntry.CleanName(@"\\server\share\eccles"), "eccles");
+				Assert.AreEqual(ZipEntry.CleanName(@"\\server\share\dir\eccles"), "dir/eccles");
+			}
+			else {
+				Assert.AreEqual(ZipEntry.CleanName(@"/eccles"), "eccles");
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
This should allow all tests to pass on both *nix and windows.

The current outstanding bug with ZipEntry file names not being automatically cleaned has been moved to it's own test, as this is a known (although unwanted) behaviour of the current state the code base is in.

By doing this we should be able to have failing tests prevent PRs from being merged in a more controlled manner.

Fixes #481 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
