### PR TITLE
fix(tar): create translated files in temp

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
@@ -36,7 +36,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// </summary>
 		/// <param name="original">If specified, used as the base file name for the temporary file</param>
 		/// <returns>Returns a temporary file name</returns>
-		public static string GetTempFileName(string original)
+		public static string GetTempFileName(string original = null)
 		{
 			string fileName;
 			var tempPath = Path.GetTempPath();

--- a/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
@@ -824,7 +824,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				if (!IsBinary(entryFilename))
 				{
-					tempFileName = Path.GetRandomFileName();
+					tempFileName = PathUtils.GetTempFileName();
 
 					using (StreamReader inStream = File.OpenText(entryFilename))
 					{


### PR DESCRIPTION
In #622 the temporary file path was changed to use `Path.GetRandomFileName()` instead of `Path.GetTempFileName()`, which resulted in the current working directory being used for storing the translated tar files while creating archives.
This instead uses the `PathUtils.GetTempFileName()` that was created for this purpose.

Fixes #644

