### PR TITLE
feat(tar): support for async streams

### DIFF
--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using BenchmarkDotNet;
-using BenchmarkDotNet.Configs;
+﻿using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.CsProj;
+using ICSharpCode.SharpZipLib.Benchmark.Tar;
 
 namespace ICSharpCode.SharpZipLib.Benchmark
 {
@@ -22,6 +21,12 @@ namespace ICSharpCode.SharpZipLib.Benchmark
 		static void Main(string[] args)
 		{
 			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+			
+			// var output = new TarOutputStream();
+			// for (int i = 0; i < 1_000_000; i++)
+			// {
+			// 	output.WriteTarOutputStream();
+			// }
 		}
 	}
 }

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.CsProj;
-using ICSharpCode.SharpZipLib.Benchmark.Tar;
 
 namespace ICSharpCode.SharpZipLib.Benchmark
 {
@@ -21,12 +20,6 @@ namespace ICSharpCode.SharpZipLib.Benchmark
 		static void Main(string[] args)
 		{
 			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-			
-			// var output = new TarOutputStream();
-			// for (int i = 0; i < 1_000_000; i++)
-			// {
-			// 	output.WriteTarOutputStream();
-			// }
 		}
 	}
 }

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarInputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarInputStream.cs
@@ -64,6 +64,7 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Tar
 			using (var zipInputStream = new ICSharpCode.SharpZipLib.Tar.TarInputStream(memoryStream, Encoding.UTF8))
 			{
 				var entry = await zipInputStream.GetNextEntryAsync(CancellationToken.None);
+
 #if NETCOREAPP2_1_OR_GREATER
 				while (await zipInputStream.ReadAsync(readBuffer.AsMemory()) > 0)
 				{

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarInputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarInputStream.cs
@@ -1,0 +1,56 @@
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using ICSharpCode.SharpZipLib.Tar;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.Tar
+{
+	[MemoryDiagnoser]
+	[Config(typeof(MultipleRuntimes))]
+	public class TarInputStream
+	{
+		private readonly byte[] archivedData;
+		private readonly byte[] readBuffer = new byte[1024];
+
+		public TarInputStream()
+		{
+			using (var outputMemoryStream = new MemoryStream())
+			{
+				using (var zipOutputStream = new ICSharpCode.SharpZipLib.Tar.TarOutputStream(outputMemoryStream, Encoding.UTF8))
+				{
+					var tarEntry = TarEntry.CreateTarEntry("some file");
+					tarEntry.Size = 1024 * 1024;
+					zipOutputStream.PutNextEntry(tarEntry);
+
+					var rng = RandomNumberGenerator.Create();
+					var inputBuffer = new byte[1024];
+					rng.GetBytes(inputBuffer);
+
+					for (int i = 0; i < 1024; i++)
+					{
+						zipOutputStream.Write(inputBuffer, 0, inputBuffer.Length);
+					}
+				}
+
+				archivedData = outputMemoryStream.ToArray();
+			}
+		}
+
+		[Benchmark]
+		public long ReadTarInputStream()
+		{
+			using (var memoryStream = new MemoryStream(archivedData))
+			using(var zipInputStream = new ICSharpCode.SharpZipLib.Tar.TarInputStream(memoryStream, Encoding.UTF8))
+			{
+				var entry = zipInputStream.GetNextEntry();
+
+				while (zipInputStream.Read(readBuffer, 0, readBuffer.Length) > 0)
+				{
+				}
+
+				return entry.Size;
+			}
+		}
+	}
+}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarOutputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarOutputStream.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using ICSharpCode.SharpZipLib.Tar;
 
@@ -11,6 +13,8 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Tar
 	public class TarOutputStream
 	{
 		private readonly byte[] _backingArray = new byte[1024 * 1024 + (6 * 1024)];
+		private readonly byte[] _inputBuffer = new byte[1024];
+		private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
 
 		[Benchmark]
 		public void WriteTarOutputStream()
@@ -24,13 +28,33 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Tar
 					tarEntry.Size = 1024 * 1024;
 					tarOutputStream.PutNextEntry(tarEntry);
 
-					var rng = RandomNumberGenerator.Create();
-					var inputBuffer = new byte[1024];
-					rng.GetBytes(inputBuffer);
+					_rng.GetBytes(_inputBuffer);
 
 					for (int i = 0; i < 1024; i++)
 					{
-						tarOutputStream.Write(inputBuffer, 0, inputBuffer.Length);
+						tarOutputStream.Write(_inputBuffer, 0, _inputBuffer.Length);
+					}
+				}
+			}
+		}
+		
+		[Benchmark]
+		public async Task WriteTarOutputStreamAsync()
+		{
+			using (var outputMemoryStream = new MemoryStream(_backingArray))
+			{
+				using (var tarOutputStream =
+				       new ICSharpCode.SharpZipLib.Tar.TarOutputStream(outputMemoryStream, Encoding.UTF8))
+				{
+					var tarEntry = TarEntry.CreateTarEntry("some file");
+					tarEntry.Size = 1024 * 1024;
+					await tarOutputStream.PutNextEntryAsync(tarEntry, CancellationToken.None);
+
+					_rng.GetBytes(_inputBuffer);
+
+					for (int i = 0; i < 1024; i++)
+					{
+						await tarOutputStream.WriteAsync(_inputBuffer, 0, _inputBuffer.Length);
 					}
 				}
 			}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarOutputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarOutputStream.cs
@@ -12,14 +12,14 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Tar
 	[Config(typeof(MultipleRuntimes))]
 	public class TarOutputStream
 	{
-		private readonly byte[] _backingArray = new byte[1024 * 1024 + (6 * 1024)];
-		private readonly byte[] _inputBuffer = new byte[1024];
+		private readonly byte[] backingArray = new byte[1024 * 1024 + (6 * 1024)];
+		private readonly byte[] inputBuffer = new byte[1024];
 		private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
 
 		[Benchmark]
 		public void WriteTarOutputStream()
 		{
-			using (var outputMemoryStream = new MemoryStream(_backingArray))
+			using (var outputMemoryStream = new MemoryStream(backingArray))
 			{
 				using (var tarOutputStream =
 				       new ICSharpCode.SharpZipLib.Tar.TarOutputStream(outputMemoryStream, Encoding.UTF8))
@@ -28,33 +28,34 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Tar
 					tarEntry.Size = 1024 * 1024;
 					tarOutputStream.PutNextEntry(tarEntry);
 
-					_rng.GetBytes(_inputBuffer);
+					_rng.GetBytes(inputBuffer);
 
 					for (int i = 0; i < 1024; i++)
 					{
-						tarOutputStream.Write(_inputBuffer, 0, _inputBuffer.Length);
+						tarOutputStream.Write(inputBuffer, 0, inputBuffer.Length);
 					}
 				}
 			}
 		}
-		
+
 		[Benchmark]
 		public async Task WriteTarOutputStreamAsync()
 		{
-			using (var outputMemoryStream = new MemoryStream(_backingArray))
+			using (var outputMemoryStream = new MemoryStream(backingArray))
 			{
 				using (var tarOutputStream =
 				       new ICSharpCode.SharpZipLib.Tar.TarOutputStream(outputMemoryStream, Encoding.UTF8))
 				{
 					var tarEntry = TarEntry.CreateTarEntry("some file");
 					tarEntry.Size = 1024 * 1024;
+
 					await tarOutputStream.PutNextEntryAsync(tarEntry, CancellationToken.None);
 
-					_rng.GetBytes(_inputBuffer);
+					_rng.GetBytes(inputBuffer);
 
 					for (int i = 0; i < 1024; i++)
 					{
-						await tarOutputStream.WriteAsync(_inputBuffer, 0, _inputBuffer.Length);
+						await tarOutputStream.WriteAsync(inputBuffer, 0, inputBuffer.Length);
 					}
 				}
 			}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarOutputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarOutputStream.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using ICSharpCode.SharpZipLib.Tar;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.Tar
+{
+	[MemoryDiagnoser]
+	[Config(typeof(MultipleRuntimes))]
+	public class TarOutputStream
+	{
+		private readonly byte[] _backingArray = new byte[1024 * 1024 + (6 * 1024)];
+
+		[Benchmark]
+		public void WriteTarOutputStream()
+		{
+			using (var outputMemoryStream = new MemoryStream(_backingArray))
+			{
+				using (var tarOutputStream =
+				       new ICSharpCode.SharpZipLib.Tar.TarOutputStream(outputMemoryStream, Encoding.UTF8))
+				{
+					var tarEntry = TarEntry.CreateTarEntry("some file");
+					tarEntry.Size = 1024 * 1024;
+					tarOutputStream.PutNextEntry(tarEntry);
+
+					var rng = RandomNumberGenerator.Create();
+					var inputBuffer = new byte[1024];
+					rng.GetBytes(inputBuffer);
+
+					for (int i = 0; i < 1024; i++)
+					{
+						tarOutputStream.Write(inputBuffer, 0, inputBuffer.Length);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/ICSharpCode.SharpZipLib/Core/ExactMemoryPool.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/ExactMemoryPool.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Buffers;
+
+namespace ICSharpCode.SharpZipLib.Core
+{
+	/// <summary>
+	/// A MemoryPool that will return a Memory which is exactly the length asked for using the bufferSize parameter.
+	/// This is in contrast to the default ArrayMemoryPool which will return a Memory of equal size to the underlying
+	/// array which at least as long as the minBufferSize parameter.
+	/// Note: The underlying array may be larger than the slice of Memory
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	internal sealed class ExactMemoryPool<T> : MemoryPool<T>
+	{
+		public new static readonly MemoryPool<T> Shared = new ExactMemoryPool<T>();
+
+		public override IMemoryOwner<T> Rent(int bufferSize = -1)
+		{
+			if ((uint)bufferSize > int.MaxValue || bufferSize < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(bufferSize));
+			}
+
+			return new ExactMemoryPoolBuffer(bufferSize);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+		}
+
+		public override int MaxBufferSize => int.MaxValue;
+
+		private sealed class ExactMemoryPoolBuffer : IMemoryOwner<T>, IDisposable
+		{
+			private T[] array;
+			private readonly int size;
+
+			public ExactMemoryPoolBuffer(int size)
+			{
+				this.size = size;
+				this.array = ArrayPool<T>.Shared.Rent(size);
+			}
+
+			public Memory<T> Memory
+			{
+				get
+				{
+					T[] array = this.array;
+					if (array == null)
+					{
+						throw new ObjectDisposedException(nameof(ExactMemoryPoolBuffer));
+					}
+
+					return new Memory<T>(array).Slice(0, size);
+				}
+			}
+
+			public void Dispose()
+			{
+				T[] array = this.array;
+				if (array == null)
+				{
+					return;
+				}
+
+				this.array = null;
+				ArrayPool<T>.Shared.Return(array);
+			}
+		}
+	}
+}

--- a/src/ICSharpCode.SharpZipLib/Core/StringBuilderPool.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/StringBuilderPool.cs
@@ -1,16 +1,16 @@
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Text;
 
 namespace ICSharpCode.SharpZipLib.Core
 {
-	class StringBuilderPool
+	internal class StringBuilderPool
 	{
 		public static StringBuilderPool Instance { get; } = new StringBuilderPool();
-		private readonly Queue<StringBuilder> pool = new Queue<StringBuilder>();
+		private readonly ConcurrentQueue<StringBuilder> pool = new ConcurrentQueue<StringBuilder>();
 
 		public StringBuilder Rent()
 		{
-			return pool.Count > 0 ? pool.Dequeue() : new StringBuilder();
+			return pool.TryDequeue(out var builder) ? builder : new StringBuilder();
 		}
 
 		public void Return(StringBuilder builder)

--- a/src/ICSharpCode.SharpZipLib/Core/StringBuilderPool.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/StringBuilderPool.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace ICSharpCode.SharpZipLib.Core
+{
+	class StringBuilderPool
+	{
+		public static StringBuilderPool Instance { get; } = new StringBuilderPool();
+		private readonly Queue<StringBuilder> pool = new Queue<StringBuilder>();
+
+		public StringBuilder Rent()
+		{
+			return pool.Count > 0 ? pool.Dequeue() : new StringBuilder();
+		}
+
+		public void Return(StringBuilder builder)
+		{
+			builder.Clear();
+			pool.Enqueue(builder);
+		}
+	}
+}

--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -36,10 +36,12 @@ Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.3.3 for mor
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
 		<PackageReference Include="System.Memory" Version="4.5.4" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
 		<PackageReference Include="System.Memory" Version="4.5.4" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -33,8 +33,16 @@ Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.3.3 for mor
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
-	 
-	 <ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+		<PackageReference Include="System.Memory" Version="4.5.4" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.Memory" Version="4.5.4" />
+	</ItemGroup>
+
+	<ItemGroup>
 	   <None Include="../../assets/sharpziplib-nuget-256x256.png">
       <Pack>True</Pack>
       <PackagePath>images</PackagePath>

--- a/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Buffers;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.SharpZipLib.Tar
 {
@@ -73,10 +75,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// This is equal to the <see cref="BlockFactor"/> multiplied by the <see cref="BlockSize"/></value>
 		public int RecordSize
 		{
-			get
-			{
-				return recordSize;
-			}
+			get { return recordSize; }
 		}
 
 		/// <summary>
@@ -96,10 +95,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <value>This is the number of blocks in each record.</value>
 		public int BlockFactor
 		{
-			get
-			{
-				return blockFactor;
-			}
+			get { return blockFactor; }
 		}
 
 		/// <summary>
@@ -292,6 +288,19 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public void SkipBlock()
 		{
+			SkipBlockAsync(CancellationToken.None, false).GetAwaiter().GetResult();
+		}
+
+		/// <summary>
+		/// Skip over a block on the input stream.
+		/// </summary>
+		public Task SkipBlockAsync(CancellationToken ct)
+		{
+			return SkipBlockAsync(ct, true).AsTask();
+		}
+
+		private async ValueTask SkipBlockAsync(CancellationToken ct, bool isAsync)
+		{
 			if (inputStream == null)
 			{
 				throw new TarException("no input stream defined");
@@ -299,7 +308,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (currentBlockIndex >= BlockFactor)
 			{
-				if (!ReadRecord())
+				if (!await ReadRecordAsync(ct, isAsync))
 				{
 					throw new TarException("Failed to read a record");
 				}
@@ -323,7 +332,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (currentBlockIndex >= BlockFactor)
 			{
-				if (!ReadRecord())
+				if (!ReadRecordAsync(CancellationToken.None, false).GetAwaiter().GetResult())
 				{
 					throw new TarException("Failed to read a record");
 				}
@@ -335,14 +344,14 @@ namespace ICSharpCode.SharpZipLib.Tar
 			currentBlockIndex++;
 			return result;
 		}
-		
-		internal void ReadBlockInt(Span<byte> buffer)
+
+		internal async ValueTask ReadBlockIntAsync(byte[] buffer, CancellationToken ct, bool isAsync)
 		{
 			if (buffer.Length != BlockSize)
 			{
 				throw new ArgumentException("BUG: buffer must have length BlockSize");
 			}
-			
+
 			if (inputStream == null)
 			{
 				throw new TarException("TarBuffer.ReadBlock - no input stream defined");
@@ -350,13 +359,13 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (currentBlockIndex >= BlockFactor)
 			{
-				if (!ReadRecord())
+				if (!await ReadRecordAsync(ct, isAsync))
 				{
 					throw new TarException("Failed to read a record");
 				}
 			}
-			
-			recordBuffer.AsSpan().Slice(currentBlockIndex* BlockSize, BlockSize).CopyTo(buffer);
+
+			recordBuffer.AsSpan().Slice(currentBlockIndex * BlockSize, BlockSize).CopyTo(buffer);
 			currentBlockIndex++;
 		}
 
@@ -366,7 +375,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <returns>
 		/// false if End-Of-File, else true.
 		/// </returns>
-		private bool ReadRecord()
+		private async ValueTask<bool> ReadRecordAsync(CancellationToken ct, bool isAsync)
 		{
 			if (inputStream == null)
 			{
@@ -380,7 +389,9 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			while (bytesNeeded > 0)
 			{
-				long numBytes = inputStream.Read(recordBuffer, offset, bytesNeeded);
+				long numBytes = isAsync
+					? await inputStream.ReadAsync(recordBuffer, offset, bytesNeeded, ct)
+					: inputStream.Read(recordBuffer, offset, bytesNeeded);
 
 				//
 				// NOTE
@@ -469,32 +480,38 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="block">
 		/// The data to write to the archive.
 		/// </param>
+		/// <param name="ct"></param>
+		public ValueTask WriteBlockAsync(byte[] block, CancellationToken ct)
+		{
+			return WriteBlockAsync(block, 0, ct);
+		}
+		
+		/// <summary>
+		/// Write a block of data to the archive.
+		/// </summary>
+		/// <param name="block">
+		/// The data to write to the archive.
+		/// </param>
 		public void WriteBlock(byte[] block)
 		{
-			if (block == null)
-			{
-				throw new ArgumentNullException(nameof(block));
-			}
+			WriteBlock(block, 0);
+		}
 
-			if (outputStream == null)
-			{
-				throw new TarException("TarBuffer.WriteBlock - no output stream defined");
-			}
-
-			if (block.Length != BlockSize)
-			{
-				string errorText = string.Format("TarBuffer.WriteBlock - block to write has length '{0}' which is not the block size of '{1}'",
-					block.Length, BlockSize);
-				throw new TarException(errorText);
-			}
-
-			if (currentBlockIndex >= BlockFactor)
-			{
-				WriteRecord();
-			}
-
-			Array.Copy(block, 0, recordBuffer, (currentBlockIndex * BlockSize), BlockSize);
-			currentBlockIndex++;
+		/// <summary>
+		/// Write an archive record to the archive, where the record may be
+		/// inside of a larger array buffer. The buffer must be "offset plus
+		/// record size" long.
+		/// </summary>
+		/// <param name="buffer">
+		/// The buffer containing the record data to write.
+		/// </param>
+		/// <param name="offset">
+		/// The offset of the record data within buffer.
+		/// </param>
+		/// <param name="ct"></param>
+		public ValueTask WriteBlockAsync(byte[] buffer, int offset, CancellationToken ct)
+		{
+			return WriteBlockAsync(buffer, offset, ct, true);
 		}
 
 		/// <summary>
@@ -509,6 +526,11 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// The offset of the record data within buffer.
 		/// </param>
 		public void WriteBlock(byte[] buffer, int offset)
+		{
+			WriteBlockAsync(buffer, offset, CancellationToken.None, false).GetAwaiter().GetResult();
+		}
+
+		internal async ValueTask WriteBlockAsync(byte[] buffer, int offset, CancellationToken ct, bool isAsync)
 		{
 			if (buffer == null)
 			{
@@ -527,14 +549,15 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if ((offset + BlockSize) > buffer.Length)
 			{
-				string errorText = string.Format("TarBuffer.WriteBlock - record has length '{0}' with offset '{1}' which is less than the record size of '{2}'",
+				string errorText = string.Format(
+					"TarBuffer.WriteBlock - record has length '{0}' with offset '{1}' which is less than the record size of '{2}'",
 					buffer.Length, offset, recordSize);
 				throw new TarException(errorText);
 			}
 
 			if (currentBlockIndex >= BlockFactor)
 			{
-				WriteRecord();
+				await WriteRecordAsync(CancellationToken.None, isAsync);
 			}
 
 			Array.Copy(buffer, offset, recordBuffer, (currentBlockIndex * BlockSize), BlockSize);
@@ -545,15 +568,23 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <summary>
 		/// Write a TarBuffer record to the archive.
 		/// </summary>
-		private void WriteRecord()
+		private async ValueTask WriteRecordAsync(CancellationToken ct, bool isAsync)
 		{
 			if (outputStream == null)
 			{
 				throw new TarException("TarBuffer.WriteRecord no output stream defined");
 			}
 
-			outputStream.Write(recordBuffer, 0, RecordSize);
-			outputStream.Flush();
+			if (isAsync)
+			{
+				await outputStream.WriteAsync(recordBuffer, 0, RecordSize, ct);
+				await outputStream.FlushAsync(ct);
+			}
+			else
+			{
+				outputStream.Write(recordBuffer, 0, RecordSize);
+				outputStream.Flush();
+			}
 
 			currentBlockIndex = 0;
 			currentRecordIndex++;
@@ -564,7 +595,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		/// <remarks>Any trailing bytes are set to zero which is by definition correct behaviour
 		/// for the end of a tar stream.</remarks>
-		private void WriteFinalRecord()
+		private async ValueTask WriteFinalRecordAsync(CancellationToken ct, bool isAsync)
 		{
 			if (outputStream == null)
 			{
@@ -575,36 +606,76 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				int dataBytes = currentBlockIndex * BlockSize;
 				Array.Clear(recordBuffer, dataBytes, RecordSize - dataBytes);
-				WriteRecord();
+				await WriteRecordAsync(ct, isAsync);
 			}
 
-			outputStream.Flush();
+			if (isAsync)
+			{
+				await outputStream.FlushAsync(ct);
+			}
+			else
+			{
+				outputStream.Flush();
+			}
 		}
 
 		/// <summary>
 		/// Close the TarBuffer. If this is an output buffer, also flush the
 		/// current block before closing.
 		/// </summary>
-		public void Close()
+		public void Close() => CloseAsync(CancellationToken.None, false).GetAwaiter().GetResult();
+		
+		/// <summary>
+		/// Close the TarBuffer. If this is an output buffer, also flush the
+		/// current block before closing.
+		/// </summary>
+		public Task CloseAsync(CancellationToken ct) => CloseAsync(ct, true).AsTask();
+
+		private async ValueTask CloseAsync(CancellationToken ct, bool isAsync)
 		{
 			if (outputStream != null)
 			{
-				WriteFinalRecord();
+				await WriteFinalRecordAsync(ct, isAsync);
 
 				if (IsStreamOwner)
 				{
-					outputStream.Dispose();
+					if (isAsync)
+					{
+#if NETSTANDARD2_1_OR_GREATER
+						await outputStream.DisposeAsync();
+#else
+						outputStream.Dispose();
+#endif
+					}
+					else
+					{
+						outputStream.Dispose();
+					}
 				}
+
 				outputStream = null;
 			}
 			else if (inputStream != null)
 			{
 				if (IsStreamOwner)
 				{
-					inputStream.Dispose();
+					if (isAsync)
+					{
+#if NETSTANDARD2_1_OR_GREATER
+						await inputStream.DisposeAsync();
+#else
+						inputStream.Dispose();
+#endif
+					}
+					else
+					{
+						inputStream.Dispose();
+					}
 				}
+
 				inputStream = null;
 			}
+
 			ArrayPool<byte>.Shared.Return(recordBuffer);
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -286,18 +286,12 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <summary>
 		/// Skip over a block on the input stream.
 		/// </summary>
-		public void SkipBlock()
-		{
-			SkipBlockAsync(CancellationToken.None, false).GetAwaiter().GetResult();
-		}
+		public void SkipBlock() => SkipBlockAsync(CancellationToken.None, false).GetAwaiter().GetResult();
 
 		/// <summary>
 		/// Skip over a block on the input stream.
 		/// </summary>
-		public Task SkipBlockAsync(CancellationToken ct)
-		{
-			return SkipBlockAsync(ct, true).AsTask();
-		}
+		public Task SkipBlockAsync(CancellationToken ct) => SkipBlockAsync(ct, true).AsTask();
 
 		private async ValueTask SkipBlockAsync(CancellationToken ct, bool isAsync)
 		{

--- a/src/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
@@ -114,7 +114,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		public static TarEntry CreateTarEntry(string name)
 		{
 			var entry = new TarEntry();
-			TarEntry.NameTarHeader(entry.header, name);
+
+			entry.NameTarHeader(name);
 			return entry;
 		}
 
@@ -188,10 +189,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </returns>
 		public TarHeader TarHeader
 		{
-			get
-			{
-				return header;
-			}
+			get { return header; }
 		}
 
 		/// <summary>
@@ -199,14 +197,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public string Name
 		{
-			get
-			{
-				return header.Name;
-			}
-			set
-			{
-				header.Name = value;
-			}
+			get { return header.Name; }
+			set { header.Name = value; }
 		}
 
 		/// <summary>
@@ -214,14 +206,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public int UserId
 		{
-			get
-			{
-				return header.UserId;
-			}
-			set
-			{
-				header.UserId = value;
-			}
+			get { return header.UserId; }
+			set { header.UserId = value; }
 		}
 
 		/// <summary>
@@ -229,14 +215,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public int GroupId
 		{
-			get
-			{
-				return header.GroupId;
-			}
-			set
-			{
-				header.GroupId = value;
-			}
+			get { return header.GroupId; }
+			set { header.GroupId = value; }
 		}
 
 		/// <summary>
@@ -244,14 +224,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public string UserName
 		{
-			get
-			{
-				return header.UserName;
-			}
-			set
-			{
-				header.UserName = value;
-			}
+			get { return header.UserName; }
+			set { header.UserName = value; }
 		}
 
 		/// <summary>
@@ -259,14 +233,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public string GroupName
 		{
-			get
-			{
-				return header.GroupName;
-			}
-			set
-			{
-				header.GroupName = value;
-			}
+			get { return header.GroupName; }
+			set { header.GroupName = value; }
 		}
 
 		/// <summary>
@@ -304,14 +272,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public DateTime ModTime
 		{
-			get
-			{
-				return header.ModTime;
-			}
-			set
-			{
-				header.ModTime = value;
-			}
+			get { return header.ModTime; }
+			set { header.ModTime = value; }
 		}
 
 		/// <summary>
@@ -322,10 +284,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </returns>
 		public string File
 		{
-			get
-			{
-				return file;
-			}
+			get { return file; }
 		}
 
 		/// <summary>
@@ -333,14 +292,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public long Size
 		{
-			get
-			{
-				return header.Size;
-			}
-			set
-			{
-				header.Size = value;
-			}
+			get { return header.Size; }
+			set { header.Size = value; }
 		}
 
 		/// <summary>
@@ -450,7 +403,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 				header.Size = new FileInfo(file.Replace('/', Path.DirectorySeparatorChar)).Length;
 			}
 
-			header.ModTime = System.IO.File.GetLastWriteTime(file.Replace('/', Path.DirectorySeparatorChar)).ToUniversalTime();
+			header.ModTime = System.IO.File.GetLastWriteTime(file.Replace('/', Path.DirectorySeparatorChar))
+				.ToUniversalTime();
 			header.DevMajor = 0;
 			header.DevMinor = 0;
 		}
@@ -549,13 +503,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="name">
 		/// The tar entry name.
 		/// </param>
-		static public void NameTarHeader(TarHeader header, string name)
+		public void NameTarHeader(string name)
 		{
-			if (header == null)
-			{
-				throw new ArgumentNullException(nameof(header));
-			}
-
 			if (name == null)
 			{
 				throw new ArgumentNullException(nameof(name));

--- a/src/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
@@ -497,9 +497,6 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <summary>
 		/// Fill in a TarHeader given only the entry's name.
 		/// </summary>
-		/// <param name="header">
-		/// The TarHeader to fill in.
-		/// </param>
 		/// <param name="name">
 		/// The tar entry name.
 		/// </param>

--- a/src/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
@@ -126,106 +126,106 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <summary>
 		/// Normal file type.
 		/// </summary>
-		public const byte LF_NORMAL = (byte)'0';
+		public const byte LF_NORMAL = (byte) '0';
 
 		/// <summary>
 		/// Link file type.
 		/// </summary>
-		public const byte LF_LINK = (byte)'1';
+		public const byte LF_LINK = (byte) '1';
 
 		/// <summary>
 		/// Symbolic link file type.
 		/// </summary>
-		public const byte LF_SYMLINK = (byte)'2';
+		public const byte LF_SYMLINK = (byte) '2';
 
 		/// <summary>
 		/// Character device file type.
 		/// </summary>
-		public const byte LF_CHR = (byte)'3';
+		public const byte LF_CHR = (byte) '3';
 
 		/// <summary>
 		/// Block device file type.
 		/// </summary>
-		public const byte LF_BLK = (byte)'4';
+		public const byte LF_BLK = (byte) '4';
 
 		/// <summary>
 		/// Directory file type.
 		/// </summary>
-		public const byte LF_DIR = (byte)'5';
+		public const byte LF_DIR = (byte) '5';
 
 		/// <summary>
 		/// FIFO (pipe) file type.
 		/// </summary>
-		public const byte LF_FIFO = (byte)'6';
+		public const byte LF_FIFO = (byte) '6';
 
 		/// <summary>
 		/// Contiguous file type.
 		/// </summary>
-		public const byte LF_CONTIG = (byte)'7';
+		public const byte LF_CONTIG = (byte) '7';
 
 		/// <summary>
 		/// Posix.1 2001 global extended header
 		/// </summary>
-		public const byte LF_GHDR = (byte)'g';
+		public const byte LF_GHDR = (byte) 'g';
 
 		/// <summary>
 		/// Posix.1 2001 extended header
 		/// </summary>
-		public const byte LF_XHDR = (byte)'x';
+		public const byte LF_XHDR = (byte) 'x';
 
 		// POSIX allows for upper case ascii type as extensions
 
 		/// <summary>
 		/// Solaris access control list file type
 		/// </summary>
-		public const byte LF_ACL = (byte)'A';
+		public const byte LF_ACL = (byte) 'A';
 
 		/// <summary>
 		/// GNU dir dump file type
 		/// This is a dir entry that contains the names of files that were in the
 		/// dir at the time the dump was made
 		/// </summary>
-		public const byte LF_GNU_DUMPDIR = (byte)'D';
+		public const byte LF_GNU_DUMPDIR = (byte) 'D';
 
 		/// <summary>
 		/// Solaris Extended Attribute File
 		/// </summary>
-		public const byte LF_EXTATTR = (byte)'E';
+		public const byte LF_EXTATTR = (byte) 'E';
 
 		/// <summary>
 		/// Inode (metadata only) no file content
 		/// </summary>
-		public const byte LF_META = (byte)'I';
+		public const byte LF_META = (byte) 'I';
 
 		/// <summary>
 		/// Identifies the next file on the tape as having a long link name
 		/// </summary>
-		public const byte LF_GNU_LONGLINK = (byte)'K';
+		public const byte LF_GNU_LONGLINK = (byte) 'K';
 
 		/// <summary>
 		/// Identifies the next file on the tape as having a long name
 		/// </summary>
-		public const byte LF_GNU_LONGNAME = (byte)'L';
+		public const byte LF_GNU_LONGNAME = (byte) 'L';
 
 		/// <summary>
 		/// Continuation of a file that began on another volume
 		/// </summary>
-		public const byte LF_GNU_MULTIVOL = (byte)'M';
+		public const byte LF_GNU_MULTIVOL = (byte) 'M';
 
 		/// <summary>
 		/// For storing filenames that dont fit in the main header (old GNU)
 		/// </summary>
-		public const byte LF_GNU_NAMES = (byte)'N';
+		public const byte LF_GNU_NAMES = (byte) 'N';
 
 		/// <summary>
 		/// GNU Sparse file
 		/// </summary>
-		public const byte LF_GNU_SPARSE = (byte)'S';
+		public const byte LF_GNU_SPARSE = (byte) 'S';
 
 		/// <summary>
 		/// GNU Tape/volume header ignore on extraction
 		/// </summary>
-		public const byte LF_GNU_VOLHDR = (byte)'V';
+		public const byte LF_GNU_VOLHDR = (byte) 'V';
 
 		/// <summary>
 		/// The magic tag representing a POSIX tar archive.  (would be written with a trailing NULL)
@@ -279,6 +279,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					throw new ArgumentNullException(nameof(value));
 				}
+
 				name = value;
 			}
 		}
@@ -341,6 +342,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					throw new ArgumentOutOfRangeException(nameof(value), "Cannot be less than zero");
 				}
+
 				size = value;
 			}
 		}
@@ -361,6 +363,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					throw new ArgumentOutOfRangeException(nameof(value), "ModTime cannot be before Jan 1st 1970");
 				}
+
 				modTime = new DateTime(value.Year, value.Month, value.Day, value.Hour, value.Minute, value.Second);
 			}
 		}
@@ -403,6 +406,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					throw new ArgumentNullException(nameof(value));
 				}
+
 				linkName = value;
 			}
 		}
@@ -420,6 +424,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					throw new ArgumentNullException(nameof(value));
 				}
+
 				magic = value;
 			}
 		}
@@ -430,10 +435,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <exception cref="ArgumentNullException">Thrown when attempting to set Version to null.</exception>
 		public string Version
 		{
-			get
-			{
-				return version;
-			}
+			get { return version; }
 
 			set
 			{
@@ -441,6 +443,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					throw new ArgumentNullException(nameof(value));
 				}
+
 				version = value;
 			}
 		}
@@ -464,6 +467,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 					{
 						currentUser = currentUser.Substring(0, UNAMELEN);
 					}
+
 					userName = currentUser;
 				}
 			}
@@ -541,17 +545,18 @@ namespace ICSharpCode.SharpZipLib.Tar
 			}
 
 			int offset = 0;
+			var headerSpan = header.AsSpan();
 
-			name = ParseName(header, offset, NAMELEN, nameEncoding);
+			name = ParseName(headerSpan.Slice(offset, NAMELEN), nameEncoding);
 			offset += NAMELEN;
 
-			mode = (int)ParseOctal(header, offset, MODELEN);
+			mode = (int) ParseOctal(header, offset, MODELEN);
 			offset += MODELEN;
 
-			UserId = (int)ParseOctal(header, offset, UIDLEN);
+			UserId = (int) ParseOctal(header, offset, UIDLEN);
 			offset += UIDLEN;
 
-			GroupId = (int)ParseOctal(header, offset, GIDLEN);
+			GroupId = (int) ParseOctal(header, offset, GIDLEN);
 			offset += GIDLEN;
 
 			Size = ParseBinaryOrOctal(header, offset, SIZELEN);
@@ -560,35 +565,35 @@ namespace ICSharpCode.SharpZipLib.Tar
 			ModTime = GetDateTimeFromCTime(ParseOctal(header, offset, MODTIMELEN));
 			offset += MODTIMELEN;
 
-			checksum = (int)ParseOctal(header, offset, CHKSUMLEN);
+			checksum = (int) ParseOctal(header, offset, CHKSUMLEN);
 			offset += CHKSUMLEN;
 
 			TypeFlag = header[offset++];
 
-			LinkName = ParseName(header, offset, NAMELEN, nameEncoding);
+			LinkName = ParseName(headerSpan.Slice(offset, NAMELEN), nameEncoding);
 			offset += NAMELEN;
 
-			Magic = ParseName(header, offset, MAGICLEN, nameEncoding);
+			Magic = ParseName(headerSpan.Slice(offset, MAGICLEN), nameEncoding);
 			offset += MAGICLEN;
 
 			if (Magic == "ustar")
 			{
-				Version = ParseName(header, offset, VERSIONLEN, nameEncoding);
+				Version = ParseName(headerSpan.Slice(offset, VERSIONLEN), nameEncoding);
 				offset += VERSIONLEN;
 
-				UserName = ParseName(header, offset, UNAMELEN, nameEncoding);
+				UserName = ParseName(headerSpan.Slice(offset, UNAMELEN), nameEncoding);
 				offset += UNAMELEN;
 
-				GroupName = ParseName(header, offset, GNAMELEN, nameEncoding);
+				GroupName = ParseName(headerSpan.Slice(offset, GNAMELEN), nameEncoding);
 				offset += GNAMELEN;
 
-				DevMajor = (int)ParseOctal(header, offset, DEVLEN);
+				DevMajor = (int) ParseOctal(header, offset, DEVLEN);
 				offset += DEVLEN;
 
-				DevMinor = (int)ParseOctal(header, offset, DEVLEN);
+				DevMinor = (int) ParseOctal(header, offset, DEVLEN);
 				offset += DEVLEN;
 
-				string prefix = ParseName(header, offset, PREFIXLEN, nameEncoding);
+				string prefix = ParseName(headerSpan.Slice(offset, PREFIXLEN), nameEncoding);
 				if (!string.IsNullOrEmpty(prefix)) Name = prefix + '/' + Name;
 			}
 
@@ -642,7 +647,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			int csOffset = offset;
 			for (int c = 0; c < CHKSUMLEN; ++c)
 			{
-				outBuffer[offset++] = (byte)' ';
+				outBuffer[offset++] = (byte) ' ';
 			}
 
 			outBuffer[offset++] = TypeFlag;
@@ -687,7 +692,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		public override bool Equals(object obj)
 		{
 			var localHeader = obj as TarHeader;
-		
+
 			bool result;
 			if (localHeader != null)
 			{
@@ -711,7 +716,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				result = false;
 			}
-		
+
 			return result;
 		}
 
@@ -750,8 +755,10 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					result = result << 8 | header[offset + pos];
 				}
+
 				return result;
 			}
+
 			return ParseOctal(header, offset, length);
 		}
 
@@ -780,14 +787,14 @@ namespace ICSharpCode.SharpZipLib.Tar
 					break;
 				}
 
