### PR TITLE
Make BZip2Constants static instead of sealed

### DIFF
--- a/src/ICSharpCode.SharpZipLib/BZip2/BZip2Constants.cs
+++ b/src/ICSharpCode.SharpZipLib/BZip2/BZip2Constants.cs
@@ -3,7 +3,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// <summary>
 	/// Defines internal values for both compression and decompression
 	/// </summary>
-	internal sealed class BZip2Constants
+	internal static class BZip2Constants
 	{
 		/// <summary>
 		/// Random numbers used to randomise repetitive blocks
@@ -113,9 +113,5 @@ namespace ICSharpCode.SharpZipLib.BZip2
 		/// Backend constant
 		/// </summary>
 		public const int OvershootBytes = 20;
-
-		private BZip2Constants()
-		{
-		}
 	}
 }


### PR DESCRIPTION
Fixes some [CA1812](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1812) analyzer warnings.

I made the change looking at the output from #449 and then noticed that  #417 contains the same change, though i'm not sure what state that one is in now.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
