### PR TITLE
feat(zip): make it possible to skip header tests

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -231,6 +231,21 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </summary>
 		ReservedPkware15 = 0x8000
 	}
+	
+	/// <summary>
+	/// Helpers for <see cref="GeneralBitFlags"/>
+	/// </summary>
+	public static class GeneralBitFlagsExtensions
+	{
+		/// <summary>
+		/// This is equivalent of <see cref="Enum.HasFlag"/> in .NET Core, but since the .NET FW
+		/// version is really slow (due to un-/boxing and reflection)  we use this wrapper.
+		/// </summary>
+		/// <param name="flagData"></param>
+		/// <param name="flag"></param>
+		/// <returns></returns>
+		public static bool Includes(this GeneralBitFlags flagData, GeneralBitFlags flag) => (flag & flagData) != 0;
+	}
 
 	#endregion Enumerations
 

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1111,13 +1111,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				if (signature != ZipConstants.LocalHeaderSignature)
 				{
-					throw new ZipException(string.Format("Wrong local header signature at 0x{0:x}, expected 0x{1:x8}, actual 0x{2:x8}",
-						entryAbsOffset, ZipConstants.LocalHeaderSignature, signature));
+					throw new ZipException($"Wrong local header signature at 0x{entryAbsOffset:x}, expected 0x{ZipConstants.LocalHeaderSignature:x8}, actual 0x{signature:x8}");
 				}
 
 				var extractVersion = (short)(ReadLEUshort() & 0x00ff);
-				var localFlags = (short)ReadLEUshort();
-				var compressionMethod = (short)ReadLEUshort();
+				var localFlags = (GeneralBitFlags)ReadLEUshort();
+				var compressionMethod = (CompressionMethod)ReadLEUshort();
 				var fileTime = (short)ReadLEUshort();
 				var fileDate = (short)ReadLEUshort();
 				uint crcValue = ReadLEUint();
@@ -1135,7 +1134,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				var localExtraData = new ZipExtraData(extraData);
 
 				// Extra data / zip64 checks
-				if (localExtraData.Find(1))
+				if (localExtraData.Find(headerID: 1))
 				{
 					// 2010-03-04 Forum 10512: removed checks for version >= ZipConstants.VersionZip64
 					// and size or compressedSize = MaxValue, due to rogue creators.
@@ -1143,7 +1142,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					size = localExtraData.ReadLong();
 					compressedSize = localExtraData.ReadLong();
 
-					if ((localFlags & (int)GeneralBitFlags.Descriptor) != 0)
+					if (localFlags.Includes(GeneralBitFlags.Descriptor))
 					{
 						// These may be valid if patched later
 						if ((size != -1) && (size != entry.Size))
@@ -1176,15 +1175,17 @@ namespace ICSharpCode.SharpZipLib.Zip
 							throw new ZipException("Compression method not supported");
 						}
 
-						if ((extractVersion > ZipConstants.VersionMadeBy)
-							|| ((extractVersion > 20) && (extractVersion < ZipConstants.VersionZip64)))
+						if (extractVersion > ZipConstants.VersionMadeBy
+							|| (extractVersion > 20 && extractVersion < ZipConstants.VersionZip64))
 						{
-							throw new ZipException(string.Format("Version required to extract this entry not supported ({0})", extractVersion));
+							throw new ZipException($"Version required to extract this entry not supported ({extractVersion})");
 						}
 
-						if ((localFlags & (int)(GeneralBitFlags.Patched | GeneralBitFlags.StrongEncryption | GeneralBitFlags.EnhancedCompress | GeneralBitFlags.HeaderMasked)) != 0)
+						const GeneralBitFlags notSupportedFlags = GeneralBitFlags.Patched | GeneralBitFlags.StrongEncryption |
+						                        GeneralBitFlags.EnhancedCompress | GeneralBitFlags.HeaderMasked;
+						if (localFlags.Includes(notSupportedFlags))
 						{
-							throw new ZipException("The library does not support the zip version required to extract this entry");
+							throw new ZipException($"The library does not support the zip features required to extract this entry ({localFlags & notSupportedFlags:F})");
 						}
 					}
 				}
@@ -1208,53 +1209,53 @@ namespace ICSharpCode.SharpZipLib.Zip
 						(extractVersion != 63)
 						)
 					{
-						throw new ZipException(string.Format("Version required to extract this entry is invalid ({0})", extractVersion));
+						throw new ZipException($"Version required to extract this entry is invalid ({extractVersion})");
 					}
 
 					var localEncoding = _stringCodec.ZipInputEncoding(localFlags);
 
 					// Local entry flags dont have reserved bit set on.
