### PR TITLE
FastZip - fix TimeSetting control when extracting Zip entries

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -3,6 +3,7 @@ using ICSharpCode.SharpZipLib.Zip.Compression;
 using System;
 using System.IO;
 using static ICSharpCode.SharpZipLib.Zip.Compression.Deflater;
+using static ICSharpCode.SharpZipLib.Zip.ZipEntryFactory;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -193,6 +194,26 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </summary>
 		public FastZip()
 		{
+		}
+
+		/// <summary>
+		/// Initialise a new instance of <see cref="FastZip"/> using the specified <see cref="TimeSetting"/>
+		/// </summary>
+		/// <param name="timeSetting">The <see cref="TimeSetting">time setting</see> to use when creating or extracting <see cref="ZipEntry">Zip entries</see>.</param>
+		public FastZip(TimeSetting timeSetting)
+		{
+			entryFactory_ = new ZipEntryFactory(timeSetting);
+			restoreDateTimeOnExtract_ = true;
+		}
+
+		/// <summary>
+		/// Initialise a new instance of <see cref="FastZip"/> using the specified <see cref="DateTime"/>
+		/// </summary>
+		/// <param name="time">The time to set all <see cref="ZipEntry.DateTime"/> values to created or extracted <see cref="ZipEntry">Zip Entries</see>.</param>
+		public FastZip(DateTime time)
+		{
+			entryFactory_ = new ZipEntryFactory(time);
+			restoreDateTimeOnExtract_ = true;
 		}
 
 		/// <summary>
@@ -735,7 +756,39 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 						if (restoreDateTimeOnExtract_)
 						{
-							File.SetLastWriteTime(targetName, entry.DateTime);
+							switch (entryFactory_.Setting)
+							{
+								case TimeSetting.CreateTime:
+									File.SetCreationTime(targetName, entry.DateTime);
+									break;
+
+								case TimeSetting.CreateTimeUtc:
+									File.SetCreationTimeUtc(targetName, entry.DateTime);
+									break;
+
+								case TimeSetting.LastAccessTime:
+									File.SetLastAccessTime(targetName, entry.DateTime);
+									break;
+
+								case TimeSetting.LastAccessTimeUtc:
+									File.SetLastAccessTimeUtc(targetName, entry.DateTime);
+									break;
+
+								case TimeSetting.LastWriteTime:
+									File.SetLastWriteTime(targetName, entry.DateTime);
+									break;
+
+								case TimeSetting.LastWriteTimeUtc:
+									File.SetLastWriteTimeUtc(targetName, entry.DateTime);
+									break;
+
+								case TimeSetting.Fixed:
+									File.SetLastWriteTime(targetName, entryFactory_.FixedDateTime);
+									break;
+
+								default:
+									throw new ZipException("Unhandled time setting in ExtractFileEntry");
+							}
 						}
 
 						if (RestoreAttributesOnExtract && entry.IsDOSEntry && (entry.ExternalFileAttributes != -1))
@@ -809,7 +862,39 @@ namespace ICSharpCode.SharpZipLib.Zip
 							Directory.CreateDirectory(dirName);
 							if (entry.IsDirectory && restoreDateTimeOnExtract_)
 							{
-								Directory.SetLastWriteTime(dirName, entry.DateTime);
+								switch (entryFactory_.Setting)
+								{
+									case TimeSetting.CreateTime:
+										Directory.SetCreationTime(dirName, entry.DateTime);
+										break;
+
+									case TimeSetting.CreateTimeUtc:
+										Directory.SetCreationTimeUtc(dirName, entry.DateTime);
+										break;
+
+									case TimeSetting.LastAccessTime:
+										Directory.SetLastAccessTime(dirName, entry.DateTime);
+										break;
+
+									case TimeSetting.LastAccessTimeUtc:
+										Directory.SetLastAccessTimeUtc(dirName, entry.DateTime);
+										break;
+
+									case TimeSetting.LastWriteTime:
+										Directory.SetLastWriteTime(dirName, entry.DateTime);
+										break;
+
+									case TimeSetting.LastWriteTimeUtc:
+										Directory.SetLastWriteTimeUtc(dirName, entry.DateTime);
+										break;
+
+									case TimeSetting.Fixed:
+										Directory.SetLastWriteTime(dirName, entryFactory_.FixedDateTime);
+										break;
+
+									default:
+										throw new ZipException("Unhandled time setting in ExtractEntry");
+								}
 							}
 						}
 						else

--- a/src/ICSharpCode.SharpZipLib/Zip/IEntryFactory.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/IEntryFactory.cs
@@ -1,4 +1,6 @@
+using System;
 using ICSharpCode.SharpZipLib.Core;
+using static ICSharpCode.SharpZipLib.Zip.ZipEntryFactory;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -50,5 +52,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// Get/set the <see cref="INameTransform"></see> applicable.
 		/// </summary>
 		INameTransform NameTransform { get; set; }
+
+		/// <summary>
+		/// Get the <see cref="TimeSetting"/> in use.
+		/// </summary>
+		TimeSetting Setting { get; }
+
+		/// <summary>
+		/// Get the <see cref="DateTime"/> value to use when <see cref="Setting"/> is set to <see cref="TimeSetting.Fixed"/>
+		/// </summary>
+		DateTime FixedDateTime { get; }
 	}
 }


### PR DESCRIPTION
When creating Zip entries with FastZip - it is possible to control timesetting for files or dirs. But when extraction it is abcent. ZipEntry's DateTime property always set to extracted entry by SetLastWriteTime() function.