### PR TITLE
Add async support on ZipOutputStream

### DIFF
--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net45</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../../assets/ICSharpCode.SharpZipLib.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -40,5 +40,5 @@ Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.3.1 for mor
       <PackagePath>images</PackagePath>
     </None>
 	 </ItemGroup>
-
+	 
 </Project>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -167,6 +169,17 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
+		/// Write an unsigned short in little endian byte order.
+		/// </summary>
+		private async Task WriteLeShortAsync(int value, CancellationToken cancellationToken)
+		{
+			unchecked
+			{
+				await baseOutputStream_.WriteAsync(new[] {(byte)(value & 0xff), (byte)((value >> 8) & 0xff)}, 0, 2, cancellationToken);
+			}
+		}
+
+		/// <summary>
 		/// Write an int in little endian byte order.
 		/// </summary>
 		private void WriteLeInt(int value)
@@ -181,12 +194,33 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Write an int in little endian byte order.
 		/// </summary>
+		private async Task WriteLeIntAsync(int value, CancellationToken cancellationToken)
+		{
+			await WriteLeShortAsync(value, cancellationToken);
+			await WriteLeShortAsync(value >> 16, cancellationToken);
+		}
+
+		/// <summary>
+		/// Write an int in little endian byte order.
+		/// </summary>
 		private void WriteLeLong(long value)
 		{
 			unchecked
 			{
 				WriteLeInt((int)value);
 				WriteLeInt((int)(value >> 32));
+			}
+		}
+
+		/// <summary>
+		/// Write an int in little endian byte order.
+		/// </summary>
+		private async Task WriteLeLongAsync(long value, CancellationToken cancellationToken)
+		{
+			unchecked
+			{
+				await WriteLeIntAsync((int)value, cancellationToken);
+				await WriteLeIntAsync((int)(value >> 32), cancellationToken);
 			}
 		}
 