-					if ((localFlags & (int)(GeneralBitFlags.ReservedPKware4 | GeneralBitFlags.ReservedPkware14 | GeneralBitFlags.ReservedPkware15)) != 0)
+					if (localFlags.Includes(GeneralBitFlags.ReservedPKware4 | GeneralBitFlags.ReservedPkware14 | GeneralBitFlags.ReservedPkware15))
 					{
 						throw new ZipException("Reserved bit flags cannot be set.");
 					}
 
 					// Encryption requires extract version >= 20
-					if (((localFlags & (int)GeneralBitFlags.Encrypted) != 0) && (extractVersion < 20))
+					if (localFlags.Includes(GeneralBitFlags.Encrypted) && extractVersion < 20)
 					{
-						throw new ZipException(string.Format("Version required to extract this entry is too low for encryption ({0})", extractVersion));
+						throw new ZipException($"Version required to extract this entry is too low for encryption ({extractVersion})");
 					}
 
 					// Strong encryption requires encryption flag to be set and extract version >= 50.
-					if ((localFlags & (int)GeneralBitFlags.StrongEncryption) != 0)
+					if (localFlags.Includes(GeneralBitFlags.StrongEncryption))
 					{
-						if ((localFlags & (int)GeneralBitFlags.Encrypted) == 0)
+						if (!localFlags.Includes(GeneralBitFlags.Encrypted))
 						{
 							throw new ZipException("Strong encryption flag set but encryption flag is not set");
 						}
 
 						if (extractVersion < 50)
 						{
-							throw new ZipException(string.Format("Version required to extract this entry is too low for encryption ({0})", extractVersion));
+							throw new ZipException($"Version required to extract this entry is too low for encryption ({extractVersion})");
 						}
 					}
 
 					// Patched entries require extract version >= 27
-					if (((localFlags & (int)GeneralBitFlags.Patched) != 0) && (extractVersion < 27))
+					if (localFlags.Includes(GeneralBitFlags.Patched) && extractVersion < 27)
 					{
-						throw new ZipException(string.Format("Patched data requires higher version than ({0})", extractVersion));
+						throw new ZipException($"Patched data requires higher version than ({extractVersion})");
 					}
 
 					// Central header flags match local entry flags.
-					if (localFlags != entry.Flags)
+					if (!localFlags.Equals((GeneralBitFlags)entry.Flags))
 					{
-						throw new ZipException("Central header/local header flags mismatch");
+						throw new ZipException($"Central header/local header flags mismatch ({(GeneralBitFlags)entry.Flags:F} vs {localFlags:F})");
 					}
 
 					// Central header compression method matches local entry
-					if (entry.CompressionMethodForHeader != (CompressionMethod)compressionMethod)
+					if (entry.CompressionMethodForHeader != compressionMethod)
 					{
-						throw new ZipException("Central header/local header compression method mismatch");
+						throw new ZipException($"Central header/local header compression method mismatch ({entry.CompressionMethodForHeader:G} vs {compressionMethod:G})");
 					}
 
 					if (entry.Version != extractVersion)
@@ -1263,7 +1264,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					}
 
 					// Strong encryption and extract version match
-					if ((localFlags & (int)GeneralBitFlags.StrongEncryption) != 0)
+					if (localFlags.Includes(GeneralBitFlags.StrongEncryption))
 					{
 						if (extractVersion < 62)
 						{
@@ -1271,15 +1272,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 						}
 					}
 
-					if ((localFlags & (int)GeneralBitFlags.HeaderMasked) != 0)
+					if (localFlags.Includes(GeneralBitFlags.HeaderMasked))
 					{
-						if ((fileTime != 0) || (fileDate != 0))
+						if (fileTime != 0 || fileDate != 0)
 						{
 							throw new ZipException("Header masked set but date/time values non-zero");
 						}
 					}
 