-				if (header[i] == (byte)' ' || header[i] == '0')
+				if (header[i] == (byte) ' ' || header[i] == '0')
 				{
 					if (stillPadding)
 					{
 						continue;
 					}
 
-					if (header[i] == (byte)' ')
+					if (header[i] == (byte) ' ')
 					{
 						break;
 					}
@@ -819,7 +826,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		[Obsolete("No Encoding for Name field is specified, any non-ASCII bytes will be discarded")]
 		public static string ParseName(byte[] header, int offset, int length)
 		{
-			return ParseName(header, offset, length, null);
+			return ParseName(header.AsSpan().Slice(offset, length), null);
 		}
 
 		/// <summary>
@@ -828,58 +835,33 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="header">
 		/// The header buffer from which to parse.
 		/// </param>
-		/// <param name="offset">
-		/// The offset into the buffer from which to parse.
-		/// </param>
-		/// <param name="length">
-		/// The number of header bytes to parse.
-		/// </param>
 		/// <param name="encoding">
 		/// name encoding, or null for ASCII only
 		/// </param>
 		/// <returns>
 		/// The name parsed.
 		/// </returns>
-		public static string ParseName(byte[] header, int offset, int length, Encoding encoding)
+		public static string ParseName(ReadOnlySpan<byte> header, Encoding encoding)
 		{
-			if (header == null)
-			{
-				throw new ArgumentNullException(nameof(header));
-			}
-
-			if (offset < 0)
-			{
-				throw new ArgumentOutOfRangeException(nameof(offset), "Cannot be less than zero");
-			}
-
-			if (length < 0)
-			{
-				throw new ArgumentOutOfRangeException(nameof(length), "Cannot be less than zero");
-			}
-
-			if (offset + length > header.Length)
-			{
-				throw new ArgumentException("Exceeds header size", nameof(length));
-			}
-
 			var builder = StringBuilderPool.Instance.Rent();
 
 			int count = 0;
 			if (encoding == null)
 			{
-				for (int i = offset; i < offset + length; ++i)
+				for (int i = 0; i < header.Length; ++i)
 				{
-					if (header[i] == 0)
+					var b = header[i];
+					if (b == 0)
 					{
 						break;
 					}
 
-					builder.Append((char)header[i]);
+					builder.Append((char) b);
 				}
 			}
 			else
 			{
-				for (int i = offset; i < offset + length; ++i, ++count)
+				for (int i = 0; i < header.Length; ++i, ++count)
 				{
 					if (header[i] == 0)
 					{
@@ -887,7 +869,12 @@ namespace ICSharpCode.SharpZipLib.Tar
 					}
 				}
 
-				builder.Append(encoding.GetString(header, offset, count));
+#if NETSTANDARD2_1_OR_GREATER
+				var value = encoding.GetString(header.Slice(0, count));
+#else
+				var value = encoding.GetString(header.ToArray(), 0, count);
+#endif
+				builder.Append(value);
 			}
 
 			var result = builder.ToString();
@@ -950,7 +937,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 			if (encoding != null)
 			{
 				// it can be more sufficient if using Span or unsafe
-				ReadOnlySpan<char> nameArray = name.AsSpan().Slice(nameOffset, Math.Min(name.Length - nameOffset, length));
+				ReadOnlySpan<char> nameArray =
+					name.AsSpan().Slice(nameOffset, Math.Min(name.Length - nameOffset, length));
 				var charArray = ArrayPool<char>.Shared.Rent(nameArray.Length);
 				nameArray.CopyTo(charArray);
 
@@ -963,7 +951,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				for (i = 0; i < length && nameOffset + i < name.Length; ++i)
 				{
-					buffer[bufferOffset + i] = (byte)name[nameOffset + i];
+					buffer[bufferOffset + i] = (byte) name[nameOffset + i];
 				}
 			}
 
@@ -971,8 +959,10 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				buffer[bufferOffset + i] = 0;
 			}
+
 			return bufferOffset + length;
 		}
