### PR TITLE
AES decryption support in ZipInputStream

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -40,7 +40,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		}
 
 		// The final n bytes of the AES stream contain the Auth Code.
-		public const int AUTH_CODE_LENGTH = 10;
+		public const int AUTH_CODE_LENGTH = Zip.ZipConstants.AESAuthCodeLength;
 
 		// Blocksize is always 16 here, even for AES-256 which has transform.InputBlockSize of 32.
 		private const int CRYPTO_BLOCK_SIZE = 16;

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -8,8 +8,6 @@ namespace ICSharpCode.SharpZipLib.Encryption
 	/// </summary>
 	internal class ZipAESTransform : ICryptoTransform
 	{
-		private const int PWD_VER_LENGTH = 2;
-
 		// WinZip use iteration count of 1000 for PBKDF2 key generation
 		private const int KEY_ROUNDS = 1000;
 
@@ -28,6 +26,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		private byte[] _authCode = null;
 
 		private bool _writeMode;
+		private Action<int> _appendHmac = remaining => { };
 
 		/// <summary>
 		/// Constructor.
@@ -63,11 +62,28 @@ namespace ICSharpCode.SharpZipLib.Encryption
 
 			// Use empty IV for AES
 			_encryptor = rm.CreateEncryptor(key1bytes, new byte[16]);
-			_pwdVerifier = pdb.GetBytes(PWD_VER_LENGTH);
+			_pwdVerifier = pdb.GetBytes(Zip.ZipConstants.AESPasswordVerifyLength);
 			//
 			_hmacsha1 = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA1, key2bytes);
 			_writeMode = writeMode;
 		}
+
+		/// <summary>
+		/// Append all of the last transformed input data to the HMAC.
+		/// </summary>
+		public void AppendAllPending()
+		{
+			_appendHmac(0);
+		}
+		
+		/// <summary>
+		/// Append all except the number of bytes specified by remaining of the last transformed input data to the HMAC.
+		/// </summary>
+		/// <param name="remaining">The number of bytes not to be added to the HMAC. The excluded bytes are form the end.</param>
+		public void AppendFinal(int remaining)
+		{
+			_appendHmac(remaining);
+		}		
 
 		/// <summary>
 		/// Implement the ICryptoTransform method.
@@ -78,8 +94,16 @@ namespace ICSharpCode.SharpZipLib.Encryption
 			// This does not change the inputBuffer. Do this before decryption for read mode.
 			if (!_writeMode)
 			{
-				_hmacsha1.AppendData(inputBuffer, inputOffset, inputCount);
+				if (!ManualHmac)
+				{
+					_hmacsha1.AppendData(inputBuffer, inputOffset, inputCount);
+				}
+				else
+				{
+					_appendHmac = remaining => _hmacsha1.AppendData(inputBuffer, inputOffset, inputCount - remaining);
+				}
 			}
+
 			// Encrypt with AES in CTR mode. Regards to Dr Brian Gladman for this.
 			int ix = 0;
 			while (ix < inputCount)
@@ -167,6 +191,13 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		/// Gets a value indicating whether the current transform can be reused.
 		/// </summary>
 		public bool CanReuseTransform => true;