-					if ((localFlags & (int)GeneralBitFlags.Descriptor) == 0)
+					if (!localFlags.Includes(GeneralBitFlags.Descriptor))
 					{
 						if (crcValue != (uint)entry.Crc)
 						{
@@ -1288,8 +1289,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 					}
 
 					// Crc valid for empty entry.
-					// This will also apply to streamed entries where size isnt known and the header cant be patched
-					if ((size == 0) && (compressedSize == 0))
+					// This will also apply to streamed entries where size isn't known and the header cant be patched
+					if (size == 0 && compressedSize == 0)
 					{
 						if (crcValue != 0)
 						{
@@ -1349,23 +1350,18 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				// Size can be verified only if it is known in the local header.
 				// it will always be known in the central header.
-				if (((localFlags & (int)GeneralBitFlags.Descriptor) == 0) ||
+				if (!localFlags.Includes(GeneralBitFlags.Descriptor) ||
 					((size > 0 || compressedSize > 0) && entry.Size > 0))
 				{
-					if ((size != 0)
-						&& (size != entry.Size))
+					if (size != 0 && size != entry.Size)
 					{
-						throw new ZipException(
-							string.Format("Size mismatch between central header({0}) and local header({1})",
-								entry.Size, size));
+						throw new ZipException($"Size mismatch between central header ({entry.Size}) and local header ({size})");
 					}
 
-					if ((compressedSize != 0)
+					if (compressedSize != 0
 						&& (compressedSize != entry.CompressedSize && compressedSize != 0xFFFFFFFF && compressedSize != -1))
 					{
-						throw new ZipException(
-							string.Format("Compressed size mismatch between central header({0}) and local header({1})",
-							entry.CompressedSize, compressedSize));
+						throw new ZipException($"Compressed size mismatch between central header({entry.CompressedSize}) and local header({compressedSize})");
 					}
 				}
 
@@ -3503,20 +3499,16 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 
 			bool isZip64 = false;
-			bool requireZip64 = false;
-
+			
 			// Check if zip64 header information is required.
-			if ((thisDiskNumber == 0xffff) ||
-				(startCentralDirDisk == 0xffff) ||
-				(entriesForThisDisk == 0xffff) ||
-				(entriesForWholeCentralDir == 0xffff) ||
-				(centralDirSize == 0xffffffff) ||
-				(offsetOfCentralDir == 0xffffffff))
-			{
-				requireZip64 = true;
-			}
+			bool requireZip64 = thisDiskNumber == 0xffff ||
+			                    startCentralDirDisk == 0xffff ||
+			                    entriesForThisDisk == 0xffff ||
+			                    entriesForWholeCentralDir == 0xffff ||
+			                    centralDirSize == 0xffffffff ||
+			                    offsetOfCentralDir == 0xffffffff;
 
-			// #357 - always check for the existance of the Zip64 central directory.
+			// #357 - always check for the existence of the Zip64 central directory.
 			// #403 - Take account of the fixed size of the locator when searching.
 			//    Subtract from locatedEndOfCentralDir so that the endLocation is the location of EndOfCentralDirectorySignature,
 			//    rather than the data following the signature.
@@ -3550,7 +3542,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				if (sig64 != ZipConstants.Zip64CentralFileHeaderSignature)
 				{
-					throw new ZipException(string.Format("Invalid Zip64 Central directory signature at {0:X}", offset64));
+					throw new ZipException($"Invalid Zip64 Central directory signature at {offset64:X}");
 				}
 
 				// NOTE: Record size = SizeOfFixedFields + SizeOfVariableData - 12.
@@ -3605,8 +3597,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 				int extraLen = ReadLEUshort();
 				int commentLen = ReadLEUshort();
 
-				int diskStartNo = ReadLEUshort();  // Not currently used
-				int internalAttributes = ReadLEUshort();  // Not currently used
+				
+				// ReSharper disable once UnusedVariable, Currently unused but needs to be read to offset the stream
+				int diskStartNo = ReadLEUshort();
+				// ReSharper disable once UnusedVariable, Currently unused but needs to be read to offset the stream
+				int internalAttributes = ReadLEUshort();
 
 				uint externalAttributes = ReadLEUint();
 				long offset = ReadLEUint();
@@ -3630,7 +3625,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 					ExternalFileAttributes = (int)externalAttributes
 				};
 
-				if ((bitFlags & 8) == 0)
+				if (!entry.HasFlag(GeneralBitFlags.Descriptor))
 				{
 					entry.CryptoCheckValue = (byte)(crc >> 24);
 				}
@@ -3698,15 +3693,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 					}
 					int saltLen = entry.AESSaltLen;
 					byte[] saltBytes = new byte[saltLen];
-					int saltIn = StreamUtils.ReadRequestedBytes(baseStream, saltBytes, 0, saltLen);
-					if (saltIn != saltLen)
-						throw new ZipException("AES Salt expected " + saltLen + " got " + saltIn);
-					//
+					int saltIn = StreamUtils.ReadRequestedBytes(baseStream, saltBytes, offset: 0, saltLen);
+					
+					if (saltIn != saltLen) throw new ZipException($"AES Salt expected {saltLen} git {saltIn}");
+					
 					byte[] pwdVerifyRead = new byte[2];
 					StreamUtils.ReadFully(baseStream, pwdVerifyRead);
 					int blockSize = entry.AESKeySize / 8;   // bits to bytes
 
-					var decryptor = new ZipAESTransform(rawPassword_, saltBytes, blockSize, false);
+					var decryptor = new ZipAESTransform(rawPassword_, saltBytes, blockSize, writeMode: false);
 					byte[] pwdVerifyCalc = decryptor.PwdVerifier;
 					if (pwdVerifyCalc[0] != pwdVerifyRead[0] || pwdVerifyCalc[1] != pwdVerifyRead[1])
 						throw new ZipException("Invalid password for AES");
@@ -3719,8 +3714,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 			else
 			{
-				if ((entry.Version < ZipConstants.VersionStrongEncryption)
-					|| (entry.Flags & (int)GeneralBitFlags.StrongEncryption) == 0)
+				if (entry.Version < ZipConstants.VersionStrongEncryption || !entry.HasFlag(GeneralBitFlags.StrongEncryption))
 				{
 					var classicManaged = new PkzipClassicManaged();
 
@@ -3745,31 +3739,29 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 		private Stream CreateAndInitEncryptionStream(Stream baseStream, ZipEntry entry)
 		{
-			CryptoStream result = null;
-			if ((entry.Version < ZipConstants.VersionStrongEncryption)
-				|| (entry.Flags & (int)GeneralBitFlags.StrongEncryption) == 0)
+			if (entry.Version >= ZipConstants.VersionStrongEncryption &&
+			    entry.HasFlag(GeneralBitFlags.StrongEncryption)) return null;
+
+			var classicManaged = new PkzipClassicManaged();
+
+			OnKeysRequired(entry.Name);
+			if (HaveKeys == false)
 			{
-				var classicManaged = new PkzipClassicManaged();
+				throw new ZipException("No password available for encrypted stream");
+			}
 
-				OnKeysRequired(entry.Name);
-				if (HaveKeys == false)
-				{
-					throw new ZipException("No password available for encrypted stream");
-				}
+			// Closing a CryptoStream will close the base stream as well so wrap it in an UncompressedStream
+			// which doesnt do this.
+			var result = new CryptoStream(new UncompressedStream(baseStream),
+				classicManaged.CreateEncryptor(key, null), CryptoStreamMode.Write);
 
-				// Closing a CryptoStream will close the base stream as well so wrap it in an UncompressedStream
-				// which doesnt do this.
-				result = new CryptoStream(new UncompressedStream(baseStream),
-					classicManaged.CreateEncryptor(key, null), CryptoStreamMode.Write);
-
-				if ((entry.Crc < 0) || (entry.Flags & 8) != 0)
-				{
-					WriteEncryptionHeader(result, entry.DosTime << 16);
-				}
-				else
-				{
-					WriteEncryptionHeader(result, entry.Crc);
-				}
+			if (entry.Crc < 0 || entry.HasFlag(GeneralBitFlags.Descriptor))
+			{
+				WriteEncryptionHeader(result, entry.DosTime << 16);
+			}
+			else
+			{
+				WriteEncryptionHeader(result, entry.Crc);
 			}
 			return result;
 		}
@@ -3792,7 +3784,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				rng.GetBytes(cryptBuffer);
 			}
 			cryptBuffer[11] = (byte)(crcValue >> 24);
-			stream.Write(cryptBuffer, 0, cryptBuffer.Length);
+			stream.Write(cryptBuffer, offset: 0, cryptBuffer.Length);
 		}
 
 		#endregion Internal routines

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1084,6 +1084,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		[Flags]
 		private enum HeaderTest
 		{
+			None = 0x0,
 			Extract = 0x01,     // Check that this header represents an entry whose data can be extracted
 			Header = 0x02,     // Check that this header contents are valid
 		}
@@ -3672,8 +3673,14 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </exception>
 		private long LocateEntry(ZipEntry entry)
 		{
-			return TestLocalHeader(entry, HeaderTest.Extract);
+			return TestLocalHeader(entry, SkipLocalEntryTestsOnLocate ? HeaderTest.None : HeaderTest.Extract);
 		}
+
+		/// <summary>
+		/// Skip the verification of the local header when reading an archive entry. Set this to attempt to read the
+		/// entries even if the headers should indicate that doing so would fail or produce an unexpected output. 
+		/// </summary>
+		public bool SkipLocalEntryTestsOnLocate { get; set; } = false;
 
 		private Stream CreateAndInitDecryptionStream(Stream baseStream, ZipEntry entry)
 		{

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
@@ -2,7 +2,6 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ICSharpCode.SharpZipLib.Tests.TestSupport

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security;
 using System.Text;
+using Does = ICSharpCode.SharpZipLib.Tests.TestSupport.Does;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
@@ -383,7 +384,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					index += count;
 				}
 			}
-			Assert.IsTrue(ZipTesting.TestArchive(ms.ToArray()));
+			Assert.That(ms.ToArray(), Does.PassTestArchive());
 		}
 
 		[Test]
@@ -391,20 +392,20 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		public void StoredNonSeekableKnownSizeNoCrcEncrypted()
 		{
 			// This cant be stored directly as the crc is not known
-			const int TargetSize = 24692;
-			const string Password = "Mabutu";
+			const int targetSize = 24692;
+			const string password = "Mabutu";
 
 			MemoryStream ms = new MemoryStreamWithoutSeek();
 
 			using (ZipOutputStream outStream = new ZipOutputStream(ms))
 			{
-				outStream.Password = Password;
+				outStream.Password = password;
 				outStream.IsStreamOwner = false;
 				var entry = new ZipEntry("dummyfile.tst");
 				entry.CompressionMethod = CompressionMethod.Stored;
 
 				// The bit thats in question is setting the size before its added to the archive.
-				entry.Size = TargetSize;
+				entry.Size = targetSize;
 
 				outStream.PutNextEntry(entry);
 
@@ -413,7 +414,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 				var rnd = new Random();
 
-				int size = TargetSize;
+				int size = targetSize;
 				byte[] original = new byte[size];
 				rnd.NextBytes(original);
 
@@ -429,7 +430,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					index += count;
 				}
 			}
-			Assert.IsTrue(ZipTesting.TestArchive(ms.ToArray(), Password));
+			Assert.That(ms.ToArray(), Does.PassTestArchive(password));
 		}
 
 		/// <summary>
