### PR TITLE
ci: use server 2019 for win builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,7 +76,7 @@ jobs:
       
   CodeCov:
     name: Code Coverage
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       DOTCOVER_VER: 2021.1.2
       DOTCOVER_PKG: jetbrains.dotcover.commandlinetools

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, windows-2019, macos-latest]
         target: [netstandard2.0, netstandard2.1]
         include:
-          - os: windows
+          - os: windows-2019
             target: net45
     env:
       LIB_PROJ: src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,11 +14,11 @@ on:
 
 jobs:
   Build:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows, macos]
+        os: [ubuntu-latest, windows-2019, macos-latest]
         target: [netstandard2.0, netstandard2.1]
         include:
           - os: windows
@@ -35,6 +35,9 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
+        
+    - name: Show .NET info
+      run: dotnet --info
 
     - name: Build library (Debug)
       run: dotnet build -c debug -f ${{ matrix.target }} ${{ env.LIB_PROJ }}


### PR DESCRIPTION
The `windows-latest` tag was changed from `windows-2019` to `windows-2022` (ref https://github.com/github/docs/issues/15603).

Unfortunately, that means it does no longer contain any runtime/targeting pack for deprecated .NET frameworks (`net45` in our case). This changes the CI to instead target the latest working version (`windows-2019`).

Perhaps a supported runtime scope update is due, but that's another discussion.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
