### PR TITLE
Suppress some localization related code analyzer suggestions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,3 +37,18 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+# C# source
+[*.{cs}]
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = none
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = none
+
+# CA1304: Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = none
+
+# CA1307: Specify StringComparison for clarity
+dotnet_diagnostic.CA1307.severity = none


### PR DESCRIPTION
Spin off from #449 that disables some of the localization related analyzers, to decide if disabling the set is ok (for now at least)

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