+
 		/// <summary>
 		/// Add an entry name to the buffer
 		/// </summary>
@@ -1071,6 +1061,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			return GetNameBytes(name, 0, buffer, offset, length, encoding);
 		}
+
 		/// <summary>
 		/// Add a string to a buffer as a collection of ascii bytes.
 		/// </summary>
@@ -1114,7 +1105,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				for (i = 0; i < length && nameOffset + i < toAdd.Length; ++i)
 				{
-					buffer[bufferOffset + i] = (byte)toAdd[nameOffset + i];
+					buffer[bufferOffset + i] = (byte) toAdd[nameOffset + i];
 				}
 			}
 			else
@@ -1126,6 +1117,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				i = Math.Min(bytes.Length, length);
 				Array.Copy(bytes, 0, buffer, bufferOffset, i);
 			}
+
 			// If length is beyond the toAdd string length (which is OK by the prev loop condition), eg if a field has fixed length and the string is shorter, make sure all of the extra chars are written as NULLs, so that the reader func would ignore them and get back the original string
 			for (; i < length; ++i)
 				buffer[bufferOffset + i] = 0;
@@ -1167,14 +1159,14 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				for (long v = value; (localIndex >= 0) && (v > 0); --localIndex)
 				{
-					buffer[offset + localIndex] = (byte)((byte)'0' + (byte)(v & 7));
+					buffer[offset + localIndex] = (byte) ((byte) '0' + (byte) (v & 7));
 					v >>= 3;
 				}
 			}
 
 			for (; localIndex >= 0; --localIndex)
 			{
-				buffer[offset + localIndex] = (byte)'0';
+				buffer[offset + localIndex] = (byte) '0';
 			}
 
 			return offset + length;
