### PR TITLE
Bzip input stream simple vectorization

### DIFF
--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/BZip2/BZip2InputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/BZip2/BZip2InputStream.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.BZip2
+{
+	[Config(typeof(MultipleRuntimes))]
+	public class BZip2InputStream
+	{
+		private byte[] compressedData;
+
+		public BZip2InputStream()
+		{
+			var outputMemoryStream = new MemoryStream();
+			using (var outputStream = new SharpZipLib.BZip2.BZip2OutputStream(outputMemoryStream))
+			{
+				var random = new Random(1234);
+				var inputData = new byte[1024 * 1024 * 30];
+				random.NextBytes(inputData);
+				var inputMemoryStream = new MemoryStream(inputData);
+				inputMemoryStream.CopyTo(outputStream);
+			}
+
+			compressedData = outputMemoryStream.ToArray();
+		}
+
+		[Benchmark]
+		public void DecompressData()
+		{
+			var memoryStream = new MemoryStream(compressedData);
+			using (var inputStream = new SharpZipLib.BZip2.BZip2InputStream(memoryStream))
+			{
+				inputStream.CopyTo(Stream.Null);
+			}
+		}
+	}
+}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
@@ -13,7 +13,7 @@ namespace ICSharpCode.SharpZipLib.Benchmark
 		{
 			AddJob(Job.Default.WithToolchain(CsProjClassicNetToolchain.Net461).AsBaseline()); // NET 4.6.1
 			AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp21)); // .NET Core 2.1
-			//Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp30)); // .NET Core 3.0
+			AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp31)); // .NET Core 3.1
 		}
 	}
 

--- a/src/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
@@ -718,6 +718,11 @@ namespace ICSharpCode.SharpZipLib.BZip2
 					var j = nextSym - 1;
 
 #if !NETSTANDARD2_0 && !NETFRAMEWORK
+					// This is vectorized memory move. Going from the back, we're taking chunks of array
+					// and write them at the new location shifted by one. Since chunks are VectorSize long,
+					// at the end we have to move "tail" (or head actually) of the array using a plain loop.
+					// If System.Numerics.Vector API is not available, the plain loop is used to do the whole copying.
+
 					while(j >= VectorSize)
 					{
 						var arrayPart = new System.Numerics.Vector<byte>(yy, j - VectorSize);

--- a/src/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
@@ -19,7 +19,11 @@ namespace ICSharpCode.SharpZipLib.BZip2
 		private const int NO_RAND_PART_B_STATE = 6;
 		private const int NO_RAND_PART_C_STATE = 7;
 
-		#endregion Constants
+#if NETSTANDARD2_1
+		private static readonly int VectorSize = System.Numerics.Vector<byte>.Count;
+#endif
+
+#endregion Constants
 
 		#region Instance Fields
 
@@ -711,10 +715,22 @@ namespace ICSharpCode.SharpZipLib.BZip2
 					unzftab[seqToUnseq[tmp]]++;
 					ll8[last] = seqToUnseq[tmp];
 
-					for (int j = nextSym - 1; j > 0; --j)
+					var j = nextSym - 1;
+
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
+					while(j >= VectorSize)
 					{
-						yy[j] = yy[j - 1];
+						var arrayPart = new System.Numerics.Vector<byte>(yy, j - VectorSize);
+						arrayPart.CopyTo(yy, j - VectorSize + 1);
+						j -= VectorSize;
 					}
+#endif
+
+					while(j > 0)
+					{
+						yy[j] = yy[--j];
+					}
+
 					yy[0] = tmp;
 
 					if (groupPos == 0)


### PR DESCRIPTION
Hi guys.
Here's the simple approach to get some speed-up on BZip2 decompression. Rotation loop (`yy[j] = yy[j -1]`) is here vectorized automatically, i.e. by means of `Vector<byte>` instead of e.g. `Vector128<byte>` tied to a specific platform. The API is available from the .NET Core/Standard 2.1, however the real gain starts in .NET Core 3.

First commits add .NET Core 3.1 as a target platform for performance tests and such a test for BZip2 decompression. The last commit is the actual vectorization. Here are some results from two Intel machines (one on Windows and one on a rather antique MacBook Air).

---
**Without** vectorization:
First machine
```
|         Method |        Job |     Toolchain |    Mean |    Error |   StdDev | Ratio |
|--------------- |----------- |-------------- |--------:|---------:|---------:|------:|
| DecompressData | Job-USQLOW | .NET Core 2.1 | 4.595 s | 0.0185 s | 0.0164 s |  0.97 |
| DecompressData | Job-NMSPHA | .NET Core 3.1 | 4.730 s | 0.0490 s | 0.0434 s |  1.00 |
| DecompressData | Job-ORXZIN |        net461 | 4.723 s | 0.0314 s | 0.0279 s |  1.00 |
```
Second machine
```
|         Method |        Job |     Toolchain |    Mean |    Error |   StdDev |
|--------------- |----------- |-------------- |--------:|---------:|---------:|
| DecompressData | Job-TBYXJE | .NET Core 2.1 | 8.177 s | 0.0607 s | 0.0538 s |
| DecompressData | Job-ZFNFSZ | .NET Core 3.1 | 8.343 s | 0.1529 s | 0.2717 s |
```
----
**With** vectorization:
First machine
```
|         Method |        Job |     Toolchain |    Mean |    Error |   StdDev | Ratio |
|--------------- |----------- |-------------- |--------:|---------:|---------:|------:|
| DecompressData | Job-JSFVZF | .NET Core 2.1 | 4.534 s | 0.0386 s | 0.0302 s |  0.99 |
| DecompressData | Job-TNNLLN | .NET Core 3.1 | 2.335 s | 0.0252 s | 0.0211 s |  0.51 |
| DecompressData | Job-THQXFG |        net461 | 4.590 s | 0.0217 s | 0.0181 s |  1.00 |
```
Second machine
```
|         Method |        Job |     Toolchain |    Mean |    Error |   StdDev |
|--------------- |----------- |-------------- |--------:|---------:|---------:|
| DecompressData | Job-DYBSPD | .NET Core 2.1 | 7.931 s | 0.1080 s | 0.0957 s |
| DecompressData | Job-FKJXRZ | .NET Core 3.1 | 5.131 s | 0.1007 s | 0.1273 s |
```
----
Machine details.
First machine
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-4770K CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
  Job-JSFVZF : .NET Core 2.1.26 (CoreCLR 4.6.29812.02, CoreFX 4.6.29812.01), X64 RyuJIT
  Job-TNNLLN : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
  Job-THQXFG : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
```
Second machine
```
BenchmarkDotNet=v0.12.1, OS=macOS 11.2.3 (20D91) [Darwin 20.3.0]
Intel Core i5-4250U CPU 1.30GHz (Haswell), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=5.0.202
  [Host]     : .NET Core 3.1.14 (CoreCLR 4.700.21.16201, CoreFX 4.700.21.16208), X64 RyuJIT
  Job-DYBSPD : .NET Core 2.1.27 (CoreCLR 4.6.29916.01, CoreFX 4.6.29916.03), X64 RyuJIT
  Job-FKJXRZ : .NET Core 3.1.14 (CoreCLR 4.700.21.16201, CoreFX 4.700.21.16208), X64 RyuJIT
```

The speed-up on test machines on vectorized vs non-vectorized is about 35-50%. Note that it is only observable from .NET Core 3 usage onwards (I also tested on .NET 5, results are similar).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
