### PR TITLE
Limit code coverage to windows CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,7 +65,14 @@ jobs:
       run: dotnet test -c debug -f ${{ matrix.target }} --no-restore
       
     - name: Run tests (Release)
+      # Only upload code coverage for windows in an attempt to fix the broken code coverage
+      if: ${{ matrix.os == 'windows' }}
       run: dotnet test -c release -f ${{ matrix.target }} --no-restore --collect="XPlat Code Coverage"
+      
+    - name: Run tests with coverage (Release)
+      # Only upload code coverage for windows in an attempt to fix the broken code coverage
+      if: ${{ matrix.os != 'windows' }}
+      run: dotnet test -c release -f ${{ matrix.target }} --no-restore
       
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.2.2


### PR DESCRIPTION
Only upload code coverage for windows in an attempt to fix the broken code coverage diffs on PRs

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
