### PR TITLE
Make ZipAESStream throw ZipException instead of Exception when the AES auth code is wrong

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.Zip;
 
 namespace ICSharpCode.SharpZipLib.Encryption
 {
@@ -137,14 +138,14 @@ namespace ICSharpCode.SharpZipLib.Encryption
 						nBytes += TransformAndBufferBlock(buffer, offset, bytesLeftToRead, finalBlock);
 					}
 					else if (byteCount < AUTH_CODE_LENGTH)
-						throw new Exception("Internal error missed auth code"); // Coding bug
+						throw new ZipException("Internal error missed auth code"); // Coding bug
 																				// Final block done. Check Auth code.
 					byte[] calcAuthCode = _transform.GetAuthCode();
 					for (int i = 0; i < AUTH_CODE_LENGTH; i++)
 					{
 						if (calcAuthCode[i] != _slideBuffer[_slideBufStartPos + i])
 						{
-							throw new Exception("AES Authentication Code does not match. This is a super-CRC check on the data in the file after compression and encryption. \r\n"
+							throw new ZipException("AES Authentication Code does not match. This is a super-CRC check on the data in the file after compression and encryption. \r\n"
 								+ "The file may be damaged.");
 						}
 					}


### PR DESCRIPTION
spin off from my question about what exception type it should use in #576 (not sure if there's a more specific exception type about to use, but plain ```Exception``` seems wrong)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