@@ -502,10 +503,10 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 				int extractCount = 0;
 				int extractIndex = 0;
-				ZipEntry entry;
+
 				byte[] decompressedData = new byte[100];
 
-				while ((entry = inStream.GetNextEntry()) != null)
+				while (inStream.GetNextEntry() != null)
 				{
 					extractCount = decompressedData.Length;
 					extractIndex = 0;
@@ -531,7 +532,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Category("Zip")]
 		public void BasicStoredEncrypted()
 		{
-			ExerciseZip(CompressionMethod.Stored, 0, 50000, "Rosebud", true);
+			ExerciseZip(CompressionMethod.Stored, compressionLevel: 0, size: 50000, "Rosebud", canSeek: true);
 		}
 
 		/// <summary>
@@ -542,7 +543,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Category("Zip")]
 		public void BasicStoredEncryptedNonSeekable()
 		{
-			ExerciseZip(CompressionMethod.Stored, 0, 50000, "Rosebud", false);
+			ExerciseZip(CompressionMethod.Stored, compressionLevel: 0, size: 50000, "Rosebud", canSeek: false);
 		}
 
 		/// <summary>

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/PassthroughTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/PassthroughTests.cs
@@ -6,6 +6,7 @@ using ICSharpCode.SharpZipLib.Checksum;
 using ICSharpCode.SharpZipLib.Tests.TestSupport;
 using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
