### PR TITLE
add a simple async read test for ZipFile

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
@@ -579,6 +580,29 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					CheckKnownEntry(instream, 1024);
 				}
 				zipFile.Close();
+			}
+		}
+
+		/// <summary>
+		/// Simple async round trip test for ZipFile class
+		/// </summary>
+		[TestCase(CompressionMethod.Stored)]
+		[TestCase(CompressionMethod.Deflated)]
+		[TestCase(CompressionMethod.BZip2)]
+		[Category("Zip")]
+		[Category("Async")]
+		public async Task RoundTripInMemoryAsync(CompressionMethod compressionMethod)
+		{
+			var storage = new MemoryStream();
+			MakeZipFile(storage, compressionMethod, false, "", 10, 1024, "");
+
+			using (ZipFile zipFile = new ZipFile(storage))
+			{
+				foreach (ZipEntry e in zipFile)
+				{
+					Stream instream = zipFile.GetInputStream(e);
+					await CheckKnownEntryAsync(instream, 1024);
+				}
 			}
 		}
 


### PR DESCRIPTION
An offshoot of #576 and related, to add a small extra test for doing async reads on the stream returned from ZipFile.GetInputStream using different compression methods - put in its own PR to make it more self contained

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