@@ -1196,12 +1188,14 @@ namespace ICSharpCode.SharpZipLib.Tar
 				// Put value as binary, right-justified into the buffer. Set high order bit of left-most byte.
 				for (int pos = length - 1; pos > 0; pos--)
 				{
-					buffer[offset + pos] = (byte)value;
+					buffer[offset + pos] = (byte) value;
 					value = value >> 8;
 				}
+
 				buffer[offset] = 0x80;
 				return offset + length;
 			}
+
 			return GetOctalBytes(value, buffer, offset, length);
 		}
 
@@ -1235,6 +1229,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				sum += buffer[i];
 			}
+
 			return sum;
 		}
 
@@ -1253,19 +1248,20 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			for (int i = 0; i < CHKSUMLEN; ++i)
 			{
-				sum += (byte)' ';
+				sum += (byte) ' ';
 			}
 
 			for (int i = CHKSUMOFS + CHKSUMLEN; i < buffer.Length; ++i)
 			{
 				sum += buffer[i];
 			}
+
 			return sum;
 		}
 
 		private static int GetCTime(DateTime dateTime)
 		{
-			return unchecked((int)((dateTime.Ticks - dateTime1970.Ticks) / timeConversionFactor));
+			return unchecked((int) ((dateTime.Ticks - dateTime1970.Ticks) / timeConversionFactor));
 		}
 
 		private static DateTime GetDateTimeFromCTime(long ticks)