+using Does = ICSharpCode.SharpZipLib.Tests.TestSupport.Does;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
@@ -34,7 +35,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				compressedData.CopyTo(outStream);
 			}
 
-			Assert.IsTrue(ZipTesting.TestArchive(ms.ToArray()));
+			Assert.That(ms.ToArray(), Does.PassTestArchive());
 		}
 
 		private static (MemoryStream, Crc32, int) CreateDeflatedData()

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
@@ -4,6 +4,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 using System;
 using System.IO;
+using Does = ICSharpCode.SharpZipLib.Tests.TestSupport.Does;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
@@ -77,7 +78,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			outStream.WriteByte(89);
 			outStream.Close();
 
-			Assert.IsTrue(ZipTesting.TestArchive(msw.ToArray()));
+			Assert.That(msw.ToArray(), Does.PassTestArchive());
 
 			msw = new MemoryStreamWithoutSeek();
 			outStream = new ZipOutputStream(msw);
@@ -88,7 +89,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			outStream.WriteByte(89);
 			outStream.Close();
 
-			Assert.IsTrue(ZipTesting.TestArchive(msw.ToArray()));
+			Assert.That(msw.ToArray(), Does.PassTestArchive());
 		}
 
 		[Test]
@@ -110,7 +111,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				outStream.Close();
 			}
 
