### PR TITLE
Consider AES overhead when testing encrypted folder entries

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1289,7 +1289,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 						// If so until details are known we will be strict.
 						if (entry.IsCrypted)
 						{
-							if (compressedSize > ZipConstants.CryptoHeaderSize + 2)
+							if (compressedSize > entry.EncryptionOverheadSize + 2)
 							{
 								throw new ZipException("Directory compressed size invalid");
 							}
@@ -1297,7 +1297,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 						else if (compressedSize > 2)
 						{
 							// When not compressed the directory size can validly be 2 bytes
-							// if the true size wasnt known when data was originally being written.
+							// if the true size wasn't known when data was originally being written.
 							// NOTE: Versions of the library 0.85.4 and earlier always added 2 bytes
 							throw new ZipException("Directory compressed size invalid");
 						}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -875,13 +875,13 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			TestDirectoryEntry(new MemoryStreamWithoutSeek());
 		}
 
-		private void TestEncryptedDirectoryEntry(MemoryStream s)
+		private void TestEncryptedDirectoryEntry(MemoryStream s, int aesKeySize)
 		{
 			var outStream = new ZipOutputStream(s);
 			outStream.Password = "Tonto hand me a beer";
 
 			outStream.IsStreamOwner = false;
-			outStream.PutNextEntry(new ZipEntry("YeUnreadableDirectory/"));
+			outStream.PutNextEntry(new ZipEntry("YeUnreadableDirectory/") { AESKeySize = aesKeySize } );
 			outStream.Close();
 
 			var ms2 = new MemoryStream(s.ToArray());
@@ -893,10 +893,10 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 		[Test]
 		[Category("Zip")]
-		public void TestEncryptedDirectoryEntry()
+		public void TestEncryptedDirectoryEntry([Values(0, 128, 256)]int aesKeySize)
 		{
-			TestEncryptedDirectoryEntry(new MemoryStream());
-			TestEncryptedDirectoryEntry(new MemoryStreamWithoutSeek());
+			TestEncryptedDirectoryEntry(new MemoryStream(), aesKeySize);
+			TestEncryptedDirectoryEntry(new MemoryStreamWithoutSeek(), aesKeySize);
 		}
 
 		[Test]


### PR DESCRIPTION
refs my last comment in #317 - TestArchive doesn't seem to consider AES encryption when testing encrypted directory entries (it always uses ```ZipConstants.CryptoHeaderSize```).

This is just a simple change to use the newly added ```EncryptionOverheadSize ``` instead.

I'm not sure what the '+ 2' is allowing for? (empty compressed data overhead? I'm not sure what the comment in the non-encrypted case about not knowing the true size refers to, when directories don't really have a size?)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
