### PR TITLE
Move the 7zip helper functions out of ZipEncryptionHandling into their own class, for easier use elsewhere

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/SevenZip.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/SevenZip.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using NUnit.Framework;
+
+namespace ICSharpCode.SharpZipLib.Tests.TestSupport
+{
+	// Helper class for verifying zips with 7-zip
+	internal static class SevenZipHelper
+	{
+		private static readonly string[] possible7zPaths = new[] {
+			// Check in PATH
+			"7z", "7za",
+
+			// Check in default install location
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "7-Zip", "7z.exe"),
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "7-Zip", "7z.exe"),
+		};
+
+		public static bool TryGet7zBinPath(out string path7z)
+		{
+			var runTimeLimit = TimeSpan.FromSeconds(3);
+
+			foreach (var testPath in possible7zPaths)
+			{
+				try
+				{
+					var p = Process.Start(new ProcessStartInfo(testPath, "i")
+					{
+						RedirectStandardOutput = true,
+						UseShellExecute = false
+					});
+					while (!p.StandardOutput.EndOfStream && (DateTime.Now - p.StartTime) < runTimeLimit)
+					{
+						p.StandardOutput.DiscardBufferedData();
+					}
+					if (!p.HasExited)
+					{
+						p.Close();
+						Assert.Warn($"Timed out checking for 7z binary in \"{testPath}\"!");
+						continue;
+					}
+
+					if (p.ExitCode == 0)
+					{
+						path7z = testPath;
+						return true;
+					}
+				}
+				catch (Exception)
+				{
+					continue;
+				}
+			}
+			path7z = null;
+			return false;
+		}
+
+		/// <summary>
+		/// Helper function to verify the provided zip stream with 7Zip.
+		/// </summary>
+		/// <param name="zipStream">A stream containing the zip archive to test.</param>
+		/// <param name="password">The password for the archive.</param>
+		internal static void VerifyZipWith7Zip(Stream zipStream, string password)
+		{
+			if (TryGet7zBinPath(out string path7z))
+			{
+				Console.WriteLine($"Using 7z path: \"{path7z}\"");
+
+				var fileName = Path.GetTempFileName();
+
+				try
+				{
+					using (var fs = File.OpenWrite(fileName))
+					{
+						zipStream.Seek(0, SeekOrigin.Begin);
+						zipStream.CopyTo(fs);
+					}
+
+					var p = Process.Start(path7z, $"t -p{password} \"{fileName}\"");
+					if (!p.WaitForExit(2000))
+					{
+						Assert.Warn("Timed out verifying zip file!");
+					}
+
+					Assert.AreEqual(0, p.ExitCode, "Archive verification failed");
+				}
+				finally
+				{
+					File.Delete(fileName);
+				}
+			}
+			else
+			{
+				Assert.Warn("Skipping file verification since 7za is not in path");
+			}
+		}
+	}
+}


### PR DESCRIPTION
When I was looking at the ZipFile/BZip2 changes I was thinking that it might be useful to verify some of those created archives with 7zip in the way it's currently done for testing encrypted archives, so - I thought it might be useful to break the 7zip helper functions out into their own class rather than being inside the ```ZipEncryptionHandling``` test class as a start towards that.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
