### PR TITLE
fix(zip): 0 in zip64 local sizes using descriptors

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -1145,12 +1145,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 					if (localFlags.HasAny(GeneralBitFlags.Descriptor))
 					{
 						// These may be valid if patched later
-						if ((size > 0) && (size != entry.Size))
+						if ((size != 0) && (size != entry.Size))
 						{
 							throw new ZipException("Size invalid for descriptor");
 						}
 
-						if ((compressedSize > 0) && (compressedSize != entry.CompressedSize))
+						if ((compressedSize != 0) && (compressedSize != entry.CompressedSize))
 						{
 							throw new ZipException("Compressed size invalid for descriptor");
 						}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFormat.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFormat.cs
@@ -114,8 +114,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 				else
 				{
-					ed.AddLeLong(-1);
-					ed.AddLeLong(-1);
+					// If the sizes are stored in the descriptor, the local Zip64 sizes should be 0
+					ed.AddLeLong(0);
+					ed.AddLeLong(0);
 				}
 				ed.AddNewEntry(1);
 


### PR DESCRIPTION
In #736, the header tests were changed to allow for `0` being passed as the Zip64 sizes when testing the archive. That is actually the correct value as per the spec, and hence this updates the output of `ZipFormat.WriteLocalHeader` to write `0` when using descriptors together with Zip64.

Fixes #744

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
