### PR TITLE
Update test/coverage packages and push to codecov

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -42,7 +42,12 @@ jobs:
       run: dotnet restore
 
     - name: Run tests
-      run: dotnet test -c ${{ matrix.configuration }} -f ${{ matrix.testtarget }} --no-restore
+      run: dotnet test -c ${{ matrix.configuration }} -f ${{ matrix.testtarget }} --no-restore --collect="XPlat Code Coverage"
+      
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.2.2
+      with:
+        fail_ci_if_error: false
         
   Codacy-Analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,7 +60,12 @@ jobs:
       run: dotnet test -c debug -f ${{ matrix.target }} --no-restore
       
     - name: Run tests (Release)
-      run: dotnet test -c release -f ${{ matrix.target }} --no-restore
+      run: dotnet test -c release -f ${{ matrix.target }} --no-restore --collect="XPlat Code Coverage"
+      
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.2.2
+      with:
+        fail_ci_if_error: false
 
   Pack:
     needs: [Build, Test]

--- a/test/ICSharpCode.SharpZipLib.TestBootstrapper/ICSharpCode.SharpZipLib.TestBootstrapper.csproj
+++ b/test/ICSharpCode.SharpZipLib.TestBootstrapper/ICSharpCode.SharpZipLib.TestBootstrapper.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="NUnitLite" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnitLite" Version="3.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
+++ b/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="coveralls.net" Version="0.7.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="nunit.console" Version="3.10.0" />
-    <PackageReference Include="NUnit.Runners" Version="3.10.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit.console" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="PublishCoverity" Version="0.11.0" />
-    <PackageReference Include="ReportGenerator" Version="2.5.10" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Code coverage is currently not being reported. This updates packages and removes the ones not being used, as well as adding upload of coverage reports to Codecov.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
