### PR TITLE
make a couple of private functions static to silence CA1822 analyzer warnings

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -1125,7 +1125,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 		}
 
-		private DateTime? GetDateTime(ZipExtraData extraData)
+		private static DateTime? GetDateTime(ZipExtraData extraData)
 		{
 			// Check for NT timestamp
 			// NOTE: Disable by default to match behavior of InfoZIP

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1904,7 +1904,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// Check if the specified compression method is supported for adding a new entry.
 		/// </summary>
 		/// <param name="compressionMethod">The compression method for the new entry.</param>
-		private void CheckSupportedCompressionMethod(CompressionMethod compressionMethod)
+		private static void CheckSupportedCompressionMethod(CompressionMethod compressionMethod)
 		{
 			if (compressionMethod != CompressionMethod.Deflated && compressionMethod != CompressionMethod.Stored && compressionMethod != CompressionMethod.BZip2)
 			{


### PR DESCRIPTION
Rather trivial, but FxCop (#449) suggests making these functions static as they don't access instance data ([CA1822](https://docs.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1822?view=vs-2019), may or may not have hypothetically better performance)

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