@@ -1280,6 +1276,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				result = dateTime1970;
 			}
+
 			return result;
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -2,6 +2,9 @@ using System;
 using System.Buffers;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.Tar
 {
@@ -130,6 +133,15 @@ namespace ICSharpCode.SharpZipLib.Tar
 		}
 
 		/// <summary>
+		/// Flushes the baseInputStream
+		/// </summary>
+		/// <param name="cancellationToken"></param>
+		public override async Task FlushAsync(CancellationToken cancellationToken)
+		{
+			await inputStream.FlushAsync(cancellationToken);
+		}
+
+		/// <summary>
 		/// Set the streams position.  This operation is not supported and will throw a NotSupportedException
 		/// </summary>
 		/// <param name="offset">The offset relative to the origin to seek to.</param>
@@ -182,16 +194,64 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <returns>A byte cast to an int; -1 if the at the end of the stream.</returns>
 		public override int ReadByte()
 		{
-			byte[] oneByteBuffer = new byte[1];
-			int num = Read(oneByteBuffer, 0, 1);
+			var oneByteBuffer = ArrayPool<byte>.Shared.Rent(1);
+			var num = Read(oneByteBuffer, 0, 1);
 			if (num <= 0)
 			{
 				// return -1 to indicate that no byte was read.
 				return -1;
 			}
 
-			return oneByteBuffer[0];
+			var result = oneByteBuffer[0];
+			ArrayPool<byte>.Shared.Return(oneByteBuffer);
+			return result;
 		}
+
+
+		/// <summary>
+		/// Reads bytes from the current tar archive entry.
+		/// 
+		/// This method is aware of the boundaries of the current
+		/// entry in the archive and will deal with them appropriately
+		/// </summary>
+		/// <param name="buffer">
+		/// The buffer into which to place bytes read.
+		/// </param>
+		/// <param name="offset">
+		/// The offset at which to place bytes read.
+		/// </param>
+		/// <param name="count">
+		/// The number of bytes to read.
+		/// </param>
+		/// <param name="cancellationToken"></param>
+		/// <returns>
+		/// The number of bytes read, or 0 at end of stream/EOF.
+		/// </returns>
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		{
+			return ReadAsync(buffer.AsMemory().Slice(offset, count), cancellationToken, true).AsTask();
+		}
+
+#if NETSTANDARD2_1_OR_GREATER
+		/// <summary>
+		/// Reads bytes from the current tar archive entry.
+		/// 
+		/// This method is aware of the boundaries of the current
+		/// entry in the archive and will deal with them appropriately
+		/// </summary>
+		/// <param name="buffer">
+		/// The buffer into which to place bytes read.
+		/// </param>
+		/// <param name="cancellationToken"></param>
+		/// <returns>
+		/// The number of bytes read, or 0 at end of stream/EOF.
+		/// </returns>
+		public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken =
+			new CancellationToken())
+		{
+			return ReadAsync(buffer, cancellationToken, true);
+		}
+#endif
 
 		/// <summary>
 		/// Reads bytes from the current tar archive entry.
@@ -218,6 +278,13 @@ namespace ICSharpCode.SharpZipLib.Tar
 				throw new ArgumentNullException(nameof(buffer));
 			}
 
+			return ReadAsync(buffer.AsMemory().Slice(offset, count), CancellationToken.None, false).GetAwaiter()
+				.GetResult();
+		}
+
+		private async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct, bool isAsync)
+		{
+			int offset = 0;
 			int totalRead = 0;
 
 			if (entryOffset >= entrySize)
@@ -225,7 +292,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				return 0;
 			}
 
-			long numToRead = count;
+			long numToRead = buffer.Length;
 
 			if ((numToRead + entryOffset) > entrySize)
 			{
@@ -236,7 +303,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				int sz = (numToRead > readBuffer.Length) ? readBuffer.Length : (int)numToRead;
 
-				Array.Copy(readBuffer, 0, buffer, offset, sz);
+				readBuffer.AsSpan().Slice(0, sz).CopyTo(buffer.Slice(offset, sz).Span);
 
 				if (sz >= readBuffer.Length)
 				{
@@ -245,8 +312,13 @@ namespace ICSharpCode.SharpZipLib.Tar
 				else
 				{
 					int newLen = readBuffer.Length - sz;
-					byte[] newBuf = new byte[newLen];
-					Array.Copy(readBuffer, sz, newBuf, 0, newLen);
+					byte[] newBuf = ArrayPool<byte>.Shared.Rent(newLen);
+					readBuffer.AsSpan().Slice(sz, newLen).CopyTo(newBuf.AsSpan().Slice(0, newLen));
+					if (readBuffer != null)
+					{
+						ArrayPool<byte>.Shared.Return(readBuffer);
+					}
+
 					readBuffer = newBuf;
 				}
 
@@ -257,24 +329,28 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			var recLen = TarBuffer.BlockSize;
 			var recBuf = ArrayPool<byte>.Shared.Rent(recLen);
-			var recBufSpan = recBuf.AsSpan();
 
 			while (numToRead > 0)
 			{
-				tarBuffer.ReadBlockInt(recBuf);
+				await tarBuffer.ReadBlockIntAsync(recBuf, ct, isAsync);
 
 				var sz = (int)numToRead;
 
 				if (recLen > sz)
 				{
-					recBufSpan.Slice(0, sz).CopyTo(buffer.AsSpan().Slice(offset, sz));
+					recBuf.AsSpan().Slice(0, sz).CopyTo(buffer.Slice(offset, sz).Span);
+					if (readBuffer != null)
+					{
+						ArrayPool<byte>.Shared.Return(readBuffer);
+					}
+
 					readBuffer = ArrayPool<byte>.Shared.Rent(recLen - sz);
-					recBufSpan.Slice(sz, recLen - sz).CopyTo(readBuffer);
+					recBuf.AsSpan().Slice(sz, recLen - sz).CopyTo(readBuffer.AsSpan());
 				}
 				else
 				{
 					sz = recLen;
-					recBufSpan.CopyTo(buffer.AsSpan().Slice(offset, recLen));
+					recBuf.AsSpan().CopyTo(buffer.Slice(offset, recLen).Span);
 				}
 
 				totalRead += sz;
@@ -300,6 +376,17 @@ namespace ICSharpCode.SharpZipLib.Tar
 				tarBuffer.Close();
 			}
 		}
+
+#if NETSTANDARD2_1_OR_GREATER
+		/// <summary>
+		/// Closes this stream. Calls the TarBuffer's close() method.
+		/// The underlying stream is closed by the TarBuffer.
+		/// </summary>
+		public override async ValueTask DisposeAsync()
+		{
+			await tarBuffer.CloseAsync(CancellationToken.None);
+		}
+#endif
 
 		#endregion Stream Overrides
 
@@ -356,25 +443,42 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="skipCount">
 		/// The number of bytes to skip.
 		/// </param>
-		public void Skip(long skipCount)
+		/// <param name="ct"></param>
+		private Task SkipAsync(long skipCount, CancellationToken ct) => SkipAsync(skipCount, ct, true).AsTask();
+
+		/// <summary>
+		/// Skip bytes in the input buffer. This skips bytes in the
+		/// current entry's data, not the entire archive, and will
+		/// stop at the end of the current entry's data if the number
+		/// to skip extends beyond that point.
+		/// </summary>
+		/// <param name="skipCount">
+		/// The number of bytes to skip.
+		/// </param>
+		private void Skip(long skipCount) =>
+			SkipAsync(skipCount, CancellationToken.None, false).GetAwaiter().GetResult();
+
+		private async ValueTask SkipAsync(long skipCount, CancellationToken ct, bool isAsync)
 		{
 			// TODO: REVIEW efficiency of TarInputStream.Skip
 			// This is horribly inefficient, but it ensures that we
 			// properly skip over bytes via the TarBuffer...
 			//
-			byte[] skipBuf = new byte[8 * 1024];
-
-			for (long num = skipCount; num > 0;)
+			var length = 8 * 1024;
+			using (var skipBuf = MemoryPool<byte>.Shared.Rent(length))
 			{
-				int toRead = num > skipBuf.Length ? skipBuf.Length : (int)num;
-				int numRead = Read(skipBuf, 0, toRead);
-
-				if (numRead == -1)
+				for (long num = skipCount; num > 0;)
 				{
-					break;
-				}
+					int toRead = num > length ? length : (int)num;
+					int numRead = await ReadAsync(skipBuf.Memory.Slice(0, toRead), ct, isAsync);
 
-				num -= numRead;
+					if (numRead == -1)
+					{
+						break;
+					}
+
+					num -= numRead;
+				}
 			}
 		}
 
@@ -417,7 +521,24 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <returns>
 		/// The next TarEntry in the archive, or null.
 		/// </returns>