@@ -498,6 +532,298 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
+		/// Starts a new Zip entry. It automatically closes the previous
+		/// entry if present.
+		/// All entry elements bar name are optional, but must be correct if present.
+		/// If the compression method is stored and the output is not patchable
+		/// the compression for that entry is automatically changed to deflate level 0
+		/// </summary>
+		/// <param name="entry">
+		/// the entry.
+		/// </param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+		/// <exception cref="System.ArgumentNullException">
+		/// if entry passed is null.
+		/// </exception>
+		/// <exception cref="System.IO.IOException">
+		/// if an I/O error occured.
+		/// </exception>
+		/// <exception cref="System.InvalidOperationException">
+		/// if stream was finished
+		/// </exception>
+		/// <exception cref="ZipException">
+		/// Too many entries in the Zip file<br/>
+		/// Entry name is too long<br/>
+		/// Finish has already been called<br/>
+		/// </exception>
+		/// <exception cref="System.NotImplementedException">
+		/// The Compression method specified for the entry is unsupported.
+		/// </exception>
+		public async Task PutNextEntryAsync(ZipEntry entry, CancellationToken cancellationToken = default)
+		{
+			if (entry == null)
+			{
+				throw new ArgumentNullException(nameof(entry));
+			}
+
+			if (entries == null)
+			{
+				throw new InvalidOperationException("ZipOutputStream was finished");
+			}
+
+			if (curEntry != null)
+			{
+				await CloseEntryAsync(cancellationToken);
+			}
+
+			if (entries.Count == int.MaxValue)
+			{
+				throw new ZipException("Too many entries for Zip file");
+			}
+
+			CompressionMethod method = entry.CompressionMethod;
+
+			// Check that the compression is one that we support
+			if (method != CompressionMethod.Deflated && method != CompressionMethod.Stored)
+			{
+				throw new NotImplementedException("Compression method not supported");
+			}
+
+			// A password must have been set in order to add AES encrypted entries
+			if (entry.AESKeySize > 0 && string.IsNullOrEmpty(this.Password))
+			{
+				throw new InvalidOperationException("The Password property must be set before AES encrypted entries can be added");
+			}
+
+			int compressionLevel = defaultCompressionLevel;
+
+			// Clear flags that the library manages internally
+			entry.Flags &= (int)GeneralBitFlags.UnicodeText;
+			patchEntryHeader = false;
+
+			bool headerInfoAvailable;
+
+			// No need to compress - definitely no data.
+			if (entry.Size == 0)
+			{
+				entry.CompressedSize = entry.Size;
+				entry.Crc = 0;
+				method = CompressionMethod.Stored;
+				headerInfoAvailable = true;
+			}
+			else
+			{
+				headerInfoAvailable = (entry.Size >= 0) && entry.HasCrc && entry.CompressedSize >= 0;
+
+				// Switch to deflation if storing isnt possible.
+				if (method == CompressionMethod.Stored)
+				{
+					if (!headerInfoAvailable)
+					{
+						if (!CanPatchEntries)
+						{
+							// Can't patch entries so storing is not possible.
+							method = CompressionMethod.Deflated;
+							compressionLevel = 0;
+						}
+					}
+					else // entry.size must be > 0
+					{
+						entry.CompressedSize = entry.Size;
+						headerInfoAvailable = entry.HasCrc;
+					}
+				}
+			}
+
+			if (headerInfoAvailable == false)
+			{
+				if (CanPatchEntries == false)
+				{
+					// Only way to record size and compressed size is to append a data descriptor
+					// after compressed data.
+
+					// Stored entries of this form have already been converted to deflating.
+					entry.Flags |= 8;
+				}
+				else
+				{
+					patchEntryHeader = true;
+				}
+			}
+
+			if (Password != null)
+			{
+				entry.IsCrypted = true;
+				if (entry.Crc < 0)
+				{
+					// Need to append a data descriptor as the crc isnt available for use
+					// with encryption, the date is used instead.  Setting the flag
+					// indicates this to the decompressor.
+					entry.Flags |= 8;
+				}
+			}
+
+			entry.Offset = offset;
+			entry.CompressionMethod = (CompressionMethod)method;
+
+			curMethod = method;
+			sizePatchPos = -1;
+
+			if ((useZip64_ == UseZip64.On) || ((entry.Size < 0) && (useZip64_ == UseZip64.Dynamic)))
+			{
+				entry.ForceZip64();
+			}
+
+			// Write the local file header
+			await WriteLeIntAsync(ZipConstants.LocalHeaderSignature, cancellationToken);
+
+			await WriteLeShortAsync(entry.Version, cancellationToken);
+			await WriteLeShortAsync(entry.Flags, cancellationToken);
+			await WriteLeShortAsync((byte)entry.CompressionMethodForHeader, cancellationToken);
+			await WriteLeIntAsync((int)entry.DosTime, cancellationToken);
+
+			// TODO: Refactor header writing.  Its done in several places.
+			if (headerInfoAvailable)
+			{
+				await WriteLeIntAsync((int)entry.Crc, cancellationToken);
+				if (entry.LocalHeaderRequiresZip64)
+				{
+					await WriteLeIntAsync(-1, cancellationToken);
+					await WriteLeIntAsync(-1, cancellationToken);
+				}
+				else
+				{
+					await WriteLeIntAsync((int)entry.CompressedSize + entry.EncryptionOverheadSize, cancellationToken);
+					await WriteLeIntAsync((int)entry.Size, cancellationToken);
+				}
+			}
+			else
+			{
+				if (patchEntryHeader)
+				{
+					crcPatchPos = baseOutputStream_.Position;
+				}
+				await WriteLeIntAsync(0, cancellationToken);  // Crc
+
+				if (patchEntryHeader)
+				{
+					sizePatchPos = baseOutputStream_.Position;
+				}
+
+				// For local header both sizes appear in Zip64 Extended Information
+				if (entry.LocalHeaderRequiresZip64 || patchEntryHeader)
+				{
+					await WriteLeIntAsync(-1, cancellationToken);
+					await WriteLeIntAsync(-1, cancellationToken);
+				}
+				else
+				{
+					await WriteLeIntAsync(0, cancellationToken);  // Compressed size
+					await WriteLeIntAsync(0, cancellationToken);  // Uncompressed size
+				}
+			}
+
+			// Apply any required transforms to the entry name, and then convert to byte array format.
+			TransformEntryName(entry);
+			byte[] name = ZipStrings.ConvertToArray(entry.Flags, entry.Name);
+
+			if (name.Length > 0xFFFF)
+			{
+				throw new ZipException("Entry name too long.");
+			}
+
+			var ed = new ZipExtraData(entry.ExtraData);
+
+			if (entry.LocalHeaderRequiresZip64)
+			{
+				ed.StartNewEntry();
+				if (headerInfoAvailable)
+				{
+					ed.AddLeLong(entry.Size);
+					ed.AddLeLong(entry.CompressedSize + entry.EncryptionOverheadSize);
+				}
+				else
+				{
+					ed.AddLeLong(-1);
+					ed.AddLeLong(-1);
+				}
+				ed.AddNewEntry(1);
+
+				if (!ed.Find(1))
+				{
+					throw new ZipException("Internal error cant find extra data");
+				}
+
+				if (patchEntryHeader)
+				{
+					sizePatchPos = ed.CurrentReadIndex;
+				}
+			}
+			else
+			{
+				ed.Delete(1);
+			}
+
+			if (entry.AESKeySize > 0)
+			{
+				AddExtraDataAES(entry, ed);
+			}
+			byte[] extra = ed.GetEntryData();
+
+			await WriteLeShortAsync(name.Length, cancellationToken);
+			await WriteLeShortAsync(extra.Length, cancellationToken);
+
+			if (name.Length > 0)
+			{
+				await baseOutputStream_.WriteAsync(name, 0, name.Length, cancellationToken);
+			}
+
+			if (entry.LocalHeaderRequiresZip64 && patchEntryHeader)
+			{
+				sizePatchPos += baseOutputStream_.Position;
+			}
+
+			if (extra.Length > 0)
+			{
+				await baseOutputStream_.WriteAsync(extra, 0, extra.Length, cancellationToken);
+			}
+
+			offset += ZipConstants.LocalHeaderBaseSize + name.Length + extra.Length;
+			// Fix offsetOfCentraldir for AES
+			if (entry.AESKeySize > 0)
+				offset += entry.AESOverheadSize;
+
+			// Activate the entry.
+			curEntry = entry;
+			crc.Reset();
+			if (method == CompressionMethod.Deflated)
+			{
+				deflater_.Reset();
+				deflater_.SetLevel(compressionLevel);
+			}
+			size = 0;
+
+			if (entry.IsCrypted)
+			{
+				if (entry.AESKeySize > 0)
+				{
+					await WriteAESHeaderAsync(entry, cancellationToken);
+				}
+				else
+				{
+					if (entry.Crc < 0)
+					{            // so testing Zip will says its ok
+						await WriteEncryptionHeaderAsync(entry.DosTime << 16, cancellationToken);
+					}
+					else
+					{
+						await WriteEncryptionHeaderAsync(entry.Crc, cancellationToken);
+					}
+				}
+			}
+		}
+
+		/// <summary>
 		/// Closes the current entry, updating header and footer information as required
 		/// </summary>
 		/// <exception cref="System.IO.IOException">