-			Assert.IsTrue(ZipTesting.TestArchive(msw.ToArray()));
+			Assert.That(msw.ToArray(), Does.PassTestArchive());
 
 			msw.Position = 0;
 
@@ -147,7 +148,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			outStream.Finish();
 			outStream.Close();
 
-			Assert.IsTrue(ZipTesting.TestArchive(msw.ToArray()));
+			Assert.That(msw.ToArray(), Does.PassTestArchive());
 		}
 
 		/// <summary>
@@ -273,7 +274,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					Assert.AreEqual(inputBytes, outputBytes, "Archive content does not match the source content");
 				}, "Failed to locate entry stream in archive");
 
-				Assert.IsTrue(zf.TestArchive(testData: true), "Archive did not pass TestArchive");
+				Assert.That(zf, Does.PassTestArchive());
 			}
 		}
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipEncryptionHandling.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using ICSharpCode.SharpZipLib.Tests.TestSupport;
 using System.Threading.Tasks;
+using Does = ICSharpCode.SharpZipLib.Tests.TestSupport.Does;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
@@ -105,7 +106,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					}
 				}
 
-				Assert.That(zipFile.TestArchive(false), Is.True, "Encrypted archive should pass validation.");
+				Assert.That(zipFile, Does.PassTestArchive(testData: false), "Encrypted archive should pass validation.");
 			}
 		}
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Does = ICSharpCode.SharpZipLib.Tests.TestSupport.Does;
 
 namespace ICSharpCode.SharpZipLib.Tests.Zip
 {
@@ -61,7 +62,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				}
 				zipFile.CommitUpdate();
 
-				Assert.IsTrue(zipFile.TestArchive(true));
+				Assert.That(zipFile, Does.PassTestArchive());
 				Assert.AreEqual(target, zipFile.Count, "Incorrect number of entries stored");
 			}
 		}
@@ -80,7 +81,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				f.Add(m, "a.dat");
 				f.Add(m, "b.dat");
 				f.CommitUpdate();
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 			}
 
 			byte[] rawArchive = memStream.ToArray();
@@ -116,7 +117,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				f.Add(m, "a.dat");
 				f.Add(m, "b.dat");
 				f.CommitUpdate();
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 			}
 
 			byte[] rawArchive = memStream.ToArray();
@@ -211,7 +212,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					f.BeginUpdate(new MemoryArchiveStorage());
 					f.Add(m, "a.dat", CompressionMethod.Stored);
 					f.CommitUpdate();
-					Assert.IsTrue(f.TestArchive(true));
+					Assert.That(f, Does.PassTestArchive());
 				}
 
 				memStream.Seek(0, SeekOrigin.Begin);
@@ -367,7 +368,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			{
 				f.IsStreamOwner = false;
 				Assert.AreEqual(totalEntries, f.Count);
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 				f.BeginUpdate(new MemoryArchiveStorage());
 
 				for (int i = 0; i < additions; ++i)
@@ -401,7 +402,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			{
 				f.IsStreamOwner = false;
 				Assert.AreEqual(totalEntries, f.Count);
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 				f.BeginUpdate(new MemoryArchiveStorage());
 
 				for (int i = 0; i < additions; ++i)
@@ -445,7 +446,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				f.Add(new StringMemoryDataSource("Mr C"), @"c\c.dat");
 				f.Add(new StringMemoryDataSource("Mrs D was a star"), @"d\d.dat");
 				f.CommitUpdate();
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 				foreach (ZipEntry entry in f)
 				{
 					Console.WriteLine($" - {entry.Name}");
@@ -506,27 +507,27 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				f.Add(addFile2);
 				f.AddDirectory(addDirectory);
 				f.CommitUpdate();
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 			}
 
 			using (ZipFile f = new ZipFile(tempFile))
 			{
 				Assert.AreEqual(3, f.Count);
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 
 				// Delete file
 				f.BeginUpdate();
 				f.Delete(f[0]);
 				f.CommitUpdate();
 				Assert.AreEqual(2, f.Count);
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 
 				// Delete directory
 				f.BeginUpdate();
 				f.Delete(f[1]);
 				f.CommitUpdate();
 				Assert.AreEqual(1, f.Count);
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 			}
 
 			File.Delete(addFile);
@@ -632,7 +633,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					f.Add(addFile);
 					f.CommitUpdate();
 					Assert.AreEqual(1, f.Count);
-					Assert.IsTrue(f.TestArchive(true));
+					Assert.That(f, Does.PassTestArchive());
 				}
 
 				using (ZipFile f = new ZipFile(tempFile))
@@ -642,7 +643,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					f.Delete(f[0]);
 					f.CommitUpdate();
 					Assert.AreEqual(0, f.Count);
-					Assert.IsTrue(f.TestArchive(true));
+					Assert.That(f, Does.PassTestArchive());
 					f.Close();
 				}
 