-		public TarEntry GetNextEntry()
+		public Task<TarEntry> GetNextEntryAsync(CancellationToken ct) => GetNextEntryAsync(ct, true).AsTask();
+
+		/// <summary>
+		/// Get the next entry in this tar archive. This will skip
+		/// over any remaining data in the current entry, if there
+		/// is one, and place the input stream at the header of the
+		/// next entry, and read the header and instantiate a new
+		/// TarEntry from the header bytes and return that entry.
+		/// If there are no more entries in the archive, null will
+		/// be returned to indicate that the end of the archive has
+		/// been reached.
+		/// </summary>
+		/// <returns>
+		/// The next TarEntry in the archive, or null.
+		/// </returns>
+		public TarEntry GetNextEntry() => GetNextEntryAsync(CancellationToken.None, true).GetAwaiter().GetResult();
+
+		private async ValueTask<TarEntry> GetNextEntryAsync(CancellationToken ct, bool isAsync)
 		{
 			if (hasHitEOF)
 			{
@@ -426,18 +547,18 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (currentEntry != null)
 			{
-				SkipToNextEntry();
+				await SkipToNextEntryAsync(ct, isAsync);
 			}
 
 			byte[] headerBuf = ArrayPool<byte>.Shared.Rent(TarBuffer.BlockSize);
-			tarBuffer.ReadBlockInt(headerBuf);
+			await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
 
 			if (TarBuffer.IsEndOfArchiveBlock(headerBuf))
 			{
 				hasHitEOF = true;
 
 				// Read the second zero-filled block
-				tarBuffer.ReadBlockInt(headerBuf);
+				await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
 			}
 			else
 			{
@@ -466,51 +587,57 @@ namespace ICSharpCode.SharpZipLib.Tar
 					this.entryOffset = 0;
 					this.entrySize = header.Size;
 
-					StringBuilder longName = null;
+					string longName = null;
 
 					if (header.TypeFlag == TarHeader.LF_GNU_LONGNAME)
 					{
-						byte[] nameBuffer = new byte[TarBuffer.BlockSize];
-						long numToRead = this.entrySize;
-
-						longName = new StringBuilder();
-
-						while (numToRead > 0)
+						using (var nameBuffer = MemoryPool<byte>.Shared.Rent(TarBuffer.BlockSize))
 						{
-							int numRead = this.Read(nameBuffer, 0,
-								(numToRead > nameBuffer.Length ? nameBuffer.Length : (int)numToRead));
+							long numToRead = this.entrySize;
 
-							if (numRead == -1)
+							var longNameBuilder = StringBuilderPool.Instance.Rent();
+
+							while (numToRead > 0)
 							{
-								throw new InvalidHeaderException("Failed to read long name entry");
+								var length = (numToRead > TarBuffer.BlockSize ? TarBuffer.BlockSize : (int)numToRead);
+								int numRead = await ReadAsync(nameBuffer.Memory.Slice(0, length), ct, isAsync);
+
+								if (numRead == -1)
+								{
+									throw new InvalidHeaderException("Failed to read long name entry");
+								}
+
+								longNameBuilder.Append(TarHeader.ParseName(nameBuffer.Memory.Slice(0, numRead).Span,
+									encoding));
+								numToRead -= numRead;
 							}
 
-							longName.Append(TarHeader.ParseName(nameBuffer, 0, numRead, encoding).ToString());
-							numToRead -= numRead;
-						}
+							longName = longNameBuilder.ToString();
+							StringBuilderPool.Instance.Return(longNameBuilder);
 
-						SkipToNextEntry();
-						this.tarBuffer.ReadBlockInt(headerBuf);
+							await SkipToNextEntryAsync(ct, isAsync);
+							await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
+						}
 					}
 					else if (header.TypeFlag == TarHeader.LF_GHDR)
 					{
 						// POSIX global extended header
 						// Ignore things we dont understand completely for now
-						SkipToNextEntry();
-						this.tarBuffer.ReadBlockInt(headerBuf);
+						await SkipToNextEntryAsync(ct, isAsync);
+						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
 					}
 					else if (header.TypeFlag == TarHeader.LF_XHDR)
 					{
 						// POSIX extended header
-						byte[] nameBuffer = new byte[TarBuffer.BlockSize];
+						byte[] nameBuffer = ArrayPool<byte>.Shared.Rent(TarBuffer.BlockSize);
 						long numToRead = this.entrySize;
 
 						var xhr = new TarExtendedHeaderReader();
 
 						while (numToRead > 0)
 						{
-							int numRead = this.Read(nameBuffer, 0,
-								(numToRead > nameBuffer.Length ? nameBuffer.Length : (int)numToRead));
+							var length = (numToRead > nameBuffer.Length ? nameBuffer.Length : (int)numToRead);
+							int numRead = await ReadAsync(nameBuffer.AsMemory().Slice(0, length), ct, isAsync);
 
 							if (numRead == -1)
 							{
@@ -521,19 +648,21 @@ namespace ICSharpCode.SharpZipLib.Tar
 							numToRead -= numRead;
 						}
 
+						ArrayPool<byte>.Shared.Return(nameBuffer);
+
 						if (xhr.Headers.TryGetValue("path", out string name))
 						{
-							longName = new StringBuilder(name);
+							longName = name;
 						}
 
-						SkipToNextEntry();
-						this.tarBuffer.ReadBlockInt(headerBuf);
+						await SkipToNextEntryAsync(ct, isAsync);
+						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
 					}
 					else if (header.TypeFlag == TarHeader.LF_GNU_VOLHDR)
 					{
 						// TODO: could show volume name when verbose
-						SkipToNextEntry();
-						this.tarBuffer.ReadBlockInt(headerBuf);
+						await SkipToNextEntryAsync(ct, isAsync);
+						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
 					}
 					else if (header.TypeFlag != TarHeader.LF_NORMAL &&
 					         header.TypeFlag != TarHeader.LF_OLDNORM &&
@@ -542,8 +671,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 					         header.TypeFlag != TarHeader.LF_DIR)
 					{
 						// Ignore things we dont understand completely for now
-						SkipToNextEntry();
-						tarBuffer.ReadBlockInt(headerBuf);
+						await SkipToNextEntryAsync(ct, isAsync);
+						await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
 					}
 
 					if (entryFactory == null)
@@ -553,9 +682,10 @@ namespace ICSharpCode.SharpZipLib.Tar
 						{
 							ArrayPool<byte>.Shared.Return(readBuffer);
 						}
+
 						if (longName != null)
 						{
-							currentEntry.Name = longName.ToString();
+							currentEntry.Name = longName;
 						}
 					}
 					else
@@ -584,6 +714,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 					{
 						ArrayPool<byte>.Shared.Return(readBuffer);
 					}
+
 					string errorText = string.Format("Bad header in record {0} block {1} {2}",
 						tarBuffer.CurrentRecord, tarBuffer.CurrentBlock, ex.Message);
 					throw new InvalidHeaderException(errorText);
@@ -602,29 +733,52 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="outputStream">
 		/// The OutputStream into which to write the entry's data.
 		/// </param>
-		public void CopyEntryContents(Stream outputStream)
+		/// <param name="ct"></param>
+		public Task CopyEntryContentsAsync(Stream outputStream, CancellationToken ct) =>
+			CopyEntryContentsAsync(outputStream, ct, true).AsTask();
+
+		/// <summary>
+		/// Copies the contents of the current tar archive entry directly into
+		/// an output stream.
+		/// </summary>
+		/// <param name="outputStream">
+		/// The OutputStream into which to write the entry's data.
+		/// </param>
+		public void CopyEntryContents(Stream outputStream) =>
+			CopyEntryContentsAsync(outputStream, CancellationToken.None, false).GetAwaiter().GetResult();
+
+		private async ValueTask CopyEntryContentsAsync(Stream outputStream, CancellationToken ct, bool isAsync)
 		{
-			byte[] tempBuffer = new byte[32 * 1024];
+			byte[] tempBuffer = ArrayPool<byte>.Shared.Rent(32 * 1024);
 
 			while (true)
 			{
-				int numRead = Read(tempBuffer, 0, tempBuffer.Length);
+				int numRead = await ReadAsync(tempBuffer, ct, isAsync);
 				if (numRead <= 0)
 				{
 					break;
 				}
 
-				outputStream.Write(tempBuffer, 0, numRead);
+				if (isAsync)
+				{
+					await outputStream.WriteAsync(tempBuffer, 0, numRead, ct);
+				}
+				else
+				{
+					outputStream.Write(tempBuffer, 0, numRead);
+				}
 			}
+
+			ArrayPool<byte>.Shared.Return(tempBuffer);
 		}
 
-		private void SkipToNextEntry()
+		private async ValueTask SkipToNextEntryAsync(CancellationToken ct, bool isAsync)
 		{
 			long numToSkip = entrySize - entryOffset;
 
 			if (numToSkip > 0)
 			{
-				Skip(numToSkip);
+				await SkipAsync(numToSkip, ct, isAsync);
 			}
 
 			if (readBuffer != null)

--- a/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -2,6 +2,8 @@ using System;
 using System.Buffers;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.SharpZipLib.Tar
 {
@@ -95,10 +97,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public override bool CanRead
 		{
-			get
-			{
-				return outputStream.CanRead;
-			}
+			get { return outputStream.CanRead; }
 		}
 
 		/// <summary>
@@ -106,10 +105,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public override bool CanSeek
 		{
-			get
-			{
-				return outputStream.CanSeek;
-			}
+			get { return outputStream.CanSeek; }
 		}
 
 		/// <summary>
@@ -117,10 +113,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public override bool CanWrite
 		{
-			get
-			{
-				return outputStream.CanWrite;
-			}
+			get { return outputStream.CanWrite; }
 		}
 
 		/// <summary>
@@ -128,10 +121,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public override long Length
 		{
-			get
-			{
-				return outputStream.Length;
-			}
+			get { return outputStream.Length; }
 		}
 
 		/// <summary>
@@ -139,14 +129,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public override long Position
 		{
-			get
-			{
-				return outputStream.Position;
-			}
-			set
-			{
-				outputStream.Position = value;
-			}
+			get { return outputStream.Position; }
+			set { outputStream.Position = value; }
 		}
 
 		/// <summary>
@@ -195,6 +179,23 @@ namespace ICSharpCode.SharpZipLib.Tar
 		}
 
 		/// <summary>
+		/// read bytes from the current stream and advance the position within the
+		/// stream by the number of bytes read.
+		/// </summary>
+		/// <param name="buffer">The buffer to store read bytes in.</param>
+		/// <param name="offset">The index into the buffer to being storing bytes at.</param>
+		/// <param name="count">The desired number of bytes to read.</param>
+		/// <param name="cancellationToken"></param>
+		/// <returns>The total number of bytes read, or zero if at the end of the stream.
+		/// The number of bytes may be less than the <paramref name="count">count</paramref>
+		/// requested if data is not available.</returns>
+		public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
+			CancellationToken cancellationToken)
+		{
+			return await outputStream.ReadAsync(buffer, offset, count, cancellationToken);
+		}
+
+		/// <summary>
 		/// All buffered data is written to destination
 		/// </summary>
 		public override void Flush()
@@ -203,16 +204,33 @@ namespace ICSharpCode.SharpZipLib.Tar
 		}
 
 		/// <summary>
+		/// All buffered data is written to destination
+		/// </summary>
+		public override async Task FlushAsync(CancellationToken cancellationToken)
+		{
+			await outputStream.FlushAsync(cancellationToken);
+		}
+
+		/// <summary>
 		/// Ends the TAR archive without closing the underlying OutputStream.
 		/// The result is that the EOF block of nulls is written.
 		/// </summary>
-		public void Finish()
+		public void Finish() => FinishAsync(CancellationToken.None, false).GetAwaiter().GetResult();
+		
+		/// <summary>
+		/// Ends the TAR archive without closing the underlying OutputStream.
+		/// The result is that the EOF block of nulls is written.
+		/// </summary>
+		public Task FinishAsync(CancellationToken cancellationToken) => FinishAsync(cancellationToken, true);
+
+		private async Task FinishAsync(CancellationToken cancellationToken, bool isAsync)
 		{
 			if (IsEntryOpen)
 			{
-				CloseEntry();
+				await CloseEntryAsync(cancellationToken, isAsync);
 			}
-			WriteEofBlock();
+
+			await WriteEofBlockAsync(cancellationToken, isAsync);
 		}
 
 		/// <summary>
@@ -227,7 +245,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				isClosed = true;
 				Finish();
 				buffer.Close();
-				
+
 				ArrayPool<byte>.Shared.Return(assemblyBuffer);
 				ArrayPool<byte>.Shared.Return(blockBuffer);
 			}
@@ -273,44 +291,70 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="entry">
 		/// The TarEntry to be written to the archive.
 		/// </param>
