### PR TITLE
Suppress some more CA1707 warnings in the Constants classes

### DIFF
--- a/src/ICSharpCode.SharpZipLib/GZip/GZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GZipConstants.cs
@@ -3,6 +3,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// <summary>
 	/// This class contains constants used for gzip.
 	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "kept for backwards compatibility")]
 	sealed public class GZipConstants
 	{
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterConstants.cs
@@ -5,6 +5,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// <summary>
 	/// This class contains constants used for deflation.
 	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "kept for backwards compatibility")]
 	public static class DeflaterConstants
 	{
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -237,6 +237,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// This class contains constants used for Zip format files
 	/// </summary>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "kept for backwards compatibility")]
 	public static class ZipConstants
 	{
 		#region Versions


### PR DESCRIPTION
Just continuing to chip away at the warnings/suggestions from #449 by disabling some more [CA1707](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1707) warnings.

Note: Some of the warnings from ```ZipConstants``` are actually on things that have been marked as ```[Obsolete]```, e,g, ```VERSION_MADE_BY``` - I don't know if there are any plans to remove those any point?


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
