### PR TITLE
fix(tar): permit slashed output dir

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
@@ -613,7 +613,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				throw new ObjectDisposedException("TarArchive");
 			}
 
-			var fullDistDir = Path.GetFullPath(destinationDirectory);
+			var fullDistDir = Path.GetFullPath(destinationDirectory).TrimEnd('/', '\\');
 
 			while (true)
 			{

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarArchiveTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarArchiveTests.cs
@@ -13,9 +13,12 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 		[Test]
 		[Category("Tar")]
 		[Category("CreatesTempFile")]
-		public void ExtractingContentsWithNonTraversalPathSucceeds()
+		[TestCase("output")]
+		[TestCase("output/")]
+		[TestCase(@"output\", IncludePlatform = "Win")]
+		public void ExtractingContentsWithNonTraversalPathSucceeds(string outputDir)
 		{
-			Assert.DoesNotThrow(() => ExtractTarOK("output", "test-good", allowTraverse: false));
+			Assert.DoesNotThrow(() => ExtractTarOK(outputDir, "file", allowTraverse: false));
 		}
 		
 		[Test]
@@ -30,8 +33,22 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 		[Category("Tar")]
 		[Category("CreatesTempFile")]
 		[TestCase("output", "../file")]
+		[TestCase("output/", "../file")]
 		[TestCase("output", "../output.txt")]
 		public void ExtractingContentsWithDisallowedPathsFails(string outputDir, string fileName)
+		{
+			Assert.Throws<InvalidNameException>(() => ExtractTarOK(outputDir, fileName, allowTraverse: false));
+		}
+		
+		[Test]
+		[Category("Tar")]
+		[Category("CreatesTempFile")]
+		[Platform(Include = "Win", Reason = "Backslashes are only treated as path separators on windows")]
+		[TestCase(@"output\", @"..\file")]
+		[TestCase(@"output/", @"..\file")]
+		[TestCase("output", @"..\output.txt")]
+		[TestCase(@"output\", @"..\output.txt")]
+		public void ExtractingContentsOnWindowsWithDisallowedPathsFails(string outputDir, string fileName)
 		{
 			Assert.Throws<InvalidNameException>(() => ExtractTarOK(outputDir, fileName, allowTraverse: false));
 		}


### PR DESCRIPTION
Fixes an issue where `TarArchive.ExtractContents` would cause an `InvalidNameException` when the destination dir ended with `/`.

Adds additional tests for combinations of tar file names and extraction destination paths.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
