### PR TITLE
Replace uses of new T[0] with Array.Empty<T>

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/EmptyRefs.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/EmptyRefs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace ICSharpCode.SharpZipLib.Core
+{
+	internal static class Empty
+	{
+#if NET45
+		internal static class EmptyArray<T>
+		{
+			public static readonly T[] Value = new T[0];
+		}
+		public static T[] Array<T>() => EmptyArray<T>.Value;
+#else
+		public static T[] Array<T>() => System.Array.Empty<T>();
+#endif
+	}
+}

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Cryptography;
+using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.Encryption
 {
@@ -163,7 +164,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 			{
 				throw new NotImplementedException("TransformFinalBlock is not implemented and inputCount is greater than 0");
 			}
-			return new byte[0];
+			return Empty.Array<byte>();
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.Tar
 {
@@ -465,7 +466,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		{
 			if ((file == null) || !Directory.Exists(file))
 			{
-				return new TarEntry[0];
+				return Empty.Array<TarEntry>();
 			}
 
 			string[] list = Directory.GetFileSystemEntries(file);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -521,7 +522,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			if (data == null)
 			{
-				_data = new byte[0];
+				_data = Empty.Array<byte>();
 			}
 			else
 			{
@@ -552,7 +553,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 			if ((_data == null) || (_data.Length != 0))
 			{
-				_data = new byte[0];
+				_data = Empty.Array<byte>();
 			}
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -539,7 +539,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 			else
 			{
-				entries_ = new ZipEntry[0];
+				entries_ = Empty.Array<ZipEntry>();
 				isNewArchive_ = true;
 			}
 		}
@@ -549,7 +549,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </summary>
 		internal ZipFile()
 		{
-			entries_ = new ZipEntry[0];
+			entries_ = Empty.Array<ZipEntry>();
 			isNewArchive_ = true;
 		}
 
@@ -2338,7 +2338,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				baseStream_.Write(centralExtraData, 0, centralExtraData.Length);
 			}
 
-			byte[] rawComment = (entry.Comment != null) ? Encoding.ASCII.GetBytes(entry.Comment) : new byte[0];
+			byte[] rawComment = (entry.Comment != null) ? Encoding.ASCII.GetBytes(entry.Comment) : Empty.Array<byte>();
 
 			if (rawComment.Length > 0)
 			{
@@ -3347,7 +3347,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			if (!isDisposed_)
 			{
 				isDisposed_ = true;
-				entries_ = new ZipEntry[0];
+				entries_ = Empty.Array<ZipEntry>();
 
 				if (IsStreamOwner && (baseStream_ != null))
 				{

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -872,7 +872,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				byte[] entryComment =
 					(entry.Comment != null) ?
 					ZipStrings.ConvertToArray(entry.Flags, entry.Comment) :
-					new byte[0];
+					Empty.Array<byte>();
 
 				if (entryComment.Length > 0xffff)
 				{
@@ -987,7 +987,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Comment for the entire archive recorded in central header.
 		/// </summary>
-		private byte[] zipComment = new byte[0];
+		private byte[] zipComment = Empty.Array<byte>();
 
 		/// <summary>
 		/// Flag indicating that header patching is required for the current entry.

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -174,7 +175,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <returns>Converted array</returns>
 		public static byte[] ConvertToArray(string str)
 			=> str == null
-			? new byte[0]
+			? Empty.Array<byte>()
 			: Encoding.GetEncoding(CodePage).GetBytes(str);
 
 		/// <summary>
@@ -187,7 +188,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <returns>Converted array</returns>
 		public static byte[] ConvertToArray(int flags, string str)
 			=> (string.IsNullOrEmpty(str))
-				? new byte[0]
+				? Empty.Array<byte>()
 				: EncodingFromFlag(flags).GetBytes(str);
 	}
 }


### PR DESCRIPTION
Applies the 'Empty.Array' helper from #501 and uses it in several places that currently use 'new T[0]' 

(the places that have been changed are all places that cause CA1825 suggestions from FxCop, refs #449) 


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
