### PR TITLE
Use net46 as the target framework for windows tests

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -22,11 +22,11 @@ jobs:
           - configuration: debug
             os: windows
             libtarget: net45
-            testtarget: net45
+            testtarget: net46
           - configuration: release
             os: windows
             libtarget: net45
-            testtarget: net45
+            testtarget: net46
     steps:
     - uses: actions/checkout@v2
       

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,11 +13,7 @@ jobs:
         os: [ubuntu, windows, macos]
         target: [netstandard2.0, netstandard2.1]
         include:
-          - configuration: Debug
-            os: windows
-            target: net45
-          - configuration: Release
-            os: windows
+          - os: windows
             target: net45
     steps:
     - uses: actions/checkout@v2
@@ -41,12 +37,8 @@ jobs:
         os: [ubuntu, windows, macos]
         target: [netcoreapp3.1]
         include:
-          - configuration: debug
-            os: windows
-            target: net45
-          - configuration: release
-            os: windows
-            target: net45
+          - os: windows
+            target: net46
     steps:
     - uses: actions/checkout@v2
       


### PR DESCRIPTION
Since the `ICSharpCode.SharpZipLib.Tests` project targets `net46` and not `net45`, no tests are currently being run for .NET FW.
This will update the actions to run the tests on windows targets correctly.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