@@ -627,6 +953,137 @@ namespace ICSharpCode.SharpZipLib.Zip
 			curEntry = null;
 		}
 
+		/// <summary>
+		/// Closes the current entry, updating header and footer information as required
+		/// </summary>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+		/// <exception cref="System.IO.IOException">
+		/// An I/O error occurs.
+		/// </exception>
+		/// <exception cref="System.InvalidOperationException">
+		/// No entry is active.
+		/// </exception>
+		public async Task CloseEntryAsync(CancellationToken cancellationToken)
+		{
+			if (curEntry == null)
+			{
+				throw new InvalidOperationException("No open entry");
+			}
+
+			long csize = size;
+
+			// First finish the deflater, if appropriate
+			if (curMethod == CompressionMethod.Deflated)
+			{
+				if (size >= 0)
+				{
+					await base.FinishAsync(cancellationToken);
+					csize = deflater_.TotalOut;
+				}
+				else
+				{
+					deflater_.Reset();
+				}
+			}
+			else if (curMethod == CompressionMethod.Stored)
+			{
+				// This is done by Finsh() for Deflated entries, but we need to do it
+				// ourselves for Stored ones
+				base.GetAuthCodeIfAES();
+			}
+
+			// Write the AES Authentication Code (a hash of the compressed and encrypted data)
+			if (curEntry.AESKeySize > 0)
+			{
+				await baseOutputStream_.WriteAsync(AESAuthCode, 0, 10, cancellationToken);
+			}
+
+			if (curEntry.Size < 0)
+			{
+				curEntry.Size = size;
+			}
+			else if (curEntry.Size != size)
+			{
+				throw new ZipException("size was " + size + ", but I expected " + curEntry.Size);
+			}
+
+			if (curEntry.CompressedSize < 0)
+			{
+				curEntry.CompressedSize = csize;
+			}
+			else if (curEntry.CompressedSize != csize)
+			{
+				throw new ZipException("compressed size was " + csize + ", but I expected " + curEntry.CompressedSize);
+			}
+
+			if (curEntry.Crc < 0)
+			{
+				curEntry.Crc = crc.Value;
+			}
+			else if (curEntry.Crc != crc.Value)
+			{
+				throw new ZipException("crc was " + crc.Value + ", but I expected " + curEntry.Crc);
+			}
+
+			offset += csize;
+
+			if (curEntry.IsCrypted)
+			{
+				curEntry.CompressedSize += curEntry.EncryptionOverheadSize;
+			}
+
+			// Patch the header if possible
+			if (patchEntryHeader)
+			{
+				patchEntryHeader = false;
+
+				long curPos = baseOutputStream_.Position;
+				baseOutputStream_.Seek(crcPatchPos, SeekOrigin.Begin);
+				await WriteLeIntAsync((int)curEntry.Crc, cancellationToken);
+
+				if (curEntry.LocalHeaderRequiresZip64)
+				{
+					if (sizePatchPos == -1)
+					{
+						throw new ZipException("Entry requires zip64 but this has been turned off");
+					}
+
+					baseOutputStream_.Seek(sizePatchPos, SeekOrigin.Begin);
+					await WriteLeLongAsync(curEntry.Size, cancellationToken);
+					await WriteLeLongAsync(curEntry.CompressedSize, cancellationToken);
+				}
+				else
+				{
+					await WriteLeIntAsync((int)curEntry.CompressedSize, cancellationToken);
+					await WriteLeIntAsync((int)curEntry.Size, cancellationToken);
+				}
+				baseOutputStream_.Seek(curPos, SeekOrigin.Begin);
+			}
+
+			// Add data descriptor if flagged as required
+			if ((curEntry.Flags & 8) != 0)
+			{
+				await WriteLeIntAsync(ZipConstants.DataDescriptorSignature, cancellationToken);
+				await WriteLeIntAsync(unchecked((int)curEntry.Crc), cancellationToken);
+
+				if (curEntry.LocalHeaderRequiresZip64)
+				{
+					await WriteLeLongAsync(curEntry.CompressedSize, cancellationToken);
+					await WriteLeLongAsync(curEntry.Size, cancellationToken);
+					offset += ZipConstants.Zip64DataDescriptorSize;
+				}
+				else
+				{
+					await WriteLeIntAsync((int)curEntry.CompressedSize, cancellationToken);
+					await WriteLeIntAsync((int)curEntry.Size, cancellationToken);
+					offset += ZipConstants.DataDescriptorSize;
+				}
+			}
+
+			entries.Add(curEntry);
+			curEntry = null;
+		}
+
 		private void WriteEncryptionHeader(long crcValue)
 		{
 			offset += ZipConstants.CryptoHeaderSize;
@@ -643,6 +1100,24 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			EncryptBlock(cryptBuffer, 0, cryptBuffer.Length);
 			baseOutputStream_.Write(cryptBuffer, 0, cryptBuffer.Length);
+		}
+
+		private async Task WriteEncryptionHeaderAsync(long crcValue, CancellationToken cancellationToken)
+		{
+			offset += ZipConstants.CryptoHeaderSize;
+
+			InitializePassword(Password);
+
+			byte[] cryptBuffer = new byte[ZipConstants.CryptoHeaderSize];
+			using (var rng = new RNGCryptoServiceProvider())
+			{
+				rng.GetBytes(cryptBuffer);
+			}
+
+			cryptBuffer[11] = (byte)(crcValue >> 24);
+
+			EncryptBlock(cryptBuffer, 0, cryptBuffer.Length);
+			await baseOutputStream_.WriteAsync(cryptBuffer, 0, cryptBuffer.Length, cancellationToken);
 		}
 
 		private static void AddExtraDataAES(ZipEntry entry, ZipExtraData extraData)
