### PR TITLE
Add .NET Standard 2.1 target framework

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         configuration: [debug, release]
         os: [ubuntu, windows, macos]
-        libtarget: [netstandard2]
+        libtarget: [netstandard2.0, netstandard2.1]
         testtarget: [netcoreapp3.1]
         include:
           - configuration: debug
@@ -31,7 +31,6 @@ jobs:
     - uses: actions/checkout@v2
       
     - name: Setup .NET Core
-      if: matrix.libtarget == 'netstandard2'
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         configuration: [debug, release]
         os: [ubuntu, windows, macos]
-        target: [netstandard2]
+        target: [netstandard2.0, netstandard2.1]
         include:
           - configuration: Debug
             os: windows
@@ -24,7 +24,6 @@ jobs:
     - uses: actions/checkout@v2
       
     - name: Setup .NET Core
-      if: matrix.target == 'netstandard2'
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
@@ -92,8 +91,10 @@ jobs:
       with:
         dotnet-version: '3.1.x'
         
-    - name: Build library for .NET Standard 2
-      run: dotnet build -c Release -f netstandard2 src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+    - name: Build library for .NET Standard 2.0
+      run: dotnet build -c Release -f netstandard2.0 src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+    - name: Build library for .NET Standard 2.1
+      run: dotnet build -c Release -f netstandard2.1 src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
     - name: Build library for .NET Framework 4.5
       run: dotnet build -c Release -f net45 src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ install:
 # - nuget restore ICSharpCode.SharpZipLib.sln
 # - nuget install NUnit.Console -Version 3.8.0 -OutputDirectory _testRunner
 script:
-  - dotnet build -f netstandard2 src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+  - dotnet build -f netstandard2.0 src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
   - dotnet run -c Debug -f netcoreapp2 -p test/ICSharpCode.SharpZipLib.TestBootstrapper/ICSharpCode.SharpZipLib.TestBootstrapper.csproj -- --where "class !~ WindowsNameTransformHandling & test !~ ZipEntryFactoryHandling.CreatedValues & test !~ ZipNameTransformHandling.FilenameCleaning" --result=docs/nunit3-test-results-debug.xml
   - dotnet run -c Release -f netcoreapp2 -p test/ICSharpCode.SharpZipLib.TestBootstrapper/ICSharpCode.SharpZipLib.TestBootstrapper.csproj -- --where "class !~ WindowsNameTransformHandling & test !~ ZipEntryFactoryHandling.CreatedValues & test !~ ZipNameTransformHandling.FilenameCleaning" --result=docs\nunit3-test-results-release.xml
 #  - dotnet test test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
 #  - xbuild /p:Configuration=Release ICSharpCode.SharpZipLib.sln
 #  - mono ./packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe --framework=mono-4.0 --labels=All --result=./Documentation/nunit3-test-results-travis.xml ./bin/Release/ICSharpCode.SharpZipLib.Tests.dll
 after_script:
-  - dotnet pack -f netstandard2 -o _dist/ src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+  - dotnet pack -f netstandard2.0 -o _dist/ src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
 #cache:
 #  directories:
 #    - bin

--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net45</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../../assets/ICSharpCode.SharpZipLib.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Also fix the .NET Standard 2.0 target framework moniker: netstandard2.0 instead of netstandard2, see https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks