### PR TITLE
Use RNGCryptoServiceProvider for crypto headers

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/PkzipClassic.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/PkzipClassic.cs
@@ -444,8 +444,10 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		public override void GenerateKey()
 		{
 			key_ = new byte[12];
-			var rng = new RNGCryptoServiceProvider();
-			rng.GetBytes(key_);
+			using (var rng = new RNGCryptoServiceProvider())
+			{
+				rng.GetBytes(key_);
+			}
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Encryption/PkzipClassic.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/PkzipClassic.cs
@@ -444,8 +444,8 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		public override void GenerateKey()
 		{
 			key_ = new byte[12];
-			var rnd = new Random();
-			rnd.NextBytes(key_);
+			var rng = new RNGCryptoServiceProvider();
+			rng.GetBytes(key_);
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -3713,8 +3713,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 		private static void WriteEncryptionHeader(Stream stream, long crcValue)
 		{
 			byte[] cryptBuffer = new byte[ZipConstants.CryptoHeaderSize];
-			var rnd = new Random();
-			rnd.NextBytes(cryptBuffer);
+			using (var rng = new RNGCryptoServiceProvider())
+			{
+				rng.GetBytes(cryptBuffer);
+			}
 			cryptBuffer[11] = (byte)(crcValue >> 24);
 			stream.Write(cryptBuffer, 0, cryptBuffer.Length);
 		}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -5,6 +5,7 @@ using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -627,8 +628,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 			InitializePassword(Password);
 
 			byte[] cryptBuffer = new byte[ZipConstants.CryptoHeaderSize];
-			var rnd = new Random();
-			rnd.NextBytes(cryptBuffer);
+			using (var rng = new RNGCryptoServiceProvider())
+			{
+				rng.GetBytes(cryptBuffer);
+			}
+
 			cryptBuffer[11] = (byte)(crcValue >> 24);
 
 			EncryptBlock(cryptBuffer, 0, cryptBuffer.Length);


### PR DESCRIPTION
Use a proper RNG for cryptographically important randomness.
Fixes #536 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
