### PR TITLE
feat(gzip): add GzipOutputStream async support

### DIFF
--- a/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -244,9 +244,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 			{
 				state_ = OutputState.Finished;
 				base.Finish();
-				
-				byte[] gzipFooter = GetFooter();
-
+				var gzipFooter = GetFooter();
 				baseOutputStream_.Write(gzipFooter, 0, gzipFooter.Length);
 			}
 		}
@@ -272,7 +270,8 @@ namespace ICSharpCode.SharpZipLib.GZip
 			{
 				state_ = OutputState.Finished;
 				await base.FinishAsync(ct);
-				await baseOutputStream_.WriteAsync(GetFooter(), ct);
+				var gzipFooter = GetFooter();
+				await baseOutputStream_.WriteAsync(gzipFooter, 0, gzipFooter.Length, ct);
 			}
 		}
 
@@ -352,7 +351,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 			baseOutputStream_.Write(gzipHeader, 0, gzipHeader.Length);
 		}
 		
-		private async ValueTask WriteHeaderAsync()
+		private async Task WriteHeaderAsync()
 		{
 			if (state_ != OutputState.Header) return;
 			state_ = OutputState.Footer;

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -412,7 +412,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 			}
 		}
 
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER
 		/// <summary>
 		/// Calls <see cref="FinishAsync"/> and closes the underlying
 		/// stream when <see cref="IsStreamOwner"></see> is true.

--- a/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipAsyncTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipAsyncTests.cs
@@ -1,0 +1,78 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Tests.TestSupport;
+using NUnit.Framework;
+
+namespace ICSharpCode.SharpZipLib.Tests.GZip
+{
+	
+#if NETCOREAPP3_1_OR_GREATER
+	[TestFixture]
+	public class GZipAsyncTests
+	{
+		[Test]
+		[Category("GZip")]
+		[Category("Async")]
+		public async Task SmallBufferDecompressionAsync([Values(0, 1, 3)] int seed)
+		{
+			var outputBufferSize = 100000;
+			var outputBuffer = new byte[outputBufferSize];
+			var inputBuffer = Utils.GetDummyBytes(outputBufferSize * 4, seed);
+			
+			await using var msGzip = new MemoryStream();
+			await using (var gzos = new GZipOutputStream(msGzip){IsStreamOwner = false})
+			{
+				await gzos.WriteAsync(inputBuffer, 0, inputBuffer.Length);
+			}
+
+			msGzip.Seek(0, SeekOrigin.Begin);
+
+			using (var gzis = new GZipInputStream(msGzip))
+			await using (var msRaw = new MemoryStream())
+			{
+				int readOut;
+				while ((readOut = gzis.Read(outputBuffer, 0, outputBuffer.Length)) > 0)
+				{
+					await msRaw.WriteAsync(outputBuffer, 0, readOut);
+				}
+
+				var resultBuffer = msRaw.ToArray();
+				for (var i = 0; i < resultBuffer.Length; i++)
+				{
+					Assert.AreEqual(inputBuffer[i], resultBuffer[i]);
+				}
+			}
+		}
+		
+		/// <summary>
+		/// Basic compress/decompress test
+		/// </summary>
+		[Test]
+		[Category("GZip")]
+		[Category("Async")]
+		public async Task OriginalFilenameAsync()
+		{
+			var content = "FileContents";
+
+			await using var ms = new MemoryStream();
+			await using (var outStream = new GZipOutputStream(ms) { IsStreamOwner = false })
+			{
+				outStream.FileName = "/path/to/file.ext";
+				outStream.Write(Encoding.ASCII.GetBytes(content));
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using (var inStream = new GZipInputStream(ms))
+			{
+				var readBuffer = new byte[content.Length];
+				inStream.Read(readBuffer, 0, readBuffer.Length);
+				Assert.AreEqual(content, Encoding.ASCII.GetString(readBuffer));
+				Assert.AreEqual("file.ext", inStream.GetFilename());
+			}
+		}
+	}
+#endif
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipAsyncTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipAsyncTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace ICSharpCode.SharpZipLib.Tests.GZip
 {
 	
-#if NETCOREAPP3_1_OR_GREATER
+
 	[TestFixture]
 	public class GZipAsyncTests
 	{
@@ -21,6 +21,7 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 			var outputBuffer = new byte[outputBufferSize];
 			var inputBuffer = Utils.GetDummyBytes(outputBufferSize * 4, seed);
 			
+#if NETCOREAPP3_1_OR_GREATER
 			await using var msGzip = new MemoryStream();
 			await using (var gzos = new GZipOutputStream(msGzip){IsStreamOwner = false})
 			{
@@ -44,6 +45,31 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 					Assert.AreEqual(inputBuffer[i], resultBuffer[i]);
 				}
 			}
+#else
+			using var msGzip = new MemoryStream();
+			using (var gzos = new GZipOutputStream(msGzip){IsStreamOwner = false})
+			{
+				await gzos.WriteAsync(inputBuffer, 0, inputBuffer.Length);
+			}
+
+			msGzip.Seek(0, SeekOrigin.Begin);
+
+			using (var gzis = new GZipInputStream(msGzip))
+			using (var msRaw = new MemoryStream())
+			{
+				int readOut;
+				while ((readOut = gzis.Read(outputBuffer, 0, outputBuffer.Length)) > 0)
+				{
+					await msRaw.WriteAsync(outputBuffer, 0, readOut);
+				}
+
+				var resultBuffer = msRaw.ToArray();
+				for (var i = 0; i < resultBuffer.Length; i++)
+				{
+					Assert.AreEqual(inputBuffer[i], resultBuffer[i]);
+				}
+			}
+#endif
 		}
 		
 		/// <summary>
@@ -56,13 +82,23 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 		{
 			var content = "FileContents";
 
+#if NETCOREAPP3_1_OR_GREATER
 			await using var ms = new MemoryStream();
 			await using (var outStream = new GZipOutputStream(ms) { IsStreamOwner = false })
 			{
 				outStream.FileName = "/path/to/file.ext";
 				outStream.Write(Encoding.ASCII.GetBytes(content));
 			}
-
+#else
+			var ms = new MemoryStream();
+			var outStream = new GZipOutputStream(ms){ IsStreamOwner = false };
+			outStream.FileName = "/path/to/file.ext";
+			var bytes = Encoding.ASCII.GetBytes(content);
+			outStream.Write(bytes, 0, bytes.Length);
+			await outStream.FinishAsync(System.Threading.CancellationToken.None);
+			outStream.Dispose();
+			
+#endif
 			ms.Seek(0, SeekOrigin.Begin);
 
 			using (var inStream = new GZipInputStream(ms))
@@ -74,5 +110,4 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 			}
 		}
 	}