+
+		/// <summary>
+		/// Gets of sets a value indicating if the HMAC is updates on every read of if updating the HMAC has to be controlled manually
+		/// Manual control of HMAC is needed in case not all the Transformed data should be automatically added to the HMAC.
+		/// E.g. because its not know how much data belongs to the current entry before the data is decrypted and analyzed. 
+		/// </summary>
+		public bool ManualHmac { get; set; }
 
 		/// <summary>
 		/// Cleanup internal state.

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
+using ICSharpCode.SharpZipLib.Encryption;
 
 namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 {
@@ -92,8 +93,24 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		public int Available
 		{
 			get { return available; }
-			set { available = value; }
+			set
+			{
+				if (cryptoTransform is ZipAESTransform ct)
+				{
+					ct.AppendFinal(value);
+				}
+				
+				available = value;
+			}
 		}
+
+		/// <summary>
+		/// A limitation how much data is decrypted. If null all the data in the input buffer will be decrypted.
+		/// Setting limit is important in case the HMAC has to be calculated for each zip entry. In that case
+		/// it is not possible to decrypt all available data in the input buffer, and only the data
+		/// belonging to the current zip entry must be decrypted so that the HMAC is correctly calculated. 
+		/// </summary>
+		internal int? DecryptionLimit { get; set; }
 
 		/// <summary>
 		/// Call <see cref="Inflater.SetInput(byte[], int, int)"/> passing the current clear text buffer contents.
@@ -113,6 +130,11 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// </summary>
 		public void Fill()
 		{
+			if (cryptoTransform is ZipAESTransform ct)
+			{
+				ct.AppendAllPending();
+			}
+
 			rawLength = 0;
 			int toRead = rawData.Length;
 
@@ -127,13 +149,11 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 				toRead -= count;
 			}
 
+			clearTextLength = rawLength;
 			if (cryptoTransform != null)
 			{
-				clearTextLength = cryptoTransform.TransformBlock(rawData, 0, rawLength, clearText, 0);
-			}
-			else
-			{
-				clearTextLength = rawLength;
+				var size = CalculateDecryptionSize(rawLength);
+				cryptoTransform.TransformBlock(rawData, 0, size, clearText, 0);
 			}
 
 			available = clearTextLength;
@@ -290,7 +310,9 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 					clearTextLength = rawLength;
 					if (available > 0)
 					{
-						cryptoTransform.TransformBlock(rawData, rawLength - available, available, clearText, rawLength - available);
+						var size = CalculateDecryptionSize(available);
+
+						cryptoTransform.TransformBlock(rawData, rawLength - available, size, clearText, rawLength - available);
 					}
 				}
 				else
@@ -299,6 +321,19 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 					clearTextLength = rawLength;
 				}
 			}
+		}
+
+		private int CalculateDecryptionSize(int availableBufferSize)
+		{
+			int size = DecryptionLimit ?? availableBufferSize;
+			size = Math.Min(size, availableBufferSize);
+			
+			if (DecryptionLimit.HasValue)
+			{
+				DecryptionLimit -= size;
+			}
+
+			return size;
 		}
 
 		#region Instance Fields
@@ -459,9 +494,10 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// <summary>
 		/// Clear any cryptographic state.
 		/// </summary>
