### PR TITLE
GZipOutputStream is the destination and not the source

### DIFF
--- a/help/api/ICSharpCode.SharpZipLib.GZip.GZipOutputStream.html
+++ b/help/api/ICSharpCode.SharpZipLib.GZip.GZipOutputStream.html
@@ -160,10 +160,10 @@ class MainClass
 {
     public static void Main(string[] args)
     {
-            using (Stream s = new GZipOutputStream(File.Create(args[0] + &quot;.gz&quot;)))
-            using (FileStream fs = File.OpenRead(args[0])) {
+            using (Stream out = new GZipOutputStream(File.Create(args[0] + &quot;.gz&quot;)))
+            using (FileStream in = File.OpenRead(args[0])) {
                 byte[] writeData = new byte[4096];
-                Streamutils.Copy(s, fs, writeData);
+                StreamUtils.Copy(in, out, writeData);
             }
         }
     }


### PR DESCRIPTION
Changed the variable names to make it clear and assign the correct stream order to the `Copy` function.
Fixed typo in `StreamUtils` class name

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

Wow!! what's with all the legalese =(