-		public void PutNextEntry(TarEntry entry)
+		/// <param name="cancellationToken"></param>
+		public Task PutNextEntryAsync(TarEntry entry, CancellationToken cancellationToken) =>
+			PutNextEntryAsync(entry, cancellationToken, true);
+
+		/// <summary>
+		/// Put an entry on the output stream. This writes the entry's
+		/// header and positions the output stream for writing
+		/// the contents of the entry. Once this method is called, the
+		/// stream is ready for calls to write() to write the entry's
+		/// contents. Once the contents are written, closeEntry()
+		/// <B>MUST</B> be called to ensure that all buffered data
+		/// is completely written to the output stream.
+		/// </summary>
+		/// <param name="entry">
+		/// The TarEntry to be written to the archive.
+		/// </param>
+		public void PutNextEntry(TarEntry entry) =>
+			PutNextEntryAsync(entry, CancellationToken.None, false).GetAwaiter().GetResult();
+
+		private async Task PutNextEntryAsync(TarEntry entry, CancellationToken cancellationToken, bool isAsync)
 		{
 			if (entry == null)
 			{
 				throw new ArgumentNullException(nameof(entry));
 			}
 
-			var namelen = nameEncoding != null ? nameEncoding.GetByteCount(entry.TarHeader.Name) : entry.TarHeader.Name.Length;
+			var namelen = nameEncoding != null
+				? nameEncoding.GetByteCount(entry.TarHeader.Name)
+				: entry.TarHeader.Name.Length;
 
 			if (namelen > TarHeader.NAMELEN)
 			{
 				var longHeader = new TarHeader();
 				longHeader.TypeFlag = TarHeader.LF_GNU_LONGNAME;
 				longHeader.Name = longHeader.Name + "././@LongLink";
-				longHeader.Mode = 420;//644 by default
+				longHeader.Mode = 420; //644 by default
 				longHeader.UserId = entry.UserId;
 				longHeader.GroupId = entry.GroupId;
 				longHeader.GroupName = entry.GroupName;
 				longHeader.UserName = entry.UserName;
 				longHeader.LinkName = "";
-				longHeader.Size = namelen + 1;  // Plus one to avoid dropping last char
+				longHeader.Size = namelen + 1; // Plus one to avoid dropping last char
 
 				longHeader.WriteHeader(blockBuffer, nameEncoding);
-				buffer.WriteBlock(blockBuffer);  // Add special long filename header block
+				// Add special long filename header block
+				await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
 
 				int nameCharIndex = 0;
 
-				while (nameCharIndex < namelen + 1 /* we've allocated one for the null char, now we must make sure it gets written out */)
+				while
+					(nameCharIndex <
+					 namelen + 1 /* we've allocated one for the null char, now we must make sure it gets written out */)
 				{
 					Array.Clear(blockBuffer, 0, blockBuffer.Length);
-					TarHeader.GetAsciiBytes(entry.TarHeader.Name, nameCharIndex, this.blockBuffer, 0, TarBuffer.BlockSize, nameEncoding); // This func handles OK the extra char out of string length
+					TarHeader.GetAsciiBytes(entry.TarHeader.Name, nameCharIndex, this.blockBuffer, 0,
+						TarBuffer.BlockSize, nameEncoding); // This func handles OK the extra char out of string length
 					nameCharIndex += TarBuffer.BlockSize;
-					buffer.WriteBlock(blockBuffer);
+
+					await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
 				}
 			}
 
 			entry.WriteEntryHeader(blockBuffer, nameEncoding);
-			buffer.WriteBlock(blockBuffer);
+			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
 
 			currBytes = 0;
 
@@ -326,13 +370,26 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// to the output stream before this entry is closed and the
 		/// next entry written.
 		/// </summary>
-		public void CloseEntry()
+		public Task CloseEntryAsync(CancellationToken cancellationToken) => CloseEntryAsync(cancellationToken, true);
+
+		/// <summary>
+		/// Close an entry. This method MUST be called for all file
+		/// entries that contain data. The reason is that we must
+		/// buffer data written to the stream in order to satisfy
+		/// the buffer's block based writes. Thus, there may be
+		/// data fragments still being assembled that must be written
+		/// to the output stream before this entry is closed and the
+		/// next entry written.
+		/// </summary>
+		public void CloseEntry() => CloseEntryAsync(CancellationToken.None, true).GetAwaiter().GetResult();
+
+		private async Task CloseEntryAsync(CancellationToken cancellationToken, bool isAsync)
 		{
 			if (assemblyBufferLength > 0)
 			{
 				Array.Clear(assemblyBuffer, assemblyBufferLength, assemblyBuffer.Length - assemblyBufferLength);
 
-				buffer.WriteBlock(assemblyBuffer);
+				await buffer.WriteBlockAsync(assemblyBuffer, 0, cancellationToken, isAsync);
 
 				currBytes += assemblyBufferLength;
 				assemblyBufferLength = 0;
@@ -356,9 +413,12 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </param>
 		public override void WriteByte(byte value)
 		{
-			Write(new byte[] { value }, 0, 1);
+			var oneByteArray = ArrayPool<byte>.Shared.Rent(1);
+			oneByteArray[0] = value;
+			Write(oneByteArray, 0, 1);
+			ArrayPool<byte>.Shared.Return(oneByteArray);
 		}
-		
+
 		/// <summary>
 		/// Writes bytes to the current tar archive entry. This method
 		/// is aware of the current entry and will throw an exception if
@@ -377,7 +437,32 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name = "count">
 		/// The number of bytes to write.
 		/// </param>
-		public override void Write(byte[] buffer, int offset, int count)
+		public override void Write(byte[] buffer, int offset, int count) =>
+			WriteAsync(buffer, offset, count, CancellationToken.None, false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Writes bytes to the current tar archive entry. This method
+		/// is aware of the current entry and will throw an exception if
+		/// you attempt to write bytes past the length specified for the
+		/// current entry. The method is also (painfully) aware of the
+		/// record buffering required by TarBuffer, and manages buffers
+		/// that are not a multiple of recordsize in length, including
+		/// assembling records from small buffers.
+		/// </summary>
+		/// <param name = "buffer">
+		/// The buffer to write to the archive.
+		/// </param>
+		/// <param name = "offset">
+		/// The offset in the buffer from which to get bytes.
+		/// </param>
+		/// <param name = "count">
+		/// The number of bytes to write.
+		/// </param>
+		/// <param name="cancellationToken"></param>
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+			WriteAsync(buffer, offset, count, cancellationToken, true);
+
+		private async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool isAsync)
 		{
 			if (buffer == null)
 			{
@@ -422,7 +507,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 					Array.Copy(assemblyBuffer, 0, blockBuffer, 0, assemblyBufferLength);
 					Array.Copy(buffer, offset, blockBuffer, assemblyBufferLength, aLen);
 
-					this.buffer.WriteBlock(blockBuffer);
+					await this.buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
 
 					currBytes += blockBuffer.Length;
 
@@ -454,7 +539,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 					break;
 				}
 
-				this.buffer.WriteBlock(buffer, offset);
+				await this.buffer.WriteBlockAsync(buffer, offset, cancellationToken, isAsync);
 
 				int bufferLength = blockBuffer.Length;
 				currBytes += bufferLength;
@@ -467,11 +552,11 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// Write an EOF (end of archive) block to the tar archive.
 		/// The	end of the archive is indicated	by two blocks consisting entirely of zero bytes.
 		/// </summary>
-		private void WriteEofBlock()
+		private async Task WriteEofBlockAsync(CancellationToken cancellationToken, bool isAsync)
 		{
 			Array.Clear(blockBuffer, 0, blockBuffer.Length);
-			buffer.WriteBlock(blockBuffer);
-			buffer.WriteBlock(blockBuffer);
+			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
+			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
 		}
 
 		#region Instance Fields

--- a/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.IO;
 using System.Text;
 
@@ -50,8 +51,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 			this.outputStream = outputStream;
 			buffer = TarBuffer.CreateOutputTarBuffer(outputStream, blockFactor);
 
-			assemblyBuffer = new byte[TarBuffer.BlockSize];
-			blockBuffer = new byte[TarBuffer.BlockSize];
+			assemblyBuffer = ArrayPool<byte>.Shared.Rent(TarBuffer.BlockSize);
+			blockBuffer = ArrayPool<byte>.Shared.Rent(TarBuffer.BlockSize);
 		}
 
 		/// <summary>
@@ -70,8 +71,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 			this.outputStream = outputStream;
 			buffer = TarBuffer.CreateOutputTarBuffer(outputStream, blockFactor);
 
-			assemblyBuffer = new byte[TarBuffer.BlockSize];
-			blockBuffer = new byte[TarBuffer.BlockSize];
+			assemblyBuffer = ArrayPool<byte>.Shared.Rent(TarBuffer.BlockSize);
+			blockBuffer = ArrayPool<byte>.Shared.Rent(TarBuffer.BlockSize);
 
 			this.nameEncoding = nameEncoding;
 		}
@@ -226,6 +227,9 @@ namespace ICSharpCode.SharpZipLib.Tar
 				isClosed = true;
 				Finish();
 				buffer.Close();
+				
+				ArrayPool<byte>.Shared.Return(assemblyBuffer);
+				ArrayPool<byte>.Shared.Return(blockBuffer);
 			}
 		}
 
@@ -354,7 +358,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		{
 			Write(new byte[] { value }, 0, 1);
 		}
-
+		
 		/// <summary>
 		/// Writes bytes to the current tar archive entry. This method
 		/// is aware of the current entry and will throw an exception if