-		protected void StopDecrypting()
+		protected virtual void StopDecrypting()
 		{
 			inputBuffer.CryptoTransform = null;
+			inputBuffer.DecryptionLimit = null;
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -325,13 +325,13 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 
 		private int CalculateDecryptionSize(int availableBufferSize)
 		{
-			int size = DecryptionLimit ?? availableBufferSize;
-			size = Math.Min(size, availableBufferSize);
-			
-			if (DecryptionLimit.HasValue)
+			if (!DecryptionLimit.HasValue)
 			{
-				DecryptionLimit -= size;
+				return availableBufferSize;
 			}
+			
+			var size = Math.Min(DecryptionLimit.Value, availableBufferSize);
+			DecryptionLimit -= size;
 
 			return size;
 		}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -367,6 +367,16 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public const int CRYPTO_HEADER_SIZE = 12;
 
 		/// <summary>
+		/// The number of bytes in the WinZipAes Auth Code.
+		/// </summary>
+		internal const int AESAuthCodeLength = 10;
+
+		/// <summary>
+		/// The number of bytes in the password verifier for WinZipAes.
+		/// </summary>
+		internal const int AESPasswordVerifyLength = 2;
+
+		/// <summary>
 		/// The size of the Zip64 central directory locator.
 		/// </summary>
 		public const int Zip64EndOfCentralDirectoryLocatorSize = 20;

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -825,6 +825,19 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
+		/// Gets the AES Version
+		/// 1: AE-1
+		/// 2: AE-2
+		/// </summary>
+		public int AESVersion
+		{
+			get
+			{
+				return _aesVer;
+			}
+		}
+
+		/// <summary>
 		/// AES Encryption strength for storage in extra data in entry header.
 		/// 1 is 128 bit, 2 is 192 bit, 3 is 256 bit.
 		/// </summary>
@@ -1149,7 +1162,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 		private bool forceZip64_;
 		private byte cryptoCheckValue_;
-		private int _aesVer;                            // Version number (2 = AE-2 ?). Assigned but not used.
+		private int _aesVer;                            // Version number (1 = AE-1, 2 = AE-2)
 		private int _aesEncryptionStrength;             // Encryption strength 1 = 128 2 = 192 3 = 256
 
 		#endregion Instance Fields

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -74,10 +74,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 		private ZipEntry entry;
 
 		private long size;
-		private CompressionMethod method;
 		private int flags;
 		private string password;
 		private readonly StringCodec _stringCodec = ZipStrings.GetStringCodec();
+		private ZipAESTransform cryptoTransform;
 
 		#endregion Instance Fields
 
@@ -141,17 +141,22 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Is the compression method for the specified entry supported?
 		/// </summary>
-		/// <remarks>
-		/// Uses entry.CompressionMethodForHeader so that entries of type WinZipAES will be rejected. 
-		/// </remarks>
 		/// <param name="entry">the entry to check.</param>
 		/// <returns>true if the compression method is supported, false if not.</returns>
 		private static bool IsEntryCompressionMethodSupported(ZipEntry entry)
 		{
-			var entryCompressionMethod = entry.CompressionMethodForHeader;
+			var entryCompressionMethodForHeader = entry.CompressionMethodForHeader;
+			var entryCompressionMethod = entry.CompressionMethod;
 
-			return entryCompressionMethod == CompressionMethod.Deflated ||
-				   entryCompressionMethod == CompressionMethod.Stored;
+			var compressionMethodSupported = 
+				entryCompressionMethod == CompressionMethod.Deflated ||
+				entryCompressionMethod == CompressionMethod.Stored;
+			var entryCompressionMethodForHeaderSupported = 
+				entryCompressionMethodForHeader == CompressionMethod.Deflated ||
+				entryCompressionMethodForHeader == CompressionMethod.Stored ||
+				entryCompressionMethodForHeader == CompressionMethod.WinZipAES;
+
+			return compressionMethodSupported && entryCompressionMethodForHeaderSupported;
 		}
 
 		/// <summary>
@@ -191,7 +196,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			var versionRequiredToExtract = (short)inputBuffer.ReadLeShort();
 
 			flags = inputBuffer.ReadLeShort();
-			method = (CompressionMethod)inputBuffer.ReadLeShort();
+			var method = (CompressionMethod)inputBuffer.ReadLeShort();
 			var dostime = (uint)inputBuffer.ReadLeInt();
 			int crc2 = inputBuffer.ReadLeInt();
 			csize = inputBuffer.ReadLeInt();
@@ -267,9 +272,20 @@ namespace ICSharpCode.SharpZipLib.Zip
 				size = entry.Size;
 			}
 
-			if (method == CompressionMethod.Stored && (!isCrypted && csize != size || (isCrypted && csize - ZipConstants.CryptoHeaderSize != size)))
+			if (method == CompressionMethod.Stored)
+			{ 
+				if (!isCrypted && csize != size || (isCrypted && csize - ZipConstants.CryptoHeaderSize != size))
+				{
+					throw new ZipException("Stored, but compressed != uncompressed");
+				}
+			}
+			else if (method == CompressionMethod.WinZipAES && entry.CompressionMethod == CompressionMethod.Stored)
 			{
-				throw new ZipException("Stored, but compressed != uncompressed");
+				var sizeWithoutAesOverhead = csize - (entry.AESSaltLen + ZipConstants.AESPasswordVerifyLength + ZipConstants.AESAuthCodeLength);
+				if (sizeWithoutAesOverhead != size)
+				{
+					throw new ZipException("Stored, but compressed != uncompressed");
+				}
 			}
 
 			// Determine how to handle reading of data if this is attempted.
@@ -360,12 +376,49 @@ namespace ICSharpCode.SharpZipLib.Zip
 		}
 
 		/// <summary>
