### PR TITLE
Improve CRC32 performance

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Checksum/BZip2Crc.cs
+++ b/src/ICSharpCode.SharpZipLib/Checksum/BZip2Crc.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace ICSharpCode.SharpZipLib.Checksum
 {
@@ -25,9 +26,19 @@ namespace ICSharpCode.SharpZipLib.Checksum
 	/// out is a one).  We start with the highest power (least significant bit) of
 	/// q and repeat for all eight bits of q.
 	///
-	/// The table is simply the CRC of all possible eight bit values.  This is all
-	/// the information needed to generate CRC's on data a byte at a time for all
-	/// combinations of CRC register values and incoming bytes.
+	/// This implementation uses sixteen lookup tables stored in one linear array
+	/// to implement the slicing-by-16 algorithm, a variant of the slicing-by-8
+	/// algorithm described in this Intel white paper:
+	///
+	/// https://web.archive.org/web/20120722193753/http://download.intel.com/technology/comms/perfnet/download/slicing-by-8.pdf
+	///
+	/// The first lookup table is simply the CRC of all possible eight bit values.
+	/// Each successive lookup table is derived from the original table generated
+	/// by Sarwate's algorithm. Slicing a 16-bit input and XORing the outputs
+	/// together will produce the same output as a byte-by-byte CRC loop with
+	/// fewer arithmetic and bit manipulation operations, at the cost of increased
+	/// memory consumed by the lookup tables. (Slicing-by-16 requires a 16KB table,
+	/// which is still small enough to fit in most processors' L1 cache.)
 	/// </remarks>
 	public sealed class BZip2Crc : IChecksum
 	{
@@ -36,72 +47,7 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		private const uint crcInit = 0xFFFFFFFF;
 		//const uint crcXor = 0x00000000;
 
-		private static readonly uint[] crcTable = {
-			0X00000000, 0X04C11DB7, 0X09823B6E, 0X0D4326D9,
-			0X130476DC, 0X17C56B6B, 0X1A864DB2, 0X1E475005,
-			0X2608EDB8, 0X22C9F00F, 0X2F8AD6D6, 0X2B4BCB61,
-			0X350C9B64, 0X31CD86D3, 0X3C8EA00A, 0X384FBDBD,
-			0X4C11DB70, 0X48D0C6C7, 0X4593E01E, 0X4152FDA9,
-			0X5F15ADAC, 0X5BD4B01B, 0X569796C2, 0X52568B75,
-			0X6A1936C8, 0X6ED82B7F, 0X639B0DA6, 0X675A1011,
-			0X791D4014, 0X7DDC5DA3, 0X709F7B7A, 0X745E66CD,
-			0X9823B6E0, 0X9CE2AB57, 0X91A18D8E, 0X95609039,
-			0X8B27C03C, 0X8FE6DD8B, 0X82A5FB52, 0X8664E6E5,
-			0XBE2B5B58, 0XBAEA46EF, 0XB7A96036, 0XB3687D81,
-			0XAD2F2D84, 0XA9EE3033, 0XA4AD16EA, 0XA06C0B5D,
-			0XD4326D90, 0XD0F37027, 0XDDB056FE, 0XD9714B49,
-			0XC7361B4C, 0XC3F706FB, 0XCEB42022, 0XCA753D95,
-			0XF23A8028, 0XF6FB9D9F, 0XFBB8BB46, 0XFF79A6F1,
-			0XE13EF6F4, 0XE5FFEB43, 0XE8BCCD9A, 0XEC7DD02D,
-			0X34867077, 0X30476DC0, 0X3D044B19, 0X39C556AE,
-			0X278206AB, 0X23431B1C, 0X2E003DC5, 0X2AC12072,
-			0X128E9DCF, 0X164F8078, 0X1B0CA6A1, 0X1FCDBB16,
-			0X018AEB13, 0X054BF6A4, 0X0808D07D, 0X0CC9CDCA,
-			0X7897AB07, 0X7C56B6B0, 0X71159069, 0X75D48DDE,
-			0X6B93DDDB, 0X6F52C06C, 0X6211E6B5, 0X66D0FB02,
-			0X5E9F46BF, 0X5A5E5B08, 0X571D7DD1, 0X53DC6066,
-			0X4D9B3063, 0X495A2DD4, 0X44190B0D, 0X40D816BA,
-			0XACA5C697, 0XA864DB20, 0XA527FDF9, 0XA1E6E04E,
-			0XBFA1B04B, 0XBB60ADFC, 0XB6238B25, 0XB2E29692,
-			0X8AAD2B2F, 0X8E6C3698, 0X832F1041, 0X87EE0DF6,
-			0X99A95DF3, 0X9D684044, 0X902B669D, 0X94EA7B2A,
-			0XE0B41DE7, 0XE4750050, 0XE9362689, 0XEDF73B3E,
-			0XF3B06B3B, 0XF771768C, 0XFA325055, 0XFEF34DE2,
-			0XC6BCF05F, 0XC27DEDE8, 0XCF3ECB31, 0XCBFFD686,
-			0XD5B88683, 0XD1799B34, 0XDC3ABDED, 0XD8FBA05A,
-			0X690CE0EE, 0X6DCDFD59, 0X608EDB80, 0X644FC637,
-			0X7A089632, 0X7EC98B85, 0X738AAD5C, 0X774BB0EB,
-			0X4F040D56, 0X4BC510E1, 0X46863638, 0X42472B8F,
-			0X5C007B8A, 0X58C1663D, 0X558240E4, 0X51435D53,
-			0X251D3B9E, 0X21DC2629, 0X2C9F00F0, 0X285E1D47,
-			0X36194D42, 0X32D850F5, 0X3F9B762C, 0X3B5A6B9B,
-			0X0315D626, 0X07D4CB91, 0X0A97ED48, 0X0E56F0FF,
-			0X1011A0FA, 0X14D0BD4D, 0X19939B94, 0X1D528623,
-			0XF12F560E, 0XF5EE4BB9, 0XF8AD6D60, 0XFC6C70D7,
-			0XE22B20D2, 0XE6EA3D65, 0XEBA91BBC, 0XEF68060B,
-			0XD727BBB6, 0XD3E6A601, 0XDEA580D8, 0XDA649D6F,
-			0XC423CD6A, 0XC0E2D0DD, 0XCDA1F604, 0XC960EBB3,
-			0XBD3E8D7E, 0XB9FF90C9, 0XB4BCB610, 0XB07DABA7,
-			0XAE3AFBA2, 0XAAFBE615, 0XA7B8C0CC, 0XA379DD7B,
-			0X9B3660C6, 0X9FF77D71, 0X92B45BA8, 0X9675461F,
-			0X8832161A, 0X8CF30BAD, 0X81B02D74, 0X857130C3,
-			0X5D8A9099, 0X594B8D2E, 0X5408ABF7, 0X50C9B640,
-			0X4E8EE645, 0X4A4FFBF2, 0X470CDD2B, 0X43CDC09C,
-			0X7B827D21, 0X7F436096, 0X7200464F, 0X76C15BF8,
-			0X68860BFD, 0X6C47164A, 0X61043093, 0X65C52D24,
-			0X119B4BE9, 0X155A565E, 0X18197087, 0X1CD86D30,
-			0X029F3D35, 0X065E2082, 0X0B1D065B, 0X0FDC1BEC,
-			0X3793A651, 0X3352BBE6, 0X3E119D3F, 0X3AD08088,
-			0X2497D08D, 0X2056CD3A, 0X2D15EBE3, 0X29D4F654,
-			0XC5A92679, 0XC1683BCE, 0XCC2B1D17, 0XC8EA00A0,
-			0XD6AD50A5, 0XD26C4D12, 0XDF2F6BCB, 0XDBEE767C,
-			0XE3A1CBC1, 0XE760D676, 0XEA23F0AF, 0XEEE2ED18,
-			0XF0A5BD1D, 0XF464A0AA, 0XF9278673, 0XFDE69BC4,
-			0X89B8FD09, 0X8D79E0BE, 0X803AC667, 0X84FBDBD0,
-			0X9ABC8BD5, 0X9E7D9662, 0X933EB0BB, 0X97FFAD0C,
-			0XAFB010B1, 0XAB710D06, 0XA6322BDF, 0XA2F33668,
-			0XBCB4666D, 0XB8757BDA, 0XB5365D03, 0XB1F740B4
-		};
+		private static readonly uint[] crcTable = CrcUtilities.GenerateSlicingLookupTable(0x04C11DB7, isReversed: false);
 
 		/// <summary>
 		/// The CRC data checksum so far.
@@ -149,6 +95,7 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		/// the byte is taken as the lower 8 bits of bval
 		/// </param>
 		/// <remarks>Reversed Data = false</remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void Update(int bval)
 		{
 			checkValue = unchecked(crcTable[(byte)(((checkValue >> 24) & 0xFF) ^ bval)] ^ (checkValue << 8));
@@ -166,7 +113,7 @@ namespace ICSharpCode.SharpZipLib.Checksum
 				throw new ArgumentNullException(nameof(buffer));
 			}
 
-			Update(new ArraySegment<byte>(buffer, 0, buffer.Length));
+			Update(buffer, 0, buffer.Length);
 		}
 
 		/// <summary>
@@ -177,11 +124,48 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		/// </param>
 		public void Update(ArraySegment<byte> segment)
 		{
-			var count = segment.Count;
-			var offset = segment.Offset;
+			Update(segment.Array, segment.Offset, segment.Count);
+		}
 
-			while (--count >= 0)
-				Update(segment.Array[offset++]);
+		/// <summary>
+		/// Internal helper function for updating a block of data using slicing.
+		/// </summary>
+		/// <param name="data">The array containing the data to add</param>
+		/// <param name="offset">Range start for <paramref name="data"/> (inclusive)</param>
+		/// <param name="count">The number of bytes to checksum starting from <paramref name="offset"/></param>
+		private void Update(byte[] data, int offset, int count)
+		{
+			int remainder = count % CrcUtilities.SlicingDegree;
+			int end = offset + count - remainder;
+
+			while (offset != end)
+			{
+				checkValue = CrcUtilities.UpdateDataForNormalPoly(data, offset, crcTable, checkValue);
+				offset += CrcUtilities.SlicingDegree;
+			}
+
+			if (remainder != 0)
+			{
+				SlowUpdateLoop(data, offset, end + remainder);
+			}
+		}
+
+		/// <summary>
+		/// A non-inlined function for updating data that doesn't fit in a 16-byte
+		/// block. We don't expect to enter this function most of the time, and when
+		/// we do we're not here for long, so disabling inlining here improves
+		/// performance overall.
+		/// </summary>
+		/// <param name="data">The array containing the data to add</param>
+		/// <param name="offset">Range start for <paramref name="data"/> (inclusive)</param>
+		/// <param name="end">Range end for <paramref name="data"/> (exclusive)</param>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private void SlowUpdateLoop(byte[] data, int offset, int end)
+		{
+			while (offset != end)
+			{
+				Update(data[offset++]);
+			}
 		}
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Checksum/Crc32.cs
+++ b/src/ICSharpCode.SharpZipLib/Checksum/Crc32.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace ICSharpCode.SharpZipLib.Checksum
 {
@@ -25,9 +26,19 @@ namespace ICSharpCode.SharpZipLib.Checksum
 	/// out is a one).  We start with the highest power (least significant bit) of
 	/// q and repeat for all eight bits of q.
 	///
-	/// The table is simply the CRC of all possible eight bit values.  This is all
-	/// the information needed to generate CRC's on data a byte at a time for all
-	/// combinations of CRC register values and incoming bytes.
+	/// This implementation uses sixteen lookup tables stored in one linear array
+	/// to implement the slicing-by-16 algorithm, a variant of the slicing-by-8
+	/// algorithm described in this Intel white paper:
+	///
+	/// https://web.archive.org/web/20120722193753/http://download.intel.com/technology/comms/perfnet/download/slicing-by-8.pdf
+	///
+	/// The first lookup table is simply the CRC of all possible eight bit values.
+	/// Each successive lookup table is derived from the original table generated
+	/// by Sarwate's algorithm. Slicing a 16-bit input and XORing the outputs
+	/// together will produce the same output as a byte-by-byte CRC loop with
+	/// fewer arithmetic and bit manipulation operations, at the cost of increased
+	/// memory consumed by the lookup tables. (Slicing-by-16 requires a 16KB table,
+	/// which is still small enough to fit in most processors' L1 cache.)
 	/// </remarks>
 	public sealed class Crc32 : IChecksum
 	{
@@ -36,60 +47,7 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		private static readonly uint crcInit = 0xFFFFFFFF;
 		private static readonly uint crcXor = 0xFFFFFFFF;
 
-		private static readonly uint[] crcTable = {
-			0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419,
-			0x706AF48F, 0xE963A535, 0x9E6495A3, 0x0EDB8832, 0x79DCB8A4,
-			0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07,
-			0x90BF1D91, 0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE,
-			0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7, 0x136C9856,
-			0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9,
-			0xFA0F3D63, 0x8D080DF5, 0x3B6E20C8, 0x4C69105E, 0xD56041E4,
-			0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
-			0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3,
-			0x45DF5C75, 0xDCD60DCF, 0xABD13D59, 0x26D930AC, 0x51DE003A,
-			0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599,
-			0xB8BDA50F, 0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924,
-			0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D, 0x76DC4190,
-			0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F,
-			0x9FBFE4A5, 0xE8B8D433, 0x7807C9A2, 0x0F00F934, 0x9609A88E,
-			0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
-			0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED,
-			0x1B01A57B, 0x8208F4C1, 0xF50FC457, 0x65B0D9C6, 0x12B7E950,
-			0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3,
-			0xFBD44C65, 0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2,
-			0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB, 0x4369E96A,
-			0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5,
-			0xAA0A4C5F, 0xDD0D7CC9, 0x5005713C, 0x270241AA, 0xBE0B1010,
-			0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
-			0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17,
-			0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD, 0xEDB88320, 0x9ABFB3B6,
-			0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615,
-			0x73DC1683, 0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8,
-			0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1, 0xF00F9344,
-			0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB,
-			0x196C3671, 0x6E6B06E7, 0xFED41B76, 0x89D32BE0, 0x10DA7A5A,
-			0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
-			0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1,
-			0xA6BC5767, 0x3FB506DD, 0x48B2364B, 0xD80D2BDA, 0xAF0A1B4C,
-			0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF,
-			0x4669BE79, 0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236,
-			0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F, 0xC5BA3BBE,
-			0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31,
-			0x2CD99E8B, 0x5BDEAE1D, 0x9B64C2B0, 0xEC63F226, 0x756AA39C,
-			0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
-			0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B,
-			0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21, 0x86D3D2D4, 0xF1D4E242,
-			0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1,
-			0x18B74777, 0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C,
-			0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45, 0xA00AE278,
-			0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7,
-			0x4969474D, 0x3E6E77DB, 0xAED16A4A, 0xD9D65ADC, 0x40DF0B66,
-			0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
-			0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605,
-			0xCDD70693, 0x54DE5729, 0x23D967BF, 0xB3667A2E, 0xC4614AB8,
-			0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B,
-			0x2D02EF8D
-		};
+		private static readonly uint[] crcTable = CrcUtilities.GenerateSlicingLookupTable(0xEDB88320, isReversed: true);
 
 		/// <summary>
 		/// The CRC data checksum so far.
@@ -98,6 +56,7 @@ namespace ICSharpCode.SharpZipLib.Checksum
 
 		#endregion Instance Fields
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static uint ComputeCrc32(uint oldCrc, byte bval)
 		{
 			return (uint)(Crc32.crcTable[(oldCrc ^ bval) & 0xFF] ^ (oldCrc >> 8));
@@ -138,6 +97,7 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		/// the byte is taken as the lower 8 bits of bval
 		/// </param>
 		/// <remarks>Reversed Data = true</remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void Update(int bval)
 		{
 			checkValue = unchecked(crcTable[(checkValue ^ bval) & 0xFF] ^ (checkValue >> 8));
@@ -155,7 +115,7 @@ namespace ICSharpCode.SharpZipLib.Checksum
 				throw new ArgumentNullException(nameof(buffer));
 			}
 
-			Update(new ArraySegment<byte>(buffer, 0, buffer.Length));
+			Update(buffer, 0, buffer.Length);
 		}
 
 		/// <summary>
@@ -166,11 +126,48 @@ namespace ICSharpCode.SharpZipLib.Checksum
 		/// </param>
 		public void Update(ArraySegment<byte> segment)
 		{
-			var count = segment.Count;
-			var offset = segment.Offset;
+			Update(segment.Array, segment.Offset, segment.Count);
+		}
 
-			while (--count >= 0)
-				Update(segment.Array[offset++]);
+		/// <summary>
+		/// Internal helper function for updating a block of data using slicing.
+		/// </summary>
+		/// <param name="data">The array containing the data to add</param>
+		/// <param name="offset">Range start for <paramref name="data"/> (inclusive)</param>
+		/// <param name="count">The number of bytes to checksum starting from <paramref name="offset"/></param>
+		private void Update(byte[] data, int offset, int count)
+		{
+			int remainder = count % CrcUtilities.SlicingDegree;
+			int end = offset + count - remainder;
+
+			while (offset != end)
+			{
+				checkValue = CrcUtilities.UpdateDataForReversedPoly(data, offset, crcTable, checkValue);
+				offset += CrcUtilities.SlicingDegree;
+			}
+
+			if (remainder != 0)
+			{
+				SlowUpdateLoop(data, offset, end + remainder);
+			}
+		}
+
+		/// <summary>
+		/// A non-inlined function for updating data that doesn't fit in a 16-byte
+		/// block. We don't expect to enter this function most of the time, and when
+		/// we do we're not here for long, so disabling inlining here improves
+		/// performance overall.
+		/// </summary>
+		/// <param name="data">The array containing the data to add</param>
+		/// <param name="offset">Range start for <paramref name="data"/> (inclusive)</param>
+		/// <param name="end">Range end for <paramref name="data"/> (exclusive)</param>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private void SlowUpdateLoop(byte[] data, int offset, int end)
+		{
+			while (offset != end)
+			{
+				Update(data[offset++]);
+			}
 		}
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Checksum/CrcUtilities.cs
+++ b/src/ICSharpCode.SharpZipLib/Checksum/CrcUtilities.cs
@@ -1,0 +1,158 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace ICSharpCode.SharpZipLib.Checksum
+{
+	internal static class CrcUtilities
+	{
+		/// <summary>
+		/// The number of slicing lookup tables to generate.
+		/// </summary>
+		internal const int SlicingDegree = 16;
+
+		/// <summary>
+		/// Generates multiple CRC lookup tables for a given polynomial, stored
+		/// in a linear array of uints. The first block (i.e. the first 256
+		/// elements) is the same as the byte-by-byte CRC lookup table. 
+		/// </summary>
+		/// <param name="polynomial">The generating CRC polynomial</param>
+		/// <param name="isReversed">Whether the polynomial is in reversed bit order</param>
+		/// <returns>A linear array of 256 * <see cref="SlicingDegree"/> elements</returns>
+		/// <remarks>
+		/// This table could also be generated as a rectangular array, but the
+		/// JIT compiler generates slower code than if we use a linear array.
+		/// Known issue, see: https://github.com/dotnet/runtime/issues/30275
+		/// </remarks>
+		internal static uint[] GenerateSlicingLookupTable(uint polynomial, bool isReversed)
+		{
+			var table = new uint[256 * SlicingDegree];
+			uint one = isReversed ? 1 : (1U << 31);
+
+			for (int i = 0; i < 256; i++)
+			{
+				uint res = (uint)(isReversed ? i : i << 24);
+				for (int j = 0; j < SlicingDegree; j++)
+				{
+					for (int k = 0; k < 8; k++)
+					{
+						if (isReversed)
+						{
+							res = (res & one) == 1 ? polynomial ^ (res >> 1) : res >> 1;
+						}
+						else
+						{
+							res = (res & one) != 0 ? polynomial ^ (res << 1) : res << 1;
+						}
+					}
+
+					table[(256 * j) + i] = res;
+				}
+			}
+
+			return table;
+		}
+
+		/// <summary>
+		/// Mixes the first four bytes of input with <paramref name="checkValue"/>
+		/// using normal ordering before calling <see cref="UpdateDataCommon"/>.
+		/// </summary>
+		/// <param name="input">Array of data to checksum</param>
+		/// <param name="offset">Offset to start reading <paramref name="input"/> from</param>
+		/// <param name="crcTable">The table to use for slicing-by-16 lookup</param>
+		/// <param name="checkValue">Checksum state before this update call</param>
+		/// <returns>A new unfinalized checksum value</returns>
+		/// <seealso cref="UpdateDataForReversedPoly"/>
+		/// <remarks>
+		/// Assumes input[offset]..input[offset + 15] are valid array indexes.
+		/// For performance reasons, this must be checked by the caller.
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static uint UpdateDataForNormalPoly(byte[] input, int offset, uint[] crcTable, uint checkValue)
+		{
+			byte x1 = (byte)((byte)(checkValue >> 24) ^ input[offset]);
+			byte x2 = (byte)((byte)(checkValue >> 16) ^ input[offset + 1]);
+			byte x3 = (byte)((byte)(checkValue >> 8) ^ input[offset + 2]);
+			byte x4 = (byte)((byte)checkValue ^ input[offset + 3]);
+
+			return UpdateDataCommon(input, offset, crcTable, x1, x2, x3, x4);
+		}
+
+		/// <summary>
+		/// Mixes the first four bytes of input with <paramref name="checkValue"/>
+		/// using reflected ordering before calling <see cref="UpdateDataCommon"/>.
+		/// </summary>
+		/// <param name="input">Array of data to checksum</param>
+		/// <param name="offset">Offset to start reading <paramref name="input"/> from</param>
+		/// <param name="crcTable">The table to use for slicing-by-16 lookup</param>
+		/// <param name="checkValue">Checksum state before this update call</param>
+		/// <returns>A new unfinalized checksum value</returns>
+		/// <seealso cref="UpdateDataForNormalPoly"/>
+		/// <remarks>
+		/// Assumes input[offset]..input[offset + 15] are valid array indexes.
+		/// For performance reasons, this must be checked by the caller.
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static uint UpdateDataForReversedPoly(byte[] input, int offset, uint[] crcTable, uint checkValue)
+		{
+			byte x1 = (byte)((byte)checkValue ^ input[offset]);
+			byte x2 = (byte)((byte)(checkValue >>= 8) ^ input[offset + 1]);
+			byte x3 = (byte)((byte)(checkValue >>= 8) ^ input[offset + 2]);
+			byte x4 = (byte)((byte)(checkValue >>= 8) ^ input[offset + 3]);
+
+			return UpdateDataCommon(input, offset, crcTable, x1, x2, x3, x4);
+		}
+
+		/// <summary>
+		/// A shared method for updating an unfinalized CRC checksum using slicing-by-16.
+		/// </summary>
+		/// <param name="input">Array of data to checksum</param>
+		/// <param name="offset">Offset to start reading <paramref name="input"/> from</param>
+		/// <param name="crcTable">The table to use for slicing-by-16 lookup</param>
+		/// <param name="x1">First byte of input after mixing with the old CRC</param>
+		/// <param name="x2">Second byte of input after mixing with the old CRC</param>
+		/// <param name="x3">Third byte of input after mixing with the old CRC</param>
+		/// <param name="x4">Fourth byte of input after mixing with the old CRC</param>
+		/// <returns>A new unfinalized checksum value</returns>
+		/// <remarks>
+		/// <para>
+		/// Even though the first four bytes of input are fed in as arguments,
+		/// <paramref name="offset"/> should be the same value passed to this
+		/// function's caller (either <see cref="UpdateDataForNormalPoly"/> or
+		/// <see cref="UpdateDataForReversedPoly"/>). This method will get inlined
+		/// into both functions, so using the same offset produces faster code.
+		/// </para>
+		/// <para>
+		/// Because most processors running C# have some kind of instruction-level
+		/// parallelism, the order of XOR operations can affect performance. This
+		/// ordering assumes that the assembly code generated by the just-in-time
+		/// compiler will emit a bunch of arithmetic operations for checking array
+		/// bounds. Then it opportunistically XORs a1 and a2 to keep the processor
+		/// busy while those other parts of the pipeline handle the range check
+		/// calculations.
+		/// </para>
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private static uint UpdateDataCommon(byte[] input, int offset, uint[] crcTable, byte x1, byte x2, byte x3, byte x4)
+		{
+			uint result;
+			uint a1 = crcTable[x1 + 3840] ^ crcTable[x2 + 3584];
+			uint a2 = crcTable[x3 + 3328] ^ crcTable[x4 + 3072];
+
+			result = crcTable[input[offset + 4] + 2816];
+			result ^= crcTable[input[offset + 5] + 2560];
+			a1 ^= crcTable[input[offset + 9] + 1536];
+			result ^= crcTable[input[offset + 6] + 2304];
+			result ^= crcTable[input[offset + 7] + 2048];
+			result ^= crcTable[input[offset + 8] + 1792];
+			a2 ^= crcTable[input[offset + 13] + 512];
+			result ^= crcTable[input[offset + 10] + 1280];
+			result ^= crcTable[input[offset + 11] + 1024];
+			result ^= crcTable[input[offset + 12] + 768];
+			result ^= a1;
+			result ^= crcTable[input[offset + 14] + 256];
+			result ^= crcTable[input[offset + 15]];
+			result ^= a2;
+
+			return result;
+		}
+	}
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/Checksum/ChecksumTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Checksum/ChecksumTests.cs
@@ -13,6 +13,14 @@ namespace ICSharpCode.SharpZipLib.Tests.Checksum
 				// Represents ASCII string of "123456789"
 				byte[] check = { 49, 50, 51, 52, 53, 54, 55, 56, 57 };
 
+		// Represents string "123456789123456789123456789123456789"
+		private readonly byte[] longCheck = {
+			49, 50, 51, 52, 53, 54, 55, 56, 57,
+			49, 50, 51, 52, 53, 54, 55, 56, 57,
+			49, 50, 51, 52, 53, 54, 55, 56, 57,
+			49, 50, 51, 52, 53, 54, 55, 56, 57
+		};
+
 		[Test]
 		public void Adler_32()
 		{
@@ -71,6 +79,32 @@ namespace ICSharpCode.SharpZipLib.Tests.Checksum
 		}
 
 		[Test]
+		public void CRC_32_BZip2_Long()
+		{
+			var underTestCrc32 = new BZip2Crc();
+			underTestCrc32.Update(longCheck);
+			Assert.AreEqual(0xEE53D2B2, underTestCrc32.Value);
+		}
+
+		[Test]
+		public void CRC_32_BZip2_Unaligned()
+		{
+			// Extract "456" and CRC
+			var underTestCrc32 = new BZip2Crc();
+			underTestCrc32.Update(new ArraySegment<byte>(check, 3, 3));
+			Assert.AreEqual(0x001D0511, underTestCrc32.Value);
+		}
+
+		[Test]
+		public void CRC_32_BZip2_Long_Unaligned()
+		{
+			// Extract "789123456789123456" and CRC
+			var underTestCrc32 = new BZip2Crc();
+			underTestCrc32.Update(new ArraySegment<byte>(longCheck, 15, 18));
+			Assert.AreEqual(0x025846E0, underTestCrc32.Value);
+		}
+
+		[Test]
 		public void CRC_32()
 		{
 			var underTestCrc32 = new Crc32();
@@ -83,6 +117,32 @@ namespace ICSharpCode.SharpZipLib.Tests.Checksum
 			Assert.AreEqual(0x0, underTestCrc32.Value);
 
 			exceptionTesting(underTestCrc32);
+		}
+
+		[Test]
+		public void CRC_32_Long()
+		{
+			var underTestCrc32 = new Crc32();
+			underTestCrc32.Update(longCheck);
+			Assert.AreEqual(0x3E29169C, underTestCrc32.Value);
+		}
+
+		[Test]
+		public void CRC_32_Unaligned()
+		{
+			// Extract "456" and CRC
+			var underTestCrc32 = new Crc32();
+			underTestCrc32.Update(new ArraySegment<byte>(check, 3, 3));
+			Assert.AreEqual(0xB1A8C371, underTestCrc32.Value);
+		}
+
+		[Test]
+		public void CRC_32_Long_Unaligned()
+		{
+			// Extract "789123456789123456" and CRC
+			var underTestCrc32 = new Crc32();
+			underTestCrc32.Update(new ArraySegment<byte>(longCheck, 15, 18));
+			Assert.AreEqual(0x31CA9A2E, underTestCrc32.Value);
 		}
 
 		private void exceptionTesting(IChecksum crcUnderTest)


### PR DESCRIPTION
This change replaces the CRC32 update code with a slicing-by-16 implementation that can process 16 bytes at a time. It uses the original byte-by-byte code as a fallback, but also marks that method for aggressive inlining to get rid of overhead from function calls. This reduces the runtime of the BZip and ZLib CRC checksums by about 75%, which is also good for overall I/O.

The performance can be improved even further by using unsafe code to eliminate array bounds checks. While that code isn't included in this PR, the benchmarks for the unsafe code are included below. The code can be found here: https://github.com/nsgomez/SharpZipLib/commit/6a2e9546b42eb4387c0b83619d91aefdcdbc5bc5

## CLA

While this is my personal GitHub account, I'm submitting this PR in my capacity as a Microsoft employee.

The method CrcUtilities.GenerateSlicingLookupTable is derived from Crc32.NET's table generation code. We do not own that source code, but because it's MIT Licensed we have sufficient rights to use, copy, and distribute it. Otherwise, _I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

## Benchmarks

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.1248 (2004/?/20H1)
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4200.0), X64 RyuJIT
  Job-KMVHYW : .NET Core 2.1.12 (CoreCLR 4.6.27817.01, CoreFX 4.6.27818.01), X64 RyuJIT
  Job-DCFJWB : .NET Framework 4.8 (4.8.4200.0), X64 RyuJIT

### net461

|               Method | Mean ± StdDev (master) | Mean ± StdDev (PR) | Diff (mean) | Mean ± StdDev (unsafe) |
|--------------------- |-----------------------:|-------------------:|------------:|-----------------------:|
|   Adler32LargeUpdate |        196.1 ± 1.04 ms |    195.6 ± 0.76 ms |      ~0.00% |        195.5 ± 0.45 ms |
|  BZip2CrcLargeUpdate |        988.8 ± 0.99 ms |    226.6 ± 0.95 ms |     -77.08% |        104.5 ± 0.32 ms |
|     Crc32LargeUpdate |        777.1 ± 4.24 ms |    204.4 ± 2.46 ms |     -73.70% |        102.5 ± 0.62 ms |
|   ReadZipInputStream |        311.9 ± 2.53 ms |    166.6 ± 0.55 ms |     -46.59% |        141.0 ± 0.35 ms |
| WriteZipOutputStream |        616.7 ± 3.83 ms |    497.0 ± 3.11 ms |     -19.41% |        462.1 ± 0.82 ms |

### netcoreapp2.1

|               Method | Mean ± StdDev (master) | Mean ± StdDev (PR) | Diff (mean) | Mean ± StdDev (unsafe) |
|--------------------- |-----------------------:|-------------------:|------------:|-----------------------:|
|   Adler32LargeUpdate |        229.5 ± 0.68 ms |    230.0 ± 0.89 ms |      ~0.00% |        231.8 ± 1.96 ms |
|  BZip2CrcLargeUpdate |      1,079.4 ± 2.90 ms |    233.5 ± 0.97 ms |     -78.37% |        104.4 ± 0.30 ms |
|     Crc32LargeUpdate |        776.2 ± 3.11 ms |    224.5 ± 1.06 ms |     -71.08% |        102.2 ± 0.13 ms |
|   ReadZipInputStream |        310.7 ± 1.41 ms |    167.2 ± 0.42 ms |     -46.19% |        141.8 ± 0.38 ms |
| WriteZipOutputStream |        606.6 ± 3.34 ms |    495.0 ± 3.33 ms |     -18.40% |        438.0 ± 1.86 ms |