### PR TITLE
test: retry zipcrypto password tests once

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
@@ -147,9 +147,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 		/// <summary>
 		/// Invalid passwords should be detected early if possible, seekable stream
+		/// Note: Have a 1/255 chance of failing due to CRC collision (hence retried once)
 		/// </summary>
 		[Test]
 		[Category("Zip")]
+		[Retry(2)]
 		public void InvalidPasswordSeekable()
 		{
 			byte[] originalData = null;
@@ -216,9 +218,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 		/// <summary>
 		/// Invalid passwords should be detected early if possible, non seekable stream
+		/// Note: Have a 1/255 chance of failing due to CRC collision (hence retried once)
 		/// </summary>
 		[Test]
 		[Category("Zip")]
+		[Retry(2)]
 		public void InvalidPasswordNonSeekable()
 		{
 			byte[] originalData = null;


### PR DESCRIPTION
This should fix the intermittent test failures in CI due to the password check only comparing a single byte (as per the spec), which have a 1/255 chance of actually matching regardless of password.

Now, it still has a 1/65025 chance of colliding, but hopefully that should be rare enough to not matter.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