@@ -667,7 +668,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			{
 				f.BeginUpdate();
 				f.CommitUpdate();
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 				f.Close();
 			}
 
@@ -692,7 +693,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				zf.BeginUpdate();
 				zf.Add(sourceFile, CompressionMethod.Stored);
 				zf.CommitUpdate();
-				Assert.IsTrue(zf.TestArchive(testData: true));
+				Assert.That(zf, Does.PassTestArchive());
 				zf.Close();
 			}
 
@@ -864,7 +865,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			using (ZipFile testFile = new ZipFile(ms))
 			{
-				Assert.IsTrue(testFile.TestArchive(true), "Unexpected error in archive detected");
+				Assert.That(testFile, Does.PassTestArchive(), "Unexpected error in archive detected");
 
 				byte[] corrupted = new byte[compressedData.Length];
 				Array.Copy(compressedData, corrupted, compressedData.Length);
@@ -875,7 +876,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			using (ZipFile testFile = new ZipFile(ms))
 			{
-				Assert.IsFalse(testFile.TestArchive(true), "Error in archive not detected");
+				Assert.That(testFile, Does.Not.PassTestArchive(), "Error in archive not detected");
 			}
 		}
 
@@ -889,7 +890,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			var ms2 = new MemoryStream(s.ToArray());
 			using (ZipFile zf = new ZipFile(ms2))
 			{
-				Assert.IsTrue(zf.TestArchive(true));
+				Assert.That(zf, Does.PassTestArchive());
 			}
 		}
 
@@ -913,10 +914,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			var ms2 = new MemoryStream(s.ToArray());
 			using (ZipFile zf = new ZipFile(ms2))
 			{
-				Assert.IsTrue(zf.TestArchive(true, TestStrategy.FindAllErrors, 
-					(status, message) => {
-						if (!string.IsNullOrWhiteSpace(message)) TestContext.Out.WriteLine(message);
-					}));
+				Assert.That(zf, Does.PassTestArchive());
 			}
 		}
 
@@ -945,7 +943,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				testFile.Add(new StringMemoryDataSource("No3"), "No3", CompressionMethod.Stored);
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 				rawData = ms.ToArray();
 			}
 
@@ -953,14 +951,14 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 			using (ZipFile testFile = new ZipFile(ms))
 			{
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 
 				testFile.BeginUpdate(new MemoryArchiveStorage(FileUpdateMode.Safe));
 				testFile.Password = "pwd";
 				testFile.Add(new StringMemoryDataSource("Zapata!"), "encrypttest.xml");
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 
 				int entryIndex = testFile.FindEntry("encrypttest.xml", true);
 				Assert.IsNotNull(entryIndex >= 0);
@@ -983,12 +981,12 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				testFile.Add(new StringMemoryDataSource("No3"), "No3", CompressionMethod.Stored);
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 			}
 
 			using (ZipFile testFile = new ZipFile(ms))
 			{
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 				testFile.IsStreamOwner = true;
 
 				testFile.BeginUpdate();
@@ -996,7 +994,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				testFile.Add(new StringMemoryDataSource("Zapata!"), "encrypttest.xml");
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 
 				int entryIndex = testFile.FindEntry("encrypttest.xml", true);
 				Assert.IsNotNull(entryIndex >= 0);
@@ -1022,7 +1020,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				}
 				f.CommitUpdate();
 
-				Assert.IsTrue(f.TestArchive(testData: true));
+				Assert.That(f, Does.PassTestArchive());
 			}
 			memStream.Seek(0, SeekOrigin.Begin);
 			using (var zf = new ZipFile(memStream))
