### PR TITLE
Move the Password property from DeflaterOutputStream into ZipOutputStream

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -153,37 +153,12 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 
 		#region Encryption
 
-		private string password;
-
 		private ICryptoTransform cryptoTransform_;
 
 		/// <summary>
 		/// Returns the 10 byte AUTH CODE to be appended immediately following the AES data stream.
 		/// </summary>
 		protected byte[] AESAuthCode;
-
-		/// <summary>
-		/// Get/set the password used for encryption.
-		/// </summary>
-		/// <remarks>When set to null or if the password is empty no encryption is performed</remarks>
-		public string Password
-		{
-			get
-			{
-				return password;
-			}
-			set
-			{
-				if ((value != null) && (value.Length == 0))
-				{
-					password = null;
-				}
-				else
-				{
-					password = value;
-				}
-			}
-		}
 
 		/// <summary>
 		/// Encrypt a block of data

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -153,7 +153,10 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 
 		#region Encryption
 
-		private ICryptoTransform cryptoTransform_;
+		/// <summary>
+		/// The CryptoTransform currently being used to encrypt the compressed data.
+		/// </summary>
+		protected ICryptoTransform cryptoTransform_;
 
 		/// <summary>
 		/// Returns the 10 byte AUTH CODE to be appended immediately following the AES data stream.
@@ -175,34 +178,6 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		protected void EncryptBlock(byte[] buffer, int offset, int length)
 		{
 			cryptoTransform_.TransformBlock(buffer, 0, length, buffer, 0);
-		}
-
-		/// <summary>
-		/// Initializes encryption keys based on given <paramref name="password"/>.
-		/// </summary>
-		/// <param name="password">The password.</param>
-		protected void InitializePassword(string password)
-		{
-			var pkManaged = new PkzipClassicManaged();
-			byte[] key = PkzipClassic.GenerateKeys(ZipStrings.ConvertToArray(password));
-			cryptoTransform_ = pkManaged.CreateEncryptor(key, null);
-		}
-
-		/// <summary>
-		/// Initializes encryption keys based on given password.
-		/// </summary>
-		protected void InitializeAESPassword(ZipEntry entry, string rawPassword,
-											out byte[] salt, out byte[] pwdVerifier)
-		{
-			salt = new byte[entry.AESSaltLen];
-			// Salt needs to be cryptographically random, and unique per file
-			if (_aesRnd == null)
-				_aesRnd = RandomNumberGenerator.Create();
-			_aesRnd.GetBytes(salt);
-			int blockSize = entry.AESKeySize / 8;   // bits to bytes
-
-			cryptoTransform_ = new ZipAESTransform(rawPassword, salt, blockSize, true);
-			pwdVerifier = ((ZipAESTransform)cryptoTransform_).PwdVerifier;
 		}
 
 		#endregion Encryption
@@ -459,12 +434,5 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		private bool isClosed_;
 
 		#endregion Instance Fields
-
-		#region Static Fields
-
-		// Static to help ensure that multiple files within a zip will get different random salt
-		private static RandomNumberGenerator _aesRnd = RandomNumberGenerator.Create();
-
-		#endregion Static Fields
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -155,6 +155,29 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public INameTransform NameTransform { get; set; } = new PathTransformer();
 
 		/// <summary>
+		/// Get/set the password used for encryption.
+		/// </summary>
+		/// <remarks>When set to null or if the password is empty no encryption is performed</remarks>
+		public string Password
+		{
+			get
+			{
+				return password;
+			}
+			set
+			{
+				if ((value != null) && (value.Length == 0))
+				{
+					password = null;
+				}
+				else
+				{
+					password = value;
+				}
+			}
+		}
+
+		/// <summary>
 		/// Write an unsigned short in little endian byte order.
 		/// </summary>
 		private void WriteLeShort(int value)
@@ -1009,6 +1032,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 		// However it does avoid the situation were a large file is added and cannot be completed correctly.
 		// NOTE: Setting the size for entries before they are added is the best solution!
 		private UseZip64 useZip64_ = UseZip64.Dynamic;
+
+		/// <summary>
+		/// The password to use when encrypting archive entries.
+		/// </summary>
+		private string password;
 
 		#endregion Instance Fields
 	}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -676,10 +676,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 											out byte[] salt, out byte[] pwdVerifier)
 		{
 			salt = new byte[entry.AESSaltLen];
+
 			// Salt needs to be cryptographically random, and unique per file
-			if (_aesRnd == null)
-				_aesRnd = RandomNumberGenerator.Create();
 			_aesRnd.GetBytes(salt);
+
 			int blockSize = entry.AESKeySize / 8;   // bits to bytes
 
 			cryptoTransform_ = new ZipAESTransform(rawPassword, salt, blockSize, true);


### PR DESCRIPTION
refs #590 

This would be a breaking API change, but - is there actually a need for the Password property to be on DeflaterOutputStream, given that it only applies to creating encrypted Zip files? (the property isn't actually referenced by DeflaterOutputStream anyway, only from ZipOutputStream)

Related:
The ```InitializePassword``` and ```InitializeAESPassword``` functions in DeflaterOutputStream only seem to be called from ZipOutputStream as well, though they set the (presently private) ```cryptoTransform_``` member as well, so moving them as well would need a further change.


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
