### PR TITLE
Remove the local nuget.config files from the test projects

### DIFF
--- a/test/ICSharpCode.SharpZipLib.TestBootstrapper/NuGet.config
+++ b/test/ICSharpCode.SharpZipLib.TestBootstrapper/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/test/ICSharpCode.SharpZipLib.Tests/NuGet.config
+++ b/test/ICSharpCode.SharpZipLib.Tests/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
I'm not sure if they're actually needed - try to remove them and see.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