@@ -1062,12 +1060,12 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				testFile.Add(new StringMemoryDataSource("No3"), "No3", CompressionMethod.Stored);
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 			}
 
 			using (ZipFile testFile = new ZipFile(ms))
 			{
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 				Assert.AreEqual("", testFile.ZipFileComment);
 				testFile.IsStreamOwner = false;
 
@@ -1075,12 +1073,12 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				testFile.SetComment("Here is my comment");
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 			}
 
 			using (ZipFile testFile = new ZipFile(ms))
 			{
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 				Assert.AreEqual("Here is my comment", testFile.ZipFileComment);
 			}
 		}
@@ -1107,24 +1105,24 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				testFile.Add(new StringMemoryDataSource("No3"), "No3", CompressionMethod.Stored);
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 			}
 
 			using (ZipFile testFile = new ZipFile(tempFile))
 			{
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 				Assert.AreEqual("", testFile.ZipFileComment);
 
 				testFile.BeginUpdate(new DiskArchiveStorage(testFile, FileUpdateMode.Direct));
 				testFile.SetComment("Here is my comment");
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 			}
 
 			using (ZipFile testFile = new ZipFile(tempFile))
 			{
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 				Assert.AreEqual("Here is my comment", testFile.ZipFileComment);
 			}
 			File.Delete(tempFile);
@@ -1138,24 +1136,24 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				testFile.Add(new StringMemoryDataSource("No3"), "No3", CompressionMethod.Stored);
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 			}
 
 			using (ZipFile testFile = new ZipFile(tempFile))
 			{
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 				Assert.AreEqual("", testFile.ZipFileComment);
 
 				testFile.BeginUpdate();
 				testFile.SetComment("Here is my comment");
 				testFile.CommitUpdate();
 
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 			}
 
 			using (ZipFile testFile = new ZipFile(tempFile))
 			{
-				Assert.IsTrue(testFile.TestArchive(true));
+				Assert.That(testFile, Does.PassTestArchive());
 				Assert.AreEqual("Here is my comment", testFile.ZipFileComment);
 			}
 			File.Delete(tempFile);
@@ -1188,7 +1186,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 						  CompressionMethod.Deflated, true);
 				}
 				f.CommitUpdate();
-				Assert.IsTrue(f.TestArchive(true));
+				Assert.That(f, Does.PassTestArchive());
 
 				foreach (string name in names)
 				{
@@ -1238,7 +1236,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 				using (ZipFile nested = new ZipFile(zipFile.GetInputStream(0)))
 				{
-					Assert.IsTrue(nested.TestArchive(true));
+					Assert.That(nested, Does.PassTestArchive());
 					Assert.AreEqual(1, nested.Count);
 
 					Stream nestedStream = nested.GetInputStream(0);
@@ -1628,7 +1626,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 					var m2 = new StringMemoryDataSource("DeflateCompressed");
 					f.Add(m2, "b.dat", CompressionMethod.Deflated);
 					f.CommitUpdate();
-					Assert.IsTrue(f.TestArchive(true));
+					Assert.That(f, Does.PassTestArchive());
 				}
 
 				memStream.Seek(0, SeekOrigin.Begin);
@@ -1757,7 +1755,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 
 			var zipData = msw.ToArray();
-			Assert.IsTrue(ZipTesting.TestArchive(zipData));
+			Assert.That(zipData, Does.PassTestArchive());
 
 			using (var memoryStream = new MemoryStream(zipData))
 			{
@@ -1772,7 +1770,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 				using (var zipFile = new ZipFile(memoryStream, leaveOpen: true))
 				{
-					Assert.That(zipFile.TestArchive(true), Is.True);
+					Assert.That(zipFile, Does.PassTestArchive());
 				}
 			}
 		}
@@ -1796,7 +1794,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 
 			var zipData = msw.ToArray();
-			Assert.IsTrue(ZipTesting.TestArchive(zipData));
+			Assert.That(zipData, Does.PassTestArchive());
 
 			using (var memoryStream = new MemoryStream())
 			{
@@ -1813,7 +1811,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 				using (var zipFile = new ZipFile(memoryStream, leaveOpen: true))
 				{
-					Assert.That(zipFile.TestArchive(true), Is.True);
+					Assert.That(zipFile, Does.PassTestArchive());
 				}
 			}
 		}


### PR DESCRIPTION
This allows for skipping (some of) the local header tests performed when reading `ZipFile` entries.

Example:
```cs
using (var zipFile = new ZipFile(inputFile)){
	zipFile.SkipLocalEntryTestsOnLocate = true;
	foreach (var entry in zipFile)
	{
		// ...
	}
}
```

Also included are some refactoring done when investigating this. Mostly to make the code path easier to follow and provide better errors when things go wrong.