### PR TITLE
fix(tar): read full extended headers

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarExtendedHeaderReader.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarExtendedHeaderReader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace ICSharpCode.SharpZipLib.Tar
@@ -26,7 +27,10 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 		private int state = LENGTH;
 
-		private static readonly byte[] StateNext = new[] { (byte)' ', (byte)'=', (byte)'\n' };
+		private int currHeaderLength;
+		private int currHeaderRead;
+
+		private static readonly byte[] StateNext = { (byte)' ', (byte)'=', (byte)'\n' };
 
 		/// <summary>
 		/// Creates a new <see cref="TarExtendedHeaderReader"/>.
@@ -46,23 +50,47 @@ namespace ICSharpCode.SharpZipLib.Tar
 			for (int i = 0; i < length; i++)
 			{
 				byte next = buffer[i];
+				
+				var foundStateEnd = state == VALUE 
+					? currHeaderRead == currHeaderLength -1
+					: next == StateNext[state];
 
-				if (next == StateNext[state])
+				if (foundStateEnd)
 				{
 					Flush();
 					headerParts[state] = sb.ToString();
 					sb.Clear();
-
+					
 					if (++state == END)
 					{
-						headers.Add(headerParts[KEY], headerParts[VALUE]);
+						Console.WriteLine($"KEY: {headerParts[KEY]}");
+						if (!headers.ContainsKey(headerParts[KEY]))
+						{
+							headers.Add(headerParts[KEY], headerParts[VALUE]);
+						}
+
 						headerParts = new string[3];
+						currHeaderLength = 0;
+						currHeaderRead = 0;
 						state = LENGTH;
+					}
+					else
+					{
+						currHeaderRead++;
+					}
+					
+
+					if (state != VALUE) continue;
+
+					if (int.TryParse(headerParts[LENGTH], out var vl))
+					{
+						currHeaderLength = vl;
 					}
 				}
 				else
 				{
 					byteBuffer[bbIndex++] = next;
+					currHeaderRead++;
 					if (bbIndex == 4)
 						Flush();
 				}

--- a/src/ICSharpCode.SharpZipLib/Tar/TarExtendedHeaderReader.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarExtendedHeaderReader.cs
@@ -63,7 +63,6 @@ namespace ICSharpCode.SharpZipLib.Tar
 					
 					if (++state == END)
 					{
-						Console.WriteLine($"KEY: {headerParts[KEY]}");
 						if (!headers.ContainsKey(headerParts[KEY]))
 						{
 							headers.Add(headerParts[KEY], headerParts[VALUE]);


### PR DESCRIPTION
Fixes #383, but is not the most elegant solution. `TarExtendedHeaderReader` should probably be rewritten from scratch.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
