### PR TITLE
Implement ReadAsync in ZipAESStream, extra simple version

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 
@@ -89,6 +91,13 @@ namespace ICSharpCode.SharpZipLib.Encryption
 				nBytes += ReadAndTransform(buffer, offset, count);
 
 			return nBytes;
+		}
+
+		/// <inheritdoc/>
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		{
+			var readCount = Read(buffer, offset, count);
+			return Task.FromResult(readCount);
 		}
 
 		// Read data from the underlying stream and decrypt it


### PR DESCRIPTION
Possible extra trivial version of #576, just for testing and a potential quick fix (whereby it doesn't attempt to actually be async)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
