### PR TITLE
fix the expected/actual value ordering in a few unit test asserts

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/FastZipHandling.cs
@@ -268,7 +268,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					{
 						var index = z.FindEntry(name, true);
 
-						Assert.AreNotEqual(index, -1, "Zip entry \"{0}\" not found", name);
+						Assert.AreNotEqual(-1, index, "Zip entry \"{0}\" not found", name);
 
 						var entry = z[index];
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipNameTransformHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipNameTransformHandling.cs
@@ -102,15 +102,15 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Category("Zip")]
 		public void FilenameCleaning()
 		{
-			Assert.AreEqual(ZipEntry.CleanName("hello"), "hello");
+			Assert.AreEqual("hello", ZipEntry.CleanName("hello"));
 			if(Environment.OSVersion.Platform == PlatformID.Win32NT) 
 			{
-				Assert.AreEqual(ZipEntry.CleanName(@"z:\eccles"), "eccles");
-				Assert.AreEqual(ZipEntry.CleanName(@"\\server\share\eccles"), "eccles");
-				Assert.AreEqual(ZipEntry.CleanName(@"\\server\share\dir\eccles"), "dir/eccles");
+				Assert.AreEqual("eccles", ZipEntry.CleanName(@"z:\eccles"));
+				Assert.AreEqual("eccles", ZipEntry.CleanName(@"\\server\share\eccles"));
+				Assert.AreEqual("dir/eccles", ZipEntry.CleanName(@"\\server\share\dir\eccles"));
 			}
 			else {
-				Assert.AreEqual(ZipEntry.CleanName(@"/eccles"), "eccles");
+				Assert.AreEqual("eccles", ZipEntry.CleanName(@"/eccles"));
 			}
 		}
 


### PR DESCRIPTION
rather trivial, but still

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