+		/// Complete any decryption processing and clear any cryptographic state.
+		/// </summary>
+		private void StopDecrypting(bool testAESAuthCode)
+		{
+			StopDecrypting();
+
+			if (testAESAuthCode && entry.AESKeySize != 0)
+			{
+				byte[] authBytes = new byte[ZipConstants.AESAuthCodeLength];
+				int authBytesRead = inputBuffer.ReadRawBuffer(authBytes, 0, authBytes.Length);
+
+				if (authBytesRead < ZipConstants.AESAuthCodeLength)
+				{
+					throw new ZipException("Internal error missed auth code"); // Coding bug
+				}
+
+				// Final block done. Check Auth code.
+				byte[] calcAuthCode = this.cryptoTransform.GetAuthCode();
+				for (int i = 0; i < ZipConstants.AESAuthCodeLength; i++)
+				{
+					if (calcAuthCode[i] != authBytes[i])
+					{
+						throw new ZipException("AES Authentication Code does not match. This is a super-CRC check on the data in the file after compression and encryption. The file may be damaged or tampered.");
+					}
+				}
+
+				// Dispose the transform?
+			}
+		}
+
+		/// <summary>
 		/// Complete cleanup as the final part of closing.
 		/// </summary>
 		/// <param name="testCrc">True if the crc value should be tested</param>
 		private void CompleteCloseEntry(bool testCrc)
 		{
-			StopDecrypting();
+			StopDecrypting(testCrc);
+
+			// AE-2 does not have a CRC by specification. Do not check CRC in this case.
+			if (entry.AESKeySize != 0 && entry.AESVersion == 2)
+			{
+				testCrc = false;
+			}
 
 			if ((flags & 8) != 0)
 			{
@@ -382,7 +435,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			crc.Reset();
 
-			if (method == CompressionMethod.Deflated)
+			if (entry.CompressionMethod == CompressionMethod.Deflated)
 			{
 				inf.Reset();
 			}
@@ -409,8 +462,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				return;
 			}
-
-			if (method == CompressionMethod.Deflated)
+			
+			if (entry.CompressionMethod == CompressionMethod.Deflated)
 			{
 				if ((flags & 8) != 0)
 				{
@@ -425,6 +478,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 
 				csize -= inf.TotalIn;
+				
 				inputBuffer.Available += inf.RemainingInput;
 			}
 
@@ -556,27 +610,69 @@ namespace ICSharpCode.SharpZipLib.Zip
 					throw new ZipException("No password set.");
 				}
 
-				// Generate and set crypto transform...
-				var managed = new PkzipClassicManaged();
-				byte[] key = PkzipClassic.GenerateKeys(_stringCodec.ZipCryptoEncoding.GetBytes(password));
-
-				inputBuffer.CryptoTransform = managed.CreateDecryptor(key, null);
-
-				byte[] cryptbuffer = new byte[ZipConstants.CryptoHeaderSize];
-				inputBuffer.ReadClearTextBuffer(cryptbuffer, 0, ZipConstants.CryptoHeaderSize);
-
-				if (cryptbuffer[ZipConstants.CryptoHeaderSize - 1] != entry.CryptoCheckValue)
+				if (entry.AESKeySize == 0)
 				{
-					throw new ZipException("Invalid password");
+					// Generate and set crypto transform...
+					var managed = new PkzipClassicManaged();
+					byte[] key = PkzipClassic.GenerateKeys(_stringCodec.ZipCryptoEncoding.GetBytes(password));
+
+					inputBuffer.CryptoTransform = managed.CreateDecryptor(key, null);
+					inputBuffer.DecryptionLimit = null;
+
+					byte[] cryptbuffer = new byte[ZipConstants.CryptoHeaderSize];
+					inputBuffer.ReadClearTextBuffer(cryptbuffer, 0, ZipConstants.CryptoHeaderSize);
+
+					if (cryptbuffer[ZipConstants.CryptoHeaderSize - 1] != entry.CryptoCheckValue)
+					{
+						throw new ZipException("Invalid password");
+					}
+
+					if (csize >= ZipConstants.CryptoHeaderSize)
+					{
+						csize -= ZipConstants.CryptoHeaderSize;
+					}
+					else if (!usesDescriptor)
+					{
+						throw new ZipException($"Entry compressed size {csize} too small for encryption");
+					}
 				}
+				else
+				{
+					int saltLen = entry.AESSaltLen;
+					byte[] saltBytes = new byte[saltLen];
+					int saltIn = inputBuffer.ReadRawBuffer(saltBytes, 0, saltLen);
 
-				if (csize >= ZipConstants.CryptoHeaderSize)
-				{
-					csize -= ZipConstants.CryptoHeaderSize;
-				}
-				else if (!usesDescriptor)
-				{
-					throw new ZipException($"Entry compressed size {csize} too small for encryption");
+					if (saltIn != saltLen)
+					{
+						throw new ZipException("AES Salt expected " + saltLen + " got " + saltIn);
+					}
+					
+					//
+					byte[] pwdVerifyRead = new byte[ZipConstants.AESPasswordVerifyLength];
+					int pwdBytesRead = inputBuffer.ReadRawBuffer(pwdVerifyRead, 0, pwdVerifyRead.Length);
+
+					if (pwdBytesRead != pwdVerifyRead.Length)
+					{
+						throw new EndOfStreamException();
+					}
+
+					int blockSize = entry.AESKeySize / 8;   // bits to bytes
+
+					var decryptor = new ZipAESTransform(password, saltBytes, blockSize, false);
+					decryptor.ManualHmac = csize <= 0;
+					byte[] pwdVerifyCalc = decryptor.PwdVerifier;
+					if (pwdVerifyCalc[0] != pwdVerifyRead[0] || pwdVerifyCalc[1] != pwdVerifyRead[1])
+					{
+						throw new ZipException("Invalid password for AES");
+					}
+
+					// The AES data has saltLen+AESPasswordVerifyLength bytes as a header, and AESAuthCodeLength bytes
+					// as a footer.
+					csize -= (saltLen + ZipConstants.AESPasswordVerifyLength + ZipConstants.AESAuthCodeLength);
+					inputBuffer.DecryptionLimit = csize >= 0 ? (int?)csize : null;
+					
+					inputBuffer.CryptoTransform = decryptor;
+					this.cryptoTransform = decryptor;
 				}
 			}
 			else
@@ -586,13 +682,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			if (csize > 0 || usesDescriptor)
 			{
-				if (method == CompressionMethod.Deflated && inputBuffer.Available > 0)
+				if (entry.CompressionMethod == CompressionMethod.Deflated && inputBuffer.Available > 0)
 				{
 					inputBuffer.SetInflaterInput(inf);
 				}
 
 				// It's not possible to know how many bytes to read when using "Stored" compression (unless using encryption)
-				if (!entry.IsCrypted && method == CompressionMethod.Stored && usesDescriptor)
+				if (!entry.IsCrypted && entry.CompressionMethod == CompressionMethod.Stored && usesDescriptor)
 				{
 					internalReader = StoredDescriptorEntry;
 					return StoredDescriptorEntry(destination, offset, count);
@@ -680,7 +776,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			bool finished = false;
 
-			switch (method)
+			switch (entry.CompressionMethod)
 			{
 				case CompressionMethod.Deflated:
 					count = base.Read(buffer, offset, count);
@@ -731,6 +827,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 						}
 					}
 					break;
+				default:
+					throw new InvalidOperationException("Internal Error: Unsupported compression method encountered.");
 			}
 
 			if (count > 0)

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -443,6 +443,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 			if (Password != null)
 			{
 				entry.IsCrypted = true;
+				
+				// In case of AES the CRC is always 0 according to specification.
+				// This also prevents that a data descriptor is needed for the CRC as it is the case for other
+				// password protected zip files. AES uses a 10 Byte auth code instead of the CRC
+				if (entry.AESKeySize != 0)
+				{
+					entry.Crc = 0;
+				}
+
 				if (entry.Crc < 0)
 				{
 					// Need to append a data descriptor as the crc isnt available for use


### PR DESCRIPTION
This pull request continues the work of @Numpsy and replaces Pull Request #381 

The issue with the HMAC calculation in the original pull request was that it always decrypted and calculated HMAC for the entire input buffer. But actually it should only decrypt and calculate the HMAC up to the compressed size of the current entry. This issue is fixed now and all the unit tests pass. AES encrypted Zips can now be decrypted and decompressed using the ZipInput Stream.

Original Information from #381

> I started looking at this and then haven't had time to try to finish it yet, so here it is in case anyone has any ideas.
> 
> The basic decryption seems to be ok, but the auth code checking is disabled as it doesn't work. I think the issue is the way that inflater input buffer runs all its data through the crypto transform rather than just the part which is actually encrypted, so the auth code calculation in the AES transform gets the wrong result.
> Not sure of the best way to handle it - might need changes in the input buffer, or a different approach to calculating the value?
> 
> The changes also have a couple of more minor changes in separate commits, in case they're useful on their own.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
