### PR TITLE
Remove supported method checks from the ZipEntry.CompressionMethod property setter

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -724,17 +724,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Gets/Sets the compression method.
 		/// </summary>
-		/// <remarks>Throws exception when set if the method is not valid as per <see cref="IsCompressionMethodSupported()"/></remarks>
-		/// <exception cref="NotSupportedException"/>
 		/// <returns>
 		/// The compression method for this entry
 		/// </returns>
 		public CompressionMethod CompressionMethod
 		{
 			get => method;
-			set => method = !IsCompressionMethodSupported(value)
-					? throw new NotSupportedException("Compression method not supported")
-					: value;
+			set => method = value;
 		}
 
 		/// <summary>

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
@@ -133,18 +133,6 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			return att;
 		}
 
-		[Test]
-		[Category("Zip")]
-		//[ExpectedException(typeof(NotSupportedException))]
-		public void UnsupportedCompressionMethod()
-		{
-			var ze = new ZipEntry("HumblePie");
-			//ze.CompressionMethod = CompressionMethod.BZip2;
-
-			Assert.That(() => ze.CompressionMethod = CompressionMethod.Deflate64,
-				Throws.TypeOf<NotSupportedException>());
-		}
-
 		/// <summary>
 		/// Invalid passwords should be detected early if possible, seekable stream
 		/// </summary>


### PR DESCRIPTION
As queried in #500 and in various other discussions - Should the CompressionMethod property setter be trying to determine if a method is supported, given that the class is shared by ZipFile and the Zip stream classes, which have different behaviour?

There were various places in the past that relied on this behaviour to reject unsupported entries, but I think ZipFile/ZipXStream should be checking that themselves where needed now.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
