### PR TITLE
Fix typos in the StreamDecodingException doc comments

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/Exceptions/StreamDecodingException.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/Exceptions/StreamDecodingException.cs
@@ -4,8 +4,8 @@ using System.Runtime.Serialization;
 namespace ICSharpCode.SharpZipLib
 {
 	/// <summary>
-	/// Indicates that an error occured during decoding of a input stream due to corrupt
-	/// data or (unintentional) library incompability.
+	/// Indicates that an error occurred during decoding of a input stream due to corrupt
+	/// data or (unintentional) library incompatibility.
 	/// </summary>
 	[Serializable]
 	public class StreamDecodingException : SharpZipBaseException


### PR DESCRIPTION
Just something I noticed while looking at something else.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
