### PR TITLE
fix(zip): dont fail test on 0 sizes and descriptor

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -472,4 +472,28 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 		#endregion Header Signatures
 	}
+
+	/// <summary>
+	/// GeneralBitFlags helper extensions
+	/// </summary>
+	public static class GenericBitFlagsExtensions
+	{
+		/// <summary>
+		/// Efficiently check if any of the <see cref="GeneralBitFlags">flags</see> are set without enum un-/boxing
+		/// </summary>
+		/// <param name="target"></param>
+		/// <param name="flags"></param>
+		/// <returns>Returns whether any of flags are set</returns>
+		public static bool HasAny(this GeneralBitFlags target, GeneralBitFlags flags)
+			=> ((int)target & (int)flags) != 0;
+
+		/// <summary>
+		/// Efficiently check if all the <see cref="GeneralBitFlags">flags</see> are set without enum un-/boxing
+		/// </summary>
+		/// <param name="target"></param>
+		/// <param name="flags"></param>
+		/// <returns>Returns whether the flags are all set</returns>
+		public static bool HasAll(this GeneralBitFlags target, GeneralBitFlags flags)
+			=> ((int)target & (int)flags) == (int)flags;
+	}
 }


### PR DESCRIPTION
Fixing what seems like a merge artifact (7 years ago!) that fails the `LocalHeaderTest`s when an archive is using Zip64 and Descriptors, and the size in the local Zip64 extra data is set to `0` (which is per spec).

This also replaces the bitwise flag checks with a helper method to increase legibility (not mixing boolean and bitwise logic).

Fixes #735