### PR TITLE
Fix Codacy Workflows

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run codacy-analysis-cli
-        uses: codacy/codacy-analysis-cli-action@1.0.1
+        uses: codacy/codacy-analysis-cli-action@1.1.0
         with:
           # The current issues needs to be fixed before this can be removed
           max-allowed-issues: 9999

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run codacy-analysis-cli
-        uses: codacy/codacy-analysis-cli-action@1.0.1
+        uses: codacy/codacy-analysis-cli-action@1.1.0
         with:
           # The current issues needs to be fixed before this can be removed
           max-allowed-issues: 9999


### PR DESCRIPTION
Somehow the Codacy Action tagged with v1.0.1 broke, even though we used the explicit version that did work before. Seems to be fixed in v1.1.0 though.
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
