### PR TITLE
skip CRC calculation for AES zip entries

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipHelperStream.cs
@@ -565,7 +565,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			if ((entry.Flags & (int)GeneralBitFlags.Descriptor) != 0)
 			{
 				// The signature is not PKZIP originally but is now described as optional
-				// in the PKZIP Appnote documenting trhe format.
+				// in the PKZIP Appnote documenting the format.
 				WriteLEInt(ZipConstants.DataDescriptorSignature);
 				WriteLEInt(unchecked((int)(entry.Crc)));
 
@@ -599,7 +599,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			int intValue = ReadLEInt();
 
 			// In theory this may not be a descriptor according to PKZIP appnote.
-			// In practise its always there.
+			// In practice its always there.
 			if (intValue != ZipConstants.DataDescriptorSignature)
 			{
 				throw new ZipException("Data descriptor signature not found");

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -500,6 +500,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Closes the current entry, updating header and footer information as required
 		/// </summary>
+		/// <exception cref="ZipException">
+		/// Invalid entry field values.
+		/// </exception>
 		/// <exception cref="System.IO.IOException">
 		/// An I/O error occurs.
 		/// </exception>
@@ -530,7 +533,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 			else if (curMethod == CompressionMethod.Stored)
 			{
-				// This is done by Finsh() for Deflated entries, but we need to do it
+				// This is done by Finish() for Deflated entries, but we need to do it
 				// ourselves for Stored ones
 				base.GetAuthCodeIfAES();
 			}
@@ -539,6 +542,19 @@ namespace ICSharpCode.SharpZipLib.Zip
 			if (curEntry.AESKeySize > 0)
 			{
 				baseOutputStream_.Write(AESAuthCode, 0, 10);
+				// Always use 0 as CRC for AE-2 format
+				curEntry.Crc = 0;
+			}
+			else
+			{
+				if (curEntry.Crc < 0)
+				{
+					curEntry.Crc = crc.Value;
+				}
+				else if (curEntry.Crc != crc.Value)
+				{
+					throw new ZipException($"crc was {crc.Value}, but {curEntry.Crc} was expected");
+				}
 			}
 
 			if (curEntry.Size < 0)
@@ -547,7 +563,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 			else if (curEntry.Size != size)
 			{
-				throw new ZipException("size was " + size + ", but I expected " + curEntry.Size);
+				throw new ZipException($"size was {size}, but {curEntry.Size} was expected");
 			}
 
 			if (curEntry.CompressedSize < 0)
@@ -556,16 +572,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 			else if (curEntry.CompressedSize != csize)
 			{
-				throw new ZipException("compressed size was " + csize + ", but I expected " + curEntry.CompressedSize);
-			}
-
-			if (curEntry.Crc < 0)
-			{
-				curEntry.Crc = crc.Value;
-			}
-			else if (curEntry.Crc != crc.Value)
-			{
-				throw new ZipException("crc was " + crc.Value + ", but I expected " + curEntry.Crc);
+				throw new ZipException($"compressed size was {csize}, but {curEntry.CompressedSize} expected");
 			}
 
 			offset += csize;
@@ -718,7 +725,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 				throw new ArgumentException("Invalid offset/count combination");
 			}
 
-			crc.Update(new ArraySegment<byte>(buffer, offset, count));
+			if (curEntry.AESKeySize == 0)
+			{
+				// Only update CRC if AES is not enabled
+				crc.Update(new ArraySegment<byte>(buffer, offset, count));
+			}
+
 			size += count;
 
 			switch (curMethod)

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -193,7 +193,12 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					ZipEntry entry = zf[0];
 					Assert.AreEqual(tempName1, entry.Name);
 					Assert.AreEqual(1, entry.Size);
-					Assert.IsTrue(zf.TestArchive(true));
+					Assert.IsTrue(zf.TestArchive(true, TestStrategy.FindFirstError, (status, message) =>
+					{
+						if(!string.IsNullOrEmpty(message)) {
+							Console.WriteLine($"{message} ({status.Entry?.Name ?? "-"})");
+						}
+					}));
 					Assert.IsTrue(entry.IsCrypted);
 
 					switch (encryptionMethod)


### PR DESCRIPTION
This skips AES calculation for AES encrypted entries to align with AE-2.

Fixes #552 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