@@ -681,6 +1156,28 @@ namespace ICSharpCode.SharpZipLib.Zip
 			// salt value, password verification value, encrypted data, and authentication code.
 			baseOutputStream_.Write(salt, 0, salt.Length);
 			baseOutputStream_.Write(pwdVerifier, 0, pwdVerifier.Length);
+		}
+
+		// Replaces WriteEncryptionHeader for AES
+		//
+		private async Task WriteAESHeaderAsync(ZipEntry entry, CancellationToken cancellationToken)
+		{
+			byte[] salt;
+			byte[] pwdVerifier;
+			InitializeAESPassword(entry, Password, out salt, out pwdVerifier);
+			// File format for AES:
+			// Size (bytes)   Content
+			// ------------   -------
+			// Variable       Salt value
+			// 2              Password verification value
+			// Variable       Encrypted file data
+			// 10             Authentication code
+			//
+			// Value in the "compressed size" fields of the local file header and the central directory entry
+			// is the total size of all the items listed above. In other words, it is the total size of the
+			// salt value, password verification value, encrypted data, and authentication code.
+			await baseOutputStream_.WriteAsync(salt, 0, salt.Length, cancellationToken);
+			await baseOutputStream_.WriteAsync(pwdVerifier, 0, pwdVerifier.Length, cancellationToken);
 		}
 
 		/// <summary>
