### PR TITLE
Build the test bootstrapper app as netcoreapp3.1 instead of netcoreapp2.0

### DIFF
--- a/test/ICSharpCode.SharpZipLib.TestBootstrapper/ICSharpCode.SharpZipLib.TestBootstrapper.csproj
+++ b/test/ICSharpCode.SharpZipLib.TestBootstrapper/ICSharpCode.SharpZipLib.TestBootstrapper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/tools/appveyor-test.ps1
+++ b/tools/appveyor-test.ps1
@@ -5,7 +5,7 @@ $resxml = ".\docs\nunit3-test-results-debug.xml";
 #$tester = "nunit3-console .\test\ICSharpCode.SharpZipLib.Tests\bin\$($env:CONFIGURATION)\netcoreapp2.0\ICSharpCode.SharpZipLib.Tests.dll"
 
 # Bootstrapper:
-$tester = "dotnet run -f netcoreapp2 -p $proj -c $env:CONFIGURATION";
+$tester = "dotnet run -f netcoreapp3.1 -p $proj -c $env:CONFIGURATION";
 iex "$tester --explore=tests.xml";
 
 [xml]$xml = Get-Content("tests.xml");


### PR DESCRIPTION
I'm not sure what the intentions are for the bootstrapper app now that the github actions are running the tests directly, but:

I'm getting build warnings (visible in the appveyor build as well) about the bootstrapper app being built as .NET Core 2.0, when the test assembly that it depends on is now built as .NET Core 3.1 and .NET 4.6, so - try fixing that by retargetting it at 3.1 to match.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
