### PR TITLE
pass CreateZip tests that are within time tolerance

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -725,7 +725,10 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			var archive = new MemoryStream(target.ToArray());
 			using (var zf = new ZipFile(archive))
 			{
-				Assert.AreEqual(TestTargetTime(timeSetting), zf[0].DateTime);
+				var expectedTime = TestTargetTime(timeSetting);
+				var actualTime = zf[0].DateTime;
+				// Assert that the time is within +/- 2s of the target time to allow for timing/rounding discrepancies
+				Assert.LessOrEqual(Math.Abs((expectedTime - actualTime).TotalSeconds), 2);
 			}
 		}
 


### PR DESCRIPTION
Second part of #602 for `CreateZipShouldSetTimeOnEntriesFromConstructorTimeSetting`
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
