### PR TITLE
Make PutNextEntry throw if the entry is AES and no password has been set. 

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -262,6 +262,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 				throw new NotImplementedException("Compression method not supported");
 			}
 
+			// A password must have been set in order to add AES encrypted entries
+			if (entry.AESKeySize > 0 && string.IsNullOrEmpty(this.Password))
+			{
+				throw new InvalidOperationException("The Password property must be set before AES encrypted entries can be added");
+			}
+
 			int compressionLevel = defaultCompressionLevel;
 
 			// Clear flags that the library manages internally

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
@@ -502,5 +502,23 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				}
 			}
 		}
+
+		/// <summary>
+		/// Test for https://github.com/icsharpcode/SharpZipLib/issues/507
+		/// </summary>
+		[Test]
+		[Category("Zip")]
+		public void AddingAnAESEntryWithNoPasswordShouldThrow()
+		{
+			using (var memoryStream = new MemoryStream())
+			{
+				using (var outStream = new ZipOutputStream(memoryStream))
+				{
+					var newEntry = new ZipEntry("test") { AESKeySize = 256 };
+
+					Assert.Throws<InvalidOperationException>(() => outStream.PutNextEntry(newEntry));
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
refs #507 - possible simple way to avoid the issue, by making PutNextEntry throw if the new entry has an AESKeySize set and the stream password hasn't been set.

I made it an InvalidOperationException rather than an ArgumentException with the idea that the operation is invalid when the stream has no password, 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
