### PR TITLE
Add support for old Info-ZIP extra block for Unix

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -955,6 +955,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 			ExtendedUnixData unixData = extraData.GetData<ExtendedUnixData>();
 			if (unixData != null && unixData.Include.HasFlag(ExtendedUnixData.Flags.ModificationTime))
 				return unixData.ModificationTime;
+			OldExtendedUnixData oldUnixData = extraData.GetData<OldExtendedUnixData>();
+			if (oldUnixData != null)
+				return oldUnixData.ModificationTime;
 
 			return null;
 		}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipExtraData.cs
@@ -320,6 +320,113 @@ namespace ICSharpCode.SharpZipLib.Zip
 		#endregion Instance Fields
 	}
 
+    /// <summary>
+	/// Class representing old format for extended unix date time values.
+	/// </summary>
+	public class OldExtendedUnixData : ITaggedData
+	{
+        #region ITaggedData Members
+
+		/// <summary>
+		/// Get the ID
+		/// </summary>
+		public short TagID
+		{
+			get { return 0x5855; }
+		}
+
+		/// <summary>
+		/// Set the data from the raw values provided.
+		/// </summary>
+		/// <param name="data">The raw data to extract values from.</param>
+		/// <param name="index">The index to start extracting values from.</param>
+		/// <param name="count">The number of bytes available.</param>
+		public void SetData(byte[] data, int index, int count)
+		{
+			using (MemoryStream ms = new MemoryStream(data, index, count, false))
+			using (ZipHelperStream helperStream = new ZipHelperStream(ms))
+			{
+				int iTime = helperStream.ReadLEInt();
+
+				_modificationTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) +
+					new TimeSpan(0, 0, 0, iTime, 0);
+
+				iTime = helperStream.ReadLEInt();
+
+				_lastAccessTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) +
+					new TimeSpan(0, 0, 0, iTime, 0);
+			}
+		}
+
+		/// <summary>
+		/// Get the binary data representing this instance.
+		/// </summary>
+		/// <returns>The raw binary data representing this instance.</returns>
+		public byte[] GetData()
+		{
+			using (MemoryStream ms = new MemoryStream())
+			using (ZipHelperStream helperStream = new ZipHelperStream(ms))
+			{
+				helperStream.IsStreamOwner = false;
+
+				TimeSpan span = _modificationTime - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+				var seconds = (int)span.TotalSeconds;
+				helperStream.WriteLEInt(seconds);
+
+				span = _lastAccessTime - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+				seconds = (int)span.TotalSeconds;
+				helperStream.WriteLEInt(seconds);
+
+				return ms.ToArray();
+			}
+		}
+
+		#endregion ITaggedData Members
+
+		/// <summary>
+		/// Get /set the Modification Time
+		/// </summary>
+		/// <exception cref="ArgumentOutOfRangeException"></exception>
+		public DateTime ModificationTime
+		{
+			get { return _modificationTime; }
+			set
+			{
+				if (!ExtendedUnixData.IsValidValue(value))
+				{
+					throw new ArgumentOutOfRangeException(nameof(value));
+				}
+
+				_modificationTime = value;
+			}
+		}
+
+		/// <summary>
+		/// Get / set the Access Time
+		/// </summary>
+		/// <exception cref="ArgumentOutOfRangeException"></exception>
+		public DateTime AccessTime
+		{
+			get { return _lastAccessTime; }
+			set
+			{
+				if (!ExtendedUnixData.IsValidValue(value))
+				{
+					throw new ArgumentOutOfRangeException(nameof(value));
+				}
+
+				_lastAccessTime = value;
+			}
+		}
+
+		#region Instance Fields
+
+		private DateTime _modificationTime = new DateTime(1970, 1, 1);
+		private DateTime _lastAccessTime = new DateTime(1970, 1, 1);
+
+		#endregion Instance Fields
+	}
+
 	/// <summary>
 	/// Class handling NT date time values.
 	/// </summary>


### PR DESCRIPTION
SharpZipLib currently supports reading timestamps from the "Extended Timestamp Extra Field" (`0x5455`).

This PR adds support for the older (but still often seen in new `.zip` files) "Info-ZIP Unix Extra Field (type 1)" (`0x5855`).

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._