--- a/test/ICSharpCode.SharpZipLib.Tests/Core/StringBuilderPoolTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Core/StringBuilderPoolTests.cs
@@ -1,0 +1,77 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.Core;
+using NUnit.Framework;
+
+namespace ICSharpCode.SharpZipLib.Tests.Core
+{
+	[TestFixture]
+	public class StringBuilderPoolTests
+	{
+		[Test]
+		[Category("Core")]
+		public void RoundTrip()
+		{
+			var pool = new StringBuilderPool();
+			var builder1 = pool.Rent();
+			pool.Return(builder1);
+			var builder2 = pool.Rent();
+			Assert.AreEqual(builder1, builder2);
+		}
+
+		[Test]
+		[Category("Core")]
+		public void ReturnsClears()
+		{
+			var pool = new StringBuilderPool();
+			var builder1 = pool.Rent();
+			builder1.Append("Hello");
+			pool.Return(builder1);
+			Assert.AreEqual(0, builder1.Length);
+		}
+
+		[Test]
+		[Category("Core")]
+		public async Task ThreadSafeAsync()
+		{
+			// use a lot of threads to increase the likelihood of errors
+			var concurrency = 100;
+			
+			var pool = new StringBuilderPool();
+			var gate = new TaskCompletionSource<bool>();
+			var startedTasks = new Task[concurrency];
+			var completedTasks = new Task<string>[concurrency];
+			for (int i = 0; i < concurrency; i++)
+			{
+				var started = new TaskCompletionSource<bool>();
+				startedTasks[i] = started.Task;
+				var captured = i;
+				completedTasks[i] = Task.Run(async () =>
+				{
+					started.SetResult(true);
+					await gate.Task;
+					var builder = pool.Rent();
+					builder.Append("Hello ");
+					builder.Append(captured);
+					var str = builder.ToString();
+					pool.Return(builder);
+					return str;
+				});
+			}
+
+			// make sure all the threads have started
+			await Task.WhenAll(startedTasks);
+			
+			// let them all loose at the same time
+			gate.SetResult(true);
+
+			// make sure every thread produces the expected string and hence had its own StringBuilder
+			var results = await Task.WhenAll(completedTasks);
+			for (int i = 0; i < concurrency; i++)
+			{
+				var result = results[i];
+				Assert.AreEqual($"Hello {i}", result);
+			}
+		}
+	}
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarBufferTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarBufferTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.Tar;
+using NUnit.Framework;
+
+namespace ICSharpCode.SharpZipLib.Tests.Tar
+{
+	[TestFixture]
+	public class TarBufferTests
+	{
+		[Test]
+		public void TestSimpleReadWrite()
+		{
+			var ms = new MemoryStream();
+			var reader = TarBuffer.CreateInputTarBuffer(ms, 1);
+			var writer = TarBuffer.CreateOutputTarBuffer(ms, 1);
+			writer.IsStreamOwner = false;
+
+			var block = new byte[TarBuffer.BlockSize];
+			var r = new Random();
+			r.NextBytes(block);
+
+			writer.WriteBlock(block);
+			writer.WriteBlock(block);
+			writer.WriteBlock(block);
+			writer.Close();
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			var block0 = reader.ReadBlock();
+			var block1 = reader.ReadBlock();
+			var block2 = reader.ReadBlock();
+			Assert.AreEqual(block, block0);
+			Assert.AreEqual(block, block1);
+			Assert.AreEqual(block, block2);
+			writer.Close();
+		}
+
+		[Test]
+		public void TestSkipBlock()
+		{
+			var ms = new MemoryStream();
+			var reader = TarBuffer.CreateInputTarBuffer(ms, 1);
+			var writer = TarBuffer.CreateOutputTarBuffer(ms, 1);
+			writer.IsStreamOwner = false;
+
+			var block0 = new byte[TarBuffer.BlockSize];
+			var block1 = new byte[TarBuffer.BlockSize];
+			var r = new Random();
+			r.NextBytes(block0);
+			r.NextBytes(block1);
+
+			writer.WriteBlock(block0);
+			writer.WriteBlock(block1);
+			writer.Close();
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			reader.SkipBlock();
+			var block = reader.ReadBlock();
+			Assert.AreEqual(block, block1);
+			writer.Close();
+		}
+
+		[Test]
+		public async Task TestSimpleReadWriteAsync()
+		{
+			var ms = new MemoryStream();
+			var reader = TarBuffer.CreateInputTarBuffer(ms, 1);
+			var writer = TarBuffer.CreateOutputTarBuffer(ms, 1);
+			writer.IsStreamOwner = false;
+
+			var block = new byte[TarBuffer.BlockSize];
+			var r = new Random();
+			r.NextBytes(block);
+
+			await writer.WriteBlockAsync(block, CancellationToken.None);
+			await writer.WriteBlockAsync(block, CancellationToken.None);
+			await writer.WriteBlockAsync(block, CancellationToken.None);
+			await writer.CloseAsync(CancellationToken.None);
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			var block0 = new byte[TarBuffer.BlockSize];
+			await reader.ReadBlockIntAsync(block0, CancellationToken.None, true);
+			var block1 = new byte[TarBuffer.BlockSize];
+			await reader.ReadBlockIntAsync(block1, CancellationToken.None, true);
+			var block2 = new byte[TarBuffer.BlockSize];
+			await reader.ReadBlockIntAsync(block2, CancellationToken.None, true);
+			Assert.AreEqual(block, block0);
+			Assert.AreEqual(block, block1);
+			Assert.AreEqual(block, block2);
+			await writer.CloseAsync(CancellationToken.None);
+		}
+
+		[Test]
+		public async Task TestSkipBlockAsync()
+		{
+			var ms = new MemoryStream();
+			var reader = TarBuffer.CreateInputTarBuffer(ms, 1);
+			var writer = TarBuffer.CreateOutputTarBuffer(ms, 1);
+			writer.IsStreamOwner = false;
+
+			var block0 = new byte[TarBuffer.BlockSize];
+			var block1 = new byte[TarBuffer.BlockSize];
+			var r = new Random();
+			r.NextBytes(block0);
+			r.NextBytes(block1);
+
+			await writer.WriteBlockAsync(block0, CancellationToken.None);
+			await writer.WriteBlockAsync(block1, CancellationToken.None);
+			await writer.CloseAsync(CancellationToken.None);
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			await reader.SkipBlockAsync(CancellationToken.None);
+			var block = new byte[TarBuffer.BlockSize];
+			await reader.ReadBlockIntAsync(block, CancellationToken.None, true);
+			Assert.AreEqual(block, block1);
+			await writer.CloseAsync(CancellationToken.None);
+		}
+	}
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarInputStreamTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarInputStreamTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.Tar;
+using NUnit.Framework;
+
+namespace ICSharpCode.SharpZipLib.Tests.Tar
+{
+	public class TarInputStreamTests
+	{
+		[Test]
+		public void TestRead()
+		{
+			var entryBytes = new byte[2000];
+			var r = new Random();
+			r.NextBytes(entryBytes);
+			using var ms = new MemoryStream();
+			using (var tos = new TarOutputStream(ms, Encoding.UTF8) { IsStreamOwner = false })
+			{
+				var e = TarEntry.CreateTarEntry("some entry");
+				e.Size = entryBytes.Length;
+				tos.PutNextEntry(e);
+				tos.Write(entryBytes, 0, entryBytes.Length);
+				tos.CloseEntry();
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using var tis = new TarInputStream(ms, Encoding.UTF8);
+			var entry = tis.GetNextEntry();
+			Assert.AreEqual("some entry", entry.Name);
+			var buffer = new byte[1000]; // smaller than 2 blocks
+			var read0 = tis.Read(buffer, 0, buffer.Length);
+			Assert.AreEqual(1000, read0);
+			Assert.AreEqual(entryBytes.AsSpan(0, 1000).ToArray(), buffer);
+
+			var read1 = tis.Read(buffer, 0, 5);
+			Assert.AreEqual(5, read1);
+			Assert.AreEqual(entryBytes.AsSpan(1000, 5).ToArray(), buffer.AsSpan().Slice(0, 5).ToArray());
+
+			var read2 = tis.Read(buffer, 0, 20);
+			Assert.AreEqual(20, read2);
+			Assert.AreEqual(entryBytes.AsSpan(1005, 20).ToArray(), buffer.AsSpan().Slice(0, 20).ToArray());
+
+			var read3 = tis.Read(buffer, 0, 975);
+			Assert.AreEqual(975, read3);
+			Assert.AreEqual(entryBytes.AsSpan(1025, 975).ToArray(), buffer.AsSpan().Slice(0, 975).ToArray());
+		}
+
+		[Test]
+		public async Task TestReadAsync()
+		{
+			var entryBytes = new byte[2000];
+			var r = new Random();
+			r.NextBytes(entryBytes);
+			using var ms = new MemoryStream();
+			using (var tos = new TarOutputStream(ms, Encoding.UTF8) { IsStreamOwner = false })
+			{
+				var e = TarEntry.CreateTarEntry("some entry");
+				e.Size = entryBytes.Length;
+				await tos.PutNextEntryAsync(e, CancellationToken.None);
+				await tos.WriteAsync(entryBytes, 0, entryBytes.Length);
+				await tos.CloseEntryAsync(CancellationToken.None);
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using var tis = new TarInputStream(ms, Encoding.UTF8);
+			var entry = await tis.GetNextEntryAsync(CancellationToken.None);
+			Assert.AreEqual("some entry", entry.Name);
+			var buffer = new byte[1000]; // smaller than 2 blocks
+			var read0 = await tis.ReadAsync(buffer, 0, buffer.Length);
+			Assert.AreEqual(1000, read0);
+			Assert.AreEqual(entryBytes.AsSpan(0, 1000).ToArray(), buffer);
+
+			var read1 = await tis.ReadAsync(buffer, 0, 5);
+			Assert.AreEqual(5, read1);
+			Assert.AreEqual(entryBytes.AsSpan(1000, 5).ToArray(), buffer.AsSpan().Slice(0, 5).ToArray());
+
+			var read2 = await tis.ReadAsync(buffer, 0, 20);
+			Assert.AreEqual(20, read2);
+			Assert.AreEqual(entryBytes.AsSpan(1005, 20).ToArray(), buffer.AsSpan().Slice(0, 20).ToArray());
+
+			var read3 = await tis.ReadAsync(buffer, 0, 975);
+			Assert.AreEqual(975, read3);
+			Assert.AreEqual(entryBytes.AsSpan(1025, 975).ToArray(), buffer.AsSpan().Slice(0, 975).ToArray());
+		}
+	}
+}


### PR DESCRIPTION
<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

Relates to #223 

I have taken a first pass at making TAR support async streams which will help with streaming to and from network streams. I have also tried to dramatically reduce memory allocations associated with reading from and writing to TAR's.

I haven't added new tests yet or really checked what the coverage is like but if you are happy with how it looks as it, I can do that.

Below are some benchmarks run before and after my changes:  
Before:  
|                  Method |        Job |     Toolchain |       Mean |    Error |   StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------------ |----------- |-------------- |-----------:|---------:|---------:|--------:|-------:|------:|----------:|
|      ReadTarInputStream | Job-IFGTKW | .NET Core 3.1 |   122.3 μs |  1.71 μs |  1.43 μs | 33.2031 | 1.2207 |     - | 1112144 B |
| ReadTarInputStreamAsync | Job-IFGTKW | .NET Core 3.1 | 1,081.9 μs | 21.64 μs | 58.50 μs | 37.1094 | 0.9766 |     - | 1227248 B |
|      WriteTarOutputStream | Job-IFGTKW | .NET Core 3.1 |    50.54 μs |  0.339 μs |  0.283 μs | 0.3052 |     - |     - |   12008 B |
| WriteTarOutputStreamAsync | Job-IFGTKW | .NET Core 3.1 | 1,135.09 μs | 22.460 μs | 51.154 μs | 3.9063 |     - |     - |  126985 B |

After:  
|                  Method |        Job |     Toolchain |     Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |----------- |-------------- |---------:|--------:|--------:|------:|------:|------:|----------:|
|      ReadTarInputStream | Job-KKAMPY | .NET Core 3.1 | 221.3 μs | 0.76 μs | 0.64 μs |     - |     - |     - |     952 B |
| ReadTarInputStreamAsync | Job-KKAMPY | .NET Core 3.1 | 227.1 μs | 4.05 μs | 3.79 μs |     - |     - |     - |    1096 B |
|      WriteTarOutputStream | Job-KKAMPY | .NET Core 3.1 | 149.7 μs | 2.71 μs | 2.54 μs |     - |     - |     - |     449 B |
| WriteTarOutputStreamAsync | Job-KKAMPY | .NET Core 3.1 | 146.7 μs | 0.67 μs | 0.56 μs |     - |     - |     - |     448 B |