### PR TITLE
add an async version of the WriteZipOutputStream benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,4 @@ paket-files/
 /test/ICSharpCode.SharpZipLib.TestBootstrapper/Properties/launchSettings.json
 _testRunner/
 docs/help/api/.manifest
+/benchmark/ICSharpCode.SharpZipLib.Benchmark/BenchmarkDotNet.Artifacts/results

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace ICSharpCode.SharpZipLib.Benchmark.Zip
@@ -32,6 +33,26 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 				for (int i = 0; i < ChunkCount; i++)
 				{
 					zipOutputStream.Write(inputBuffer, 0, inputBuffer.Length);
+				}
+
+				return memoryStream.Position;
+			}
+		}
+
+		[Benchmark]
+		public async Task<long> WriteZipOutputStreamAsync()
+		{
+			using (var memoryStream = new MemoryStream(outputBuffer))
+			{
+				using (var zipOutputStream = new SharpZipLib.Zip.ZipOutputStream(memoryStream))
+				{
+					zipOutputStream.IsStreamOwner = false;
+					zipOutputStream.PutNextEntry(new SharpZipLib.Zip.ZipEntry("0"));
+
+					for (int i = 0; i < ChunkCount; i++)
+					{
+						await zipOutputStream.WriteAsync(inputBuffer, 0, inputBuffer.Length);
+					}
 				}
 
 				return memoryStream.Position;


### PR DESCRIPTION


_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
