### PR TITLE
fix(zip): skip reading position for non-seekable async streams

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -521,9 +521,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public async Task PutNextEntryAsync(ZipEntry entry, CancellationToken ct = default)
 		{
 			if (curEntry != null) await CloseEntryAsync(ct);
+			var position = CanPatchEntries ? baseOutputStream_.Position : -1; 
 			await baseOutputStream_.WriteProcToStreamAsync(s =>
 			{
-				PutNextEntry(s, entry, baseOutputStream_.Position);
+				PutNextEntry(s, entry, position);
 			}, ct);
 			
 			if (!entry.IsCrypted) return;

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
@@ -177,13 +177,15 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 		/// </summary>
 		/// <value></value>
 		/// <returns>true if the stream is open.</returns>
-		public override bool CanSeek
+		public override bool CanSeek => false;
+
+		/// <inheritdoc />
+		public override long Position
 		{
-			get
-			{
-				return false;
-			}
+			get => throw new NotSupportedException("Getting position is not supported");
+			set => throw new NotSupportedException("Setting position is not supported");
 		}
+
 	}
 
 	/// <summary>

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/StreamHandling.cs
@@ -111,11 +111,10 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				outStream.Close();
 			}
 
-			Assert.That(msw.ToArray(), Does.PassTestArchive());
+			var msBytes = msw.ToArray();
+			Assert.That(msBytes, Does.PassTestArchive());
 
-			msw.Position = 0;
-
-			using (var zis = new ZipInputStream(msw))
+			using (var zis = new ZipInputStream(new MemoryStream(msBytes)))
 			{
 				while (zis.GetNextEntry() != null)
 				{

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
@@ -97,5 +97,26 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			ZipTesting.AssertValidZip(ms, password, false);
 		}
 
+		[Test]
+		[Category("Zip")]
+		[Category("Async")]
+		public async Task WriteReadOnlyZipStreamAsync ()
+		{
+			using var ms = new MemoryStreamWithoutSeek();
+
+			using(var outStream = new ZipOutputStream(ms) { IsStreamOwner = false })
+			{
+				await outStream.PutNextEntryAsync(new ZipEntry("FirstFile"));
+				await Utils.WriteDummyDataAsync(outStream, 12);
+
+				await outStream.PutNextEntryAsync(new ZipEntry("SecondFile"));
+				await Utils.WriteDummyDataAsync(outStream, 12);
+
+				await outStream.FinishAsync(CancellationToken.None);
+			}
+
+			ZipTesting.AssertValidZip(new MemoryStream(ms.ToArray()));
+		}
+
 	}
 }


### PR DESCRIPTION
The async version of `PutNextEntry` tries to read the target streams position to be able to correctly patch the sizes, even if the stream doesn't support seeking. This causes a `NotSupported` exception to be thrown when used with common non-seekable target streams.

Fixes #731.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._