@@ -920,6 +1417,179 @@ namespace ICSharpCode.SharpZipLib.Zip
 			using (ZipHelperStream zhs = new ZipHelperStream(baseOutputStream_))
 			{
 				zhs.WriteEndOfCentralDirectory(numEntries, sizeEntries, offset, zipComment);
+			}
+
+			entries = null;
+		}
+
+		/// <summary>
+		/// Finishes the stream.  This will write the central directory at the
+		/// end of the zip file and flush the stream.
+		/// </summary>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
+		/// <remarks>
+		/// This is automatically called when the stream is closed.
+		/// </remarks>
+		/// <exception cref="System.IO.IOException">
+		/// An I/O error occurs.
+		/// </exception>
+		/// <exception cref="ZipException">
+		/// Comment exceeds the maximum length<br/>
+		/// Entry name exceeds the maximum length
+		/// </exception>
+		public override async Task FinishAsync(CancellationToken cancellationToken)
+		{
+			if (entries == null)
+			{
+				return;
+			}
+
+			if (curEntry != null)
+			{
+				await CloseEntryAsync(cancellationToken);
+			}
+
+			long numEntries = entries.Count;
+			long sizeEntries = 0;
+
+			foreach (ZipEntry entry in entries)
+			{
+				await WriteLeIntAsync(ZipConstants.CentralHeaderSignature, cancellationToken);
+				await WriteLeShortAsync((entry.HostSystem << 8) | entry.VersionMadeBy, cancellationToken);
+				await WriteLeShortAsync(entry.Version, cancellationToken);
+				await WriteLeShortAsync(entry.Flags, cancellationToken);
+				await WriteLeShortAsync((short)entry.CompressionMethodForHeader, cancellationToken);
+				await WriteLeIntAsync((int)entry.DosTime, cancellationToken);
+				await WriteLeIntAsync((int)entry.Crc, cancellationToken);
+
+				if (entry.IsZip64Forced() ||
+					(entry.CompressedSize >= uint.MaxValue))
+				{
+					await WriteLeIntAsync(-1, cancellationToken);
+				}
+				else
+				{
+					await WriteLeIntAsync((int)entry.CompressedSize, cancellationToken);
+				}
+
+				if (entry.IsZip64Forced() ||
+					(entry.Size >= uint.MaxValue))
+				{
+					await WriteLeIntAsync(-1, cancellationToken);
+				}
+				else
+				{
+					await WriteLeIntAsync((int)entry.Size, cancellationToken);
+				}
+
+				byte[] name = ZipStrings.ConvertToArray(entry.Flags, entry.Name);
+
+				if (name.Length > 0xffff)
+				{
+					throw new ZipException("Name too long.");
+				}
+
+				var ed = new ZipExtraData(entry.ExtraData);
+
+				if (entry.CentralHeaderRequiresZip64)
+				{
+					ed.StartNewEntry();
+					if (entry.IsZip64Forced() ||
+						(entry.Size >= 0xffffffff))
+					{
+						ed.AddLeLong(entry.Size);
+					}
+
+					if (entry.IsZip64Forced() ||
+						(entry.CompressedSize >= 0xffffffff))
+					{
+						ed.AddLeLong(entry.CompressedSize);
+					}
+
+					if (entry.Offset >= 0xffffffff)
+					{
+						ed.AddLeLong(entry.Offset);
+					}
+
+					ed.AddNewEntry(1);
+				}
+				else
+				{
+					ed.Delete(1);
+				}
+
+				if (entry.AESKeySize > 0)
+				{
+					AddExtraDataAES(entry, ed);
+				}
+				byte[] extra = ed.GetEntryData();
+
+				byte[] entryComment =
+					(entry.Comment != null) ?
+					ZipStrings.ConvertToArray(entry.Flags, entry.Comment) :
+					new byte[0];
+
+				if (entryComment.Length > 0xffff)
+				{
+					throw new ZipException("Comment too long.");
+				}
+
+				await WriteLeShortAsync(name.Length, cancellationToken);
+				await WriteLeShortAsync(extra.Length, cancellationToken);
+				await WriteLeShortAsync(entryComment.Length, cancellationToken);
+				await WriteLeShortAsync(0, cancellationToken);    // disk number
+				await WriteLeShortAsync(0, cancellationToken);    // internal file attributes
+									// external file attributes
+
+				if (entry.ExternalFileAttributes != -1)
+				{
+					await WriteLeIntAsync(entry.ExternalFileAttributes, cancellationToken);
+				}
+				else
+				{
+					if (entry.IsDirectory)
+					{                         // mark entry as directory (from nikolam.AT.perfectinfo.com)
+						await WriteLeIntAsync(16, cancellationToken);
+					}
+					else
+					{
+						await WriteLeIntAsync(0, cancellationToken);
+					}
+				}
+
+				if (entry.Offset >= uint.MaxValue)
+				{
+					await WriteLeIntAsync(-1, cancellationToken);
+				}
+				else
+				{
+					await WriteLeIntAsync((int)entry.Offset, cancellationToken);
+				}
+
+				if (name.Length > 0)
+				{
+					await baseOutputStream_.WriteAsync(name, 0, name.Length, cancellationToken);
+				}
+
+				if (extra.Length > 0)
+				{
+					await baseOutputStream_.WriteAsync(extra, 0, extra.Length, cancellationToken);
+				}
+
+				if (entryComment.Length > 0)
+				{
+					await baseOutputStream_.WriteAsync(entryComment, 0, entryComment.Length, cancellationToken);
+				}
+
+				sizeEntries += ZipConstants.CentralHeaderBaseSize + name.Length + extra.Length + entryComment.Length;
+			}
+
+#if NETSTANDARD2_1
+			await
+#endif
+			using (ZipHelperStream zhs = new ZipHelperStream(baseOutputStream_))
+			{
+				await zhs.WriteEndOfCentralDirectoryAsync(numEntries, sizeEntries, offset, zipComment, cancellationToken);
 			}
 
 			entries = null;


### PR DESCRIPTION
This is a very rough first pass at adding async support to ZipOutputStream.

All method doing synchronous stream writes have been duplicated with an asynchronous counterpart, starting from `ZipOutputStream.PutNextEntryAsync()`. Unfortunately, this makes a lot of duplicated code but is unavoidable to have both sync + async code paths.

.NET Standard 2.1 has been added to the target frameworks. It's required to get full async support with `Stream.DisposeAsync()`.

New unit tests must be written to cover the new async code paths.

Fixes #223

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
