### PR TITLE
Add flag to skip excessively flushing tar output buffer

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -399,6 +399,12 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		/// <remarks>The default value is true.</remarks>
 		public bool IsStreamOwner { get; set; } = true;
+		
+		/// <summary>
+		/// If enabled, skips flushing of output stream after every written block
+		/// </summary>
+		/// <remarks>The default value is true.</remarks>
+		public bool SkipFlushOnEveryBlock { get; set; } = false;
 
 		/// <summary>
 		/// Get the current block number, within the current record, zero based.
@@ -528,7 +534,10 @@ namespace ICSharpCode.SharpZipLib.Tar
 			}
 
 			outputStream.Write(recordBuffer, 0, RecordSize);
-			outputStream.Flush();
+			if (!SkipFlushOnEveryBlock)
+			{
+				outputStream.Flush();
+			}
 
 			currentBlockIndex = 0;
 			currentRecordIndex++;

--- a/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -90,6 +90,16 @@ namespace ICSharpCode.SharpZipLib.Tar
 		}
 
 		/// <summary>
+		/// If enabled, skips flushing of output stream after every written block
+		/// </summary>
+		/// <remarks>The default value is false.</remarks>
+		public bool SkipFlushOnEveryBlock
+		{
+			get => buffer.SkipFlushOnEveryBlock;
+			set => buffer.SkipFlushOnEveryBlock = value;
+		}
+
+		/// <summary>
 		/// true if the stream supports reading; otherwise, false.
 		/// </summary>
 		public override bool CanRead

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
@@ -764,6 +764,32 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 		[Category("Tar")]
 		[Category("Performance")]
 		[Explicit("Long Running")]
+		public void WriteThroughputDisk([Values(true, false)]bool skipFlush)
+		{
+			const string EntryName = "LargeTarEntry";
+
+			PerformanceTesting.TestWrite(TestDataSize.Huge, bs =>
+			{
+				var tos = new TarOutputStream(bs, null);
+				tos.SkipFlushOnEveryBlock = skipFlush;
+				tos.PutNextEntry(new TarEntry(new TarHeader()
+				{
+					Name = EntryName,
+					Size = (int)TestDataSize.Huge,
+				}));
+				return tos;
+			},
+			stream =>
+			{
+				((TarOutputStream)stream).CloseEntry();
+			}, useTempFile: true);
+			
+		}
+
+		[Test]
+		[Category("Tar")]
+		[Category("Performance")]
+		[Explicit("Long Running")]
 		public void SingleLargeEntry()
 		{
 			const string EntryName = "LargeTarEntry";


### PR DESCRIPTION
Fixes #219.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
