### PR TITLE
Simplify DropPathRoot and fix out of bounds issue

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Linq;
 
 namespace ICSharpCode.SharpZipLib.Core
 {
@@ -8,14 +10,24 @@ namespace ICSharpCode.SharpZipLib.Core
 	public static class PathUtils
 	{
 		/// <summary>
-		/// Remove any path root present in the path
+		/// Remove any path root present in the path and optionally replaces invalid path chars,
+		/// as indicated by <see cref="Path.GetInvalidPathChars"/>, with <c>'_'</c>
 		/// </summary>
 		/// <param name="path">A <see cref="string"/> containing path information.</param>
+		/// <param name="replaceInvalidChars">Replaces any invalid path chars</param>
 		/// <returns>The path with the root removed if it was present; path otherwise.</returns>
-		/// <remarks>Unlike the <see cref="System.IO.Path"/> class the path isn't otherwise checked for validity.</remarks>
-		public static string DropPathRoot(string path)
+		public static string DropPathRoot(string path, bool replaceInvalidChars = false)
 		{
-			var stripLength = Path.GetPathRoot(path).Length;
+			// Replace any invalid path characters with '_' to prevent Path.GetPathRoot throwing
+			var invalidChars = Path.GetInvalidPathChars();
+			var cleanPath = new string(path.Select(c => invalidChars.Contains(c) ? '_' : c).ToArray());
+
+			if (replaceInvalidChars)
+			{
+				path = cleanPath;
+			}
+			
+			var stripLength = Path.GetPathRoot(cleanPath).Length;
 			while (path.Length > stripLength && (path[stripLength] == '/' || path[stripLength] == '\\')) stripLength++;
 			return path.Substring(stripLength);
 		}

--- a/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
@@ -15,48 +15,9 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <remarks>Unlike the <see cref="System.IO.Path"/> class the path isn't otherwise checked for validity.</remarks>
 		public static string DropPathRoot(string path)
 		{
-			string result = path;
-
-			if (!string.IsNullOrEmpty(path))
-			{
-				if ((path[0] == '\\') || (path[0] == '/'))
-				{
-					// UNC name ?
-					if ((path.Length > 1) && ((path[1] == '\\') || (path[1] == '/')))
-					{
-						int index = 2;
-						int elements = 2;
-
-						// Scan for two separate elements \\machine\share\restofpath
-						while ((index <= path.Length) &&
-							(((path[index] != '\\') && (path[index] != '/')) || (--elements > 0)))
-						{
-							index++;
-						}
-
-						index++;
-
-						if (index < path.Length)
-						{
-							result = path.Substring(index);
-						}
-						else
-						{
-							result = "";
-						}
-					}
-				}
-				else if ((path.Length > 1) && (path[1] == ':'))
-				{
-					int dropCount = 2;
-					if ((path.Length > 2) && ((path[2] == '\\') || (path[2] == '/')))
-					{
-						dropCount = 3;
-					}
-					result = result.Remove(0, dropCount);
-				}
-			}
-			return result;
+			var stripLength = Path.GetPathRoot(path).Length;
+			while (path.Length > stripLength && (path[stripLength] == '/' || path[stripLength] == '\\')) stripLength++;
+			return path.Substring(stripLength);
 		}
 
 		/// <summary>

--- a/test/ICSharpCode.SharpZipLib.Tests/Core/CoreTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Core/CoreTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using ICSharpCode.SharpZipLib.Core;
 using NUnit.Framework;
 
@@ -60,13 +61,28 @@ namespace ICSharpCode.SharpZipLib.Tests.Core
 		[Category("Core")]
 		public void DropPathRoot()
 		{
-			Func<string, string> testPath = PathUtils.DropPathRoot;
-			Assert.AreEqual("file.txt", testPath(@"\\server\share\file.txt"));
-			Assert.AreEqual("file.txt", testPath(@"c:\file.txt"));
-			Assert.AreEqual(@"subdir with spaces\file.txt", testPath(@"z:\subdir with spaces\file.txt"));
-			Assert.AreEqual("", testPath(@"\\server\share\"));
-			Assert.AreEqual(@"server\share\file.txt", testPath(@"\server\share\file.txt"));
-			Assert.AreEqual(@"path\file.txt", testPath(@"\\server\share\\path\file.txt"));
+			string TestPath(string s) => PathUtils.DropPathRoot(s, replaceInvalidChars: false);
+			Assert.AreEqual("file.txt", TestPath(@"\\server\share\file.txt"));
+			Assert.AreEqual("file.txt", TestPath(@"c:\file.txt"));
+			Assert.AreEqual(@"subdir with spaces\file.txt", TestPath(@"z:\subdir with spaces\file.txt"));
+			Assert.AreEqual("", TestPath(@"\\server\share\"));
+			Assert.AreEqual(@"server\share\file.txt", TestPath(@"\server\share\file.txt"));
+			Assert.AreEqual(@"path\file.txt", TestPath(@"\\server\share\\path\file.txt"));
+			Assert.DoesNotThrow(() => Console.WriteLine(TestPath(@"c:\file:+/")));
+			Assert.DoesNotThrow(() => Console.WriteLine(TestPath(@"c:\file*?")));
+			Assert.DoesNotThrow(() => Console.WriteLine(TestPath("c:\\file|\"")));
+			Assert.DoesNotThrow(() => Console.WriteLine(TestPath(@"c:\file<>")));
+		}
+
+		[Test]
+		[TestCase(@"c:\file:+/")]
+		[TestCase(@"c:\file*?")]
+		[TestCase("c:\\file|\"")]
+		[TestCase(@"c:\file<>")]
+		[Category("Core")]
+		public void DropPathRoot_DoesNotThrowForInvalidPath(string path)
+		{
+			Assert.DoesNotThrow(() => Console.WriteLine(PathUtils.DropPathRoot(path)));
 		}
 	}
 }

--- a/test/ICSharpCode.SharpZipLib.Tests/Core/CoreTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Core/CoreTests.cs
@@ -56,7 +56,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Core
 			Assert.IsFalse(NameFilter.IsValidFilterExpression(@"[]"));
 		}
 
-		private static string DropRoot(string s) => PathUtils.DropPathRoot(s, replaceInvalidChars: false);
+		// Use a shorter name wrapper to make tests more legible
+		private static string DropRoot(string s) => PathUtils.DropPathRoot(s);
 		
 		[Test]
 		[Category("Core")]
@@ -90,6 +91,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Core
 		[TestCase(@"c:\file*?")]
 		[TestCase("c:\\file|\"")]
 		[TestCase(@"c:\file<>")]
+		[TestCase(@"c:file")]
+		[TestCase(@"c::file")]
+		[TestCase(@"c:?file")]
+		[TestCase(@"c:+file")]
+		[TestCase(@"cc:file")]
 		[Category("Core")]
 		public void DropPathRoot_DoesNotThrowForInvalidPath(string path)
 		{

--- a/test/ICSharpCode.SharpZipLib.Tests/Core/CoreTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Core/CoreTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using ICSharpCode.SharpZipLib.Core;
 using NUnit.Framework;
 
@@ -56,22 +55,34 @@ namespace ICSharpCode.SharpZipLib.Tests.Core
 			Assert.IsFalse(NameFilter.IsValidFilterExpression(@"\,)"));
 			Assert.IsFalse(NameFilter.IsValidFilterExpression(@"[]"));
 		}
+
+		private static string DropRoot(string s) => PathUtils.DropPathRoot(s, replaceInvalidChars: false);
 		
 		[Test]
 		[Category("Core")]
-		public void DropPathRoot()
+		[Platform("Win")]
+		public void DropPathRoot_Windows()
 		{
-			string TestPath(string s) => PathUtils.DropPathRoot(s, replaceInvalidChars: false);
-			Assert.AreEqual("file.txt", TestPath(@"\\server\share\file.txt"));
-			Assert.AreEqual("file.txt", TestPath(@"c:\file.txt"));
-			Assert.AreEqual(@"subdir with spaces\file.txt", TestPath(@"z:\subdir with spaces\file.txt"));
-			Assert.AreEqual("", TestPath(@"\\server\share\"));
-			Assert.AreEqual(@"server\share\file.txt", TestPath(@"\server\share\file.txt"));
-			Assert.AreEqual(@"path\file.txt", TestPath(@"\\server\share\\path\file.txt"));
-			Assert.DoesNotThrow(() => Console.WriteLine(TestPath(@"c:\file:+/")));
-			Assert.DoesNotThrow(() => Console.WriteLine(TestPath(@"c:\file*?")));
-			Assert.DoesNotThrow(() => Console.WriteLine(TestPath("c:\\file|\"")));
-			Assert.DoesNotThrow(() => Console.WriteLine(TestPath(@"c:\file<>")));
+			Assert.AreEqual("file.txt", DropRoot(@"\\server\share\file.txt"));
+			Assert.AreEqual("file.txt", DropRoot(@"c:\file.txt"));
+			Assert.AreEqual(@"subdir with spaces\file.txt", DropRoot(@"z:\subdir with spaces\file.txt"));
+			Assert.AreEqual("", DropRoot(@"\\server\share\"));
+			Assert.AreEqual(@"server\share\file.txt", DropRoot(@"\server\share\file.txt"));
+			Assert.AreEqual(@"path\file.txt", DropRoot(@"\\server\share\\path\file.txt"));
+		}
+
+		[Test]
+		[Category("Core")]
+		[Platform(Exclude="Win")]
+		public void DropPathRoot_Posix()
+		{
+			Assert.AreEqual("file.txt", DropRoot("/file.txt"));
+			Assert.AreEqual(@"tmp/file.txt", DropRoot(@"/tmp/file.txt"));
+			Assert.AreEqual(@"tmp\file.txt", DropRoot(@"\tmp\file.txt"));
+			Assert.AreEqual(@"tmp/file.txt", DropRoot(@"\tmp/file.txt"));
+			Assert.AreEqual(@"tmp\file.txt", DropRoot(@"/tmp\file.txt"));
+			Assert.AreEqual("", DropRoot("/"));
+
 		}
 
 		[Test]

--- a/test/ICSharpCode.SharpZipLib.Tests/Core/CoreTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Core/CoreTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ICSharpCode.SharpZipLib.Core;
 using NUnit.Framework;
 
@@ -53,6 +54,19 @@ namespace ICSharpCode.SharpZipLib.Tests.Core
 
 			Assert.IsFalse(NameFilter.IsValidFilterExpression(@"\,)"));
 			Assert.IsFalse(NameFilter.IsValidFilterExpression(@"[]"));
+		}
+		
+		[Test]
+		[Category("Core")]
+		public void DropPathRoot()
+		{
+			Func<string, string> testPath = PathUtils.DropPathRoot;
+			Assert.AreEqual("file.txt", testPath(@"\\server\share\file.txt"));
+			Assert.AreEqual("file.txt", testPath(@"c:\file.txt"));
+			Assert.AreEqual(@"subdir with spaces\file.txt", testPath(@"z:\subdir with spaces\file.txt"));
+			Assert.AreEqual("", testPath(@"\\server\share\"));
+			Assert.AreEqual(@"server\share\file.txt", testPath(@"\server\share\file.txt"));
+			Assert.AreEqual(@"path\file.txt", testPath(@"\\server\share\\path\file.txt"));
 		}
 	}
 }

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/SevenZip.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/SevenZip.cs
@@ -17,7 +17,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "7-Zip", "7z.exe"),
 		};
 
-		public static bool TryGet7zBinPath(out string path7z)
+		private static bool TryGet7zBinPath(out string path7z)
 		{
 			var runTimeLimit = TimeSpan.FromSeconds(3);
 
@@ -77,12 +77,25 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 						zipStream.CopyTo(fs);
 					}
 
-					var p = Process.Start(path7z, $"t -p{password} \"{fileName}\"");
+					var p = Process.Start(new ProcessStartInfo(path7z, $"t -p{password} \"{fileName}\"")
+					{
+						RedirectStandardOutput = true,
+						RedirectStandardError = true,
+						UseShellExecute = false,
+					});
+					
+					if (p == null)
+					{
+						Assert.Inconclusive("Failed to start 7z process. Skipping!");
+					}
 					if (!p.WaitForExit(2000))
 					{
 						Assert.Warn("Timed out verifying zip file!");
 					}
 
+					TestContext.Out.Write(p.StandardOutput.ReadToEnd());
+					var errors = p.StandardError.ReadToEnd();
+					Assert.IsEmpty(errors, "7z reported errors");
 					Assert.AreEqual(0, p.ExitCode, "Archive verification failed");
 				}
 				finally

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
@@ -13,9 +13,16 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 		public static int DummyContentLength = 16;
 
 		private static Random random = new Random();
+		
+		/// <summary>
+		/// Returns the system root for the current platform (usually c:\ for windows and / for others)
+		/// </summary>
+		public static string SystemRoot { get; } = 
+			Path.GetPathRoot(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
 
 		private static void Compare(byte[] a, byte[] b)
 		{
+			
 			if (a == null)
 			{
 				throw new ArgumentNullException(nameof(a));

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -23,6 +23,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			try
 			{
+				// ReSharper disable once ExpressionIsAlwaysNull
 				bad = new ZipFile(nullStream);
 			}
 			catch
@@ -439,17 +440,21 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				f.IsStreamOwner = false;
 
 				f.BeginUpdate(new MemoryArchiveStorage());
-				f.Add(new StringMemoryDataSource("Hello world"), @"z:\a\a.dat");
+				f.Add(new StringMemoryDataSource("Hello world"), Utils.SystemRoot + @"a\a.dat");
 				f.Add(new StringMemoryDataSource("Another"), @"\b\b.dat");
 				f.Add(new StringMemoryDataSource("Mr C"), @"c\c.dat");
 				f.Add(new StringMemoryDataSource("Mrs D was a star"), @"d\d.dat");
 				f.CommitUpdate();
 				Assert.IsTrue(f.TestArchive(true));
+				foreach (ZipEntry entry in f)
+				{
+					Console.WriteLine($" - {entry.Name}");
+				}
 			}
 
 			byte[] master = memStream.ToArray();
 
-			TryDeleting(master, 4, 1, @"z:\a\a.dat");
+			TryDeleting(master, 4, 1, Utils.SystemRoot + @"a\a.dat");
 			TryDeleting(master, 4, 1, @"\a\a.dat");
 			TryDeleting(master, 4, 1, @"a/a.dat");
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipNameTransformHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipNameTransformHandling.cs
@@ -3,6 +3,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 using System;
 using System.IO;
+using ICSharpCode.SharpZipLib.Tests.TestSupport;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
@@ -16,8 +17,6 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			var t = new ZipNameTransform();
 
 			TestFile(t, "abcdef", "abcdef");
-			TestFile(t, @"\\uncpath\d1\file1", "file1");
-			TestFile(t, @"C:\absolute\file2", "absolute/file2");
 
 			// This is ignored but could be converted to 'file3'
 			TestFile(t, @"./file3", "./file3");
@@ -28,49 +27,72 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			// Trick filenames.
 			TestFile(t, @".....file3", ".....file3");
+		}
+
+		[Test]
+		[Category("Zip")]
+		[Platform("Win")]
+		public void Basic_Windows()
+		{
+			var t = new ZipNameTransform();
+			TestFile(t, @"\\uncpath\d1\file1", "file1");
+			TestFile(t, @"C:\absolute\file2", "absolute/file2");
+			
 			TestFile(t, @"c::file", "_file");
+		}
+		
+		[Test]
+		[Category("Zip")]
+		[Platform(Exclude="Win")]
+		public void Basic_Posix()
+		{
+			var t = new ZipNameTransform();
+			TestFile(t, @"backslash_path\file1", "backslash_path/file1");
+			TestFile(t, "/absolute/file2", "absolute/file2");
+			
+			TestFile(t, @"////////:file", "_file");
 		}
 
 		[Test]
 		public void TooLong()
 		{
 			var zt = new ZipNameTransform();
-			var veryLong = new string('x', 65536);
-			try
-			{
-				zt.TransformDirectory(veryLong);
-				Assert.Fail("Expected an exception");
-			}
-			catch (PathTooLongException)
-			{
-			}
+			var tooLong = new string('x', 65536);
+			Assert.Throws<PathTooLongException>(() => zt.TransformDirectory(tooLong));
 		}
 
 		[Test]
 		public void LengthBoundaryOk()
 		{
 			var zt = new ZipNameTransform();
-			string veryLong = "c:\\" + new string('x', 65535);
-			try
-			{
-				zt.TransformDirectory(veryLong);
-			}
-			catch
-			{
-				Assert.Fail("Expected no exception");
-			}
+			var tooLongWithRoot = Utils.SystemRoot + new string('x', 65535);
+			Assert.DoesNotThrow(() => zt.TransformDirectory(tooLongWithRoot));
 		}
 
 		[Test]
 		[Category("Zip")]
-		public void NameTransforms()
+		[Platform("Win")]
+		public void NameTransforms_Windows()
 		{
 			INameTransform t = new ZipNameTransform(@"C:\Slippery");
 			Assert.AreEqual("Pongo/Directory/", t.TransformDirectory(@"C:\Slippery\Pongo\Directory"), "Value should be trimmed and converted");
 			Assert.AreEqual("PoNgo/Directory/", t.TransformDirectory(@"c:\slipperY\PoNgo\Directory"), "Trimming should be case insensitive");
-			Assert.AreEqual("slippery/Pongo/Directory/", t.TransformDirectory(@"d:\slippery\Pongo\Directory"), "Trimming should be case insensitive");
+			Assert.AreEqual("slippery/Pongo/Directory/", t.TransformDirectory(@"d:\slippery\Pongo\Directory"), "Trimming should account for root");
 
 			Assert.AreEqual("Pongo/File", t.TransformFile(@"C:\Slippery\Pongo\File"), "Value should be trimmed and converted");
+		}
+		
+		[Test]
+		[Category("Zip")]
+		[Platform(Exclude="Win")]
+		public void NameTransforms_Posix()
+		{
+			INameTransform t = new ZipNameTransform(@"/Slippery");
+			Assert.AreEqual("Pongo/Directory/", t.TransformDirectory(@"/Slippery\Pongo\Directory"), "Value should be trimmed and converted");
+			Assert.AreEqual("PoNgo/Directory/", t.TransformDirectory(@"/slipperY\PoNgo\Directory"), "Trimming should be case insensitive");
+			Assert.AreEqual("slippery/Pongo/Directory/", t.TransformDirectory(@"/slippery/slippery/Pongo/Directory"), "Trimming should account for root");
+
+			Assert.AreEqual("Pongo/File", t.TransformFile(@"/Slippery/Pongo/File"), "Value should be trimmed and converted");
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes #56

This did grow a bit, since a lot of stuff was discovered while working on this.
Prior to this, all tests (and indeed the behaviour) for handling paths just presumed that the platform was Windows.
The core problem method (DropPathRoot) has now been changed to use the framework/platforms path handling methods, but with some special exceptions for .NET < 4.6.2.
This does feel a bit hackish, but I think it's better than the previous method, which was to implement custom code for determining what a root path is. If that code fails to notice something that the OS would consider a absolute path it could lead to vulnerabilities. If this implementation fails to notice it, it would instead throw, which could then be fixed.
And also, since this only happens in older frameworks, in most cases it would just work as intended.

If creating from a windows OS, it will strip what the OS considers to be a root path from the file name, which ensures "correct" entries in our archive, and on reading entries from an archive, it will strip them as appropriate for the OS.

This PR also includes updates to tests which now have separated versions for windows and non-windows platforms, and also pipes the output of `7z` to the test context, so that it will only be displayed if a test fails.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
