### PR TITLE
Fix NullReferenceException in PathUtils.DropPathRoot if Path.GetPathR…

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
@@ -26,7 +26,7 @@ namespace ICSharpCode.SharpZipLib.Core
 			var cleanPath = new string(path.Take(258)
 				.Select( (c, i) => invalidChars.Contains(c) || (i == 2 && cleanRootSep) ? '_' : c).ToArray());
 
-			var stripLength = Path.GetPathRoot(cleanPath).Length;
+			var stripLength = Path.GetPathRoot(cleanPath)?.Length ?? 0;
 			while (path.Length > stripLength && (path[stripLength] == '/' || path[stripLength] == '\\')) stripLength++;
 			return path.Substring(stripLength);
 		}


### PR DESCRIPTION
The Path.GetPathRoot method is able to return null.
PathUtils.DropPathRoot should handle this case.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