-#endif
 }

--- a/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipAsyncTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipAsyncTests.cs
@@ -109,5 +109,36 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 				Assert.AreEqual("file.ext", inStream.GetFilename());
 			}
 		}
+
+		/// <summary>
+		/// Test creating an empty gzip stream using async
+		/// </summary>
+		[Test]
+		[Category("GZip")]
+		[Category("Async")]
+		public async Task EmptyGZipStreamAsync()
+		{
+#if NETCOREAPP3_1_OR_GREATER
+			await using var ms = new MemoryStream();
+			await using (var outStream = new GZipOutputStream(ms) { IsStreamOwner = false })
+			{
+				// No content
+			}
+#else
+			var ms = new MemoryStream();
+			var outStream = new GZipOutputStream(ms){ IsStreamOwner = false };
+			await outStream.FinishAsync(System.Threading.CancellationToken.None);
+			outStream.Dispose();
+
+#endif
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using (var inStream = new GZipInputStream(ms))
+			using (var reader = new StreamReader(inStream))
+			{
+				var content = await reader.ReadToEndAsync();
+				Assert.IsEmpty(content);
+			}
+		}
 	}
 }

--- a/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipTests.cs
@@ -388,32 +388,23 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 
 		[Test]
 		[Category("GZip")]
-		public void SmallBufferDecompression()
+		public void SmallBufferDecompression([Values(0, 1, 3)] int seed)
 		{
 			var outputBufferSize = 100000;
-			var inputBufferSize = outputBufferSize * 4;
-			var inputBuffer = Utils.GetDummyBytes(inputBufferSize, seed: 0);
-			
 			var outputBuffer = new byte[outputBufferSize];
+			var inputBuffer = Utils.GetDummyBytes(outputBufferSize * 4, seed);
 
 			using var msGzip = new MemoryStream();
-			using (var gzos = new GZipOutputStream(msGzip))
+			using (var gzos = new GZipOutputStream(msGzip){IsStreamOwner = false})
 			{
-				gzos.IsStreamOwner = false;
-				
 				gzos.Write(inputBuffer, 0, inputBuffer.Length);
-				
-				gzos.Flush();
-				gzos.Finish();
 			}
 
 			msGzip.Seek(0, SeekOrigin.Begin);
-				
-
+	
 			using (var gzis = new GZipInputStream(msGzip))
 			using (var msRaw = new MemoryStream())
 			{
-					
 				int readOut;
 				while ((readOut = gzis.Read(outputBuffer, 0, outputBuffer.Length)) > 0)
 				{
@@ -421,59 +412,13 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 				}
 
 				var resultBuffer = msRaw.ToArray();
-
 				for (var i = 0; i < resultBuffer.Length; i++)
 				{
 					Assert.AreEqual(inputBuffer[i], resultBuffer[i]);
 				}
-
-
 			}
 		}
-		
-#if NETCOREAPP3_1_OR_GREATER
-		[Test]
-		[Category("GZip")]
-		[Category("Async")]
-		public async Task SmallBufferDecompressionAsync()
-		{
-			var outputBufferSize = 100000;
-			var inputBufferSize = outputBufferSize * 4;
-			var inputBuffer = Utils.GetDummyBytes(inputBufferSize, seed: 0);
-			
-			var outputBuffer = new byte[outputBufferSize];
 
-			await using var msGzip = new MemoryStream();
-			await using (var gzos = new GZipOutputStream(msGzip){IsStreamOwner = false})
-			{
-				await gzos.WriteAsync(inputBuffer, 0, inputBuffer.Length);
-			}
-
-			msGzip.Seek(0, SeekOrigin.Begin);
-
-
-			using (var gzis = new GZipInputStream(msGzip))
-			await using (var msRaw = new MemoryStream())
-			{
-					
-				int readOut;
-				while ((readOut = await gzis.ReadAsync(outputBuffer, 0, outputBuffer.Length)) > 0)
-				{
-					await msRaw.WriteAsync(outputBuffer, 0, readOut);
-				}
-
-				var resultBuffer = msRaw.ToArray();
-
-				for (var i = 0; i < resultBuffer.Length; i++)
-				{
-					Assert.AreEqual(inputBuffer[i], resultBuffer[i]);
-				}
-
-
-			}
-		}
-#endif
-		
 		/// <summary>
 		/// Should gracefully handle reading from a stream that becomes unreadable after
 		///  all of the data has been read.

--- a/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/GZip/GZipTests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.SharpZipLib.Tests.GZip
 {
@@ -428,7 +430,50 @@ namespace ICSharpCode.SharpZipLib.Tests.GZip
 
 			}
 		}
+		
+#if NETCOREAPP3_1_OR_GREATER
+		[Test]
+		[Category("GZip")]
+		[Category("Async")]
+		public async Task SmallBufferDecompressionAsync()
+		{
+			var outputBufferSize = 100000;
+			var inputBufferSize = outputBufferSize * 4;
+			var inputBuffer = Utils.GetDummyBytes(inputBufferSize, seed: 0);
+			
+			var outputBuffer = new byte[outputBufferSize];
 
+			await using var msGzip = new MemoryStream();
+			await using (var gzos = new GZipOutputStream(msGzip){IsStreamOwner = false})
+			{
+				await gzos.WriteAsync(inputBuffer, 0, inputBuffer.Length);
+			}
+
+			msGzip.Seek(0, SeekOrigin.Begin);
+
+
+			using (var gzis = new GZipInputStream(msGzip))
+			await using (var msRaw = new MemoryStream())
+			{
+					
+				int readOut;
+				while ((readOut = await gzis.ReadAsync(outputBuffer, 0, outputBuffer.Length)) > 0)
+				{
+					await msRaw.WriteAsync(outputBuffer, 0, readOut);
+				}
+
+				var resultBuffer = msRaw.ToArray();
+
+				for (var i = 0; i < resultBuffer.Length; i++)
+				{
+					Assert.AreEqual(inputBuffer[i], resultBuffer[i]);
+				}
+
+
+			}
+		}
+#endif
+		
 		/// <summary>
 		/// Should gracefully handle reading from a stream that becomes unreadable after
 		///  all of the data has been read.

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using ICSharpCode.SharpZipLib.Tests.TestSupport;
 using ICSharpCode.SharpZipLib.Zip;
+using ICSharpCode.SharpZipLib.Tests.TestSupport;
 using NUnit.Framework;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
@@ -10,12 +10,12 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 	[TestFixture]
 	public class ZipStreamAsyncTests
 	{
-#if NETCOREAPP3_1_OR_GREATER
 		[Test]
 		[Category("Zip")]
 		[Category("Async")]
 		public async Task WriteZipStreamUsingAsync()
 		{
+#if NETCOREAPP3_1_OR_GREATER
 			await using var ms = new MemoryStream();
 			
 			await using (var outStream = new ZipOutputStream(ms){IsStreamOwner = false})
@@ -28,8 +28,11 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 
 			ZipTesting.AssertValidZip(ms);
-		}
+#else
+			await Task.CompletedTask;
+			Assert.Ignore("Async Using is not supported");
 #endif
+		}
 
 		[Test]
 		[Category("Zip")]


### PR DESCRIPTION
Follow up to #574 that implements `DisposeAsync` and "true" async write support to `GzipOutputStream`.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
