### PR TITLE
prepare for v1.4.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,11 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
-        target: [netstandard2.0, netstandard2.1]
-        include:
-          - os: windows-2019
-            target: net45
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        target: [netstandard2.0, netstandard2.1, net6.0]
     env:
       LIB_PROJ: src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
     steps:
@@ -31,10 +28,10 @@ jobs:
         ref: ${{ github.events.inputs.tag }}
         fetch-depth: 0
 
-    - name: Setup .NET Core
+    - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.0.x'
         
     - name: Show .NET info
       run: dotnet --info
@@ -52,17 +49,17 @@ jobs:
       matrix:
         # Windows testing is combined with code coverage
         os: [ubuntu, macos]
-        target: [netcoreapp3.1]
+        target: [net6.0]
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
     - name: Setup .NET Core
-      if: matrix.target == 'netcoreapp3.1'
+      if: matrix.target == 'net6.0'
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.0.x'
 
     - name: Restore test dependencies
       run: dotnet restore
@@ -89,7 +86,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.0.x'
         
     # NOTE: This is the temporary fix for https://github.com/actions/virtual-environments/issues/1090
     - name: Cleanup before restore
@@ -120,7 +117,7 @@ jobs:
 
   Pack:
     needs: [Build, Test, CodeCov]
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
       PKG_SUFFIX: ''
       PKG_PROJ: src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -135,14 +132,14 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
         
     - name: Build library for .NET Standard 2.0
       run: dotnet build -c Release -f netstandard2.0 ${{ env.PKG_PROPS }} ${{ env.PKG_PROJ }}
     - name: Build library for .NET Standard 2.1
       run: dotnet build -c Release -f netstandard2.1 ${{ env.PKG_PROPS }} ${{ env.PKG_PROJ }}
-    - name: Build library for .NET Framework 4.5
-      run: dotnet build -c Release -f net45  ${{ env.PKG_PROPS }} ${{ env.PKG_PROJ }}
+    - name: Build library for .NET 6.0
+      run: dotnet build -c Release -f net6.0  ${{ env.PKG_PROPS }} ${{ env.PKG_PROJ }}
 
     - name: Add PR suffix to package
       if: ${{ github.event_name == 'pull_request' }}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -40,7 +40,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		}
 
 		// The final n bytes of the AES stream contain the Auth Code.
-		private const int AUTH_CODE_LENGTH = 10;
+		public const int AUTH_CODE_LENGTH = 10;
 
 		// Blocksize is always 16 here, even for AES-256 which has transform.InputBlockSize of 32.
 		private const int CRYPTO_BLOCK_SIZE = 16;

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -126,18 +126,24 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
 		{
 			var buffer = Array.Empty<byte>();
-			if (inputCount > ZipAESStream.AUTH_CODE_LENGTH)
-			{
-				// At least one byte of data is preceeding the auth code
-				int finalBlock = inputCount - ZipAESStream.AUTH_CODE_LENGTH;
-				buffer = new byte[finalBlock];
-				TransformBlock(inputBuffer, inputOffset, finalBlock, buffer, 0);
-			}
-			else if (inputCount < ZipAESStream.AUTH_CODE_LENGTH)
-				throw new Zip.ZipException("Auth code missing from input stream");
 
-			// Read the authcode from the last 10 bytes
-			_authCode = _hmacsha1.GetHashAndReset();
+			// FIXME: When used together with `ZipAESStream`, the final block handling is done inside of it instead
+			// This should not be necessary anymore, and the entire `ZipAESStream` class should be replaced with a plain `CryptoStream`
+			if (inputCount != 0) {
+				if (inputCount > ZipAESStream.AUTH_CODE_LENGTH)
+				{
+					// At least one byte of data is preceeding the auth code
+					int finalBlock = inputCount - ZipAESStream.AUTH_CODE_LENGTH;
+					buffer = new byte[finalBlock];
+					TransformBlock(inputBuffer, inputOffset, finalBlock, buffer, 0);
+				}
+				else if (inputCount < ZipAESStream.AUTH_CODE_LENGTH)
+					throw new Zip.ZipException("Auth code missing from input stream");
+
+				// Read the authcode from the last 10 bytes
+				_authCode = _hmacsha1.GetHashAndReset();
+			}
+			
 
 			return buffer;
 		}

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Security.Cryptography;
-using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.Encryption
 {
@@ -9,31 +8,6 @@ namespace ICSharpCode.SharpZipLib.Encryption
 	/// </summary>
 	internal class ZipAESTransform : ICryptoTransform
 	{
-#if NET45
-		class IncrementalHash : HMACSHA1
-		{
-			bool _finalised;
-			public IncrementalHash(byte[] key) : base(key) { }
-			public static IncrementalHash CreateHMAC(string n, byte[] key) => new IncrementalHash(key);
-			public void AppendData(byte[] buffer, int offset, int count) => TransformBlock(buffer, offset, count, buffer, offset);
-			public byte[] GetHashAndReset()
-			{
-				if (!_finalised)
-				{
-					byte[] dummy = new byte[0];
-					TransformFinalBlock(dummy, 0, 0);
-					_finalised = true;
-				}
-				return Hash;
-			}
-		}
-
-		static class HashAlgorithmName
-		{
-			public static string SHA1 = null;
-		}
-#endif
-
 		private const int PWD_VER_LENGTH = 2;
 
 		// WinZip use iteration count of 1000 for PBKDF2 key generation
@@ -137,91 +111,61 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		/// <summary>
 		/// Returns the 2 byte password verifier
 		/// </summary>
-		public byte[] PwdVerifier
-		{
-			get
-			{
-				return _pwdVerifier;
-			}
-		}
+		public byte[] PwdVerifier => _pwdVerifier;
 
 		/// <summary>
 		/// Returns the 10 byte AUTH CODE to be checked or appended immediately following the AES data stream.
 		/// </summary>
-		public byte[] GetAuthCode()
-		{
-			if (_authCode == null)
-			{
-				_authCode = _hmacsha1.GetHashAndReset();
-			}
-			return _authCode;
-		}
+		public byte[] GetAuthCode() => _authCode ?? (_authCode = _hmacsha1.GetHashAndReset());
 
 		#region ICryptoTransform Members
 
 		/// <summary>
-		/// Not implemented.
+		/// Transform final block and read auth code
 		/// </summary>
 		public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
 		{
-			if (inputCount > 0)
+			var buffer = Array.Empty<byte>();
+			if (inputCount > ZipAESStream.AUTH_CODE_LENGTH)
 			{
-				throw new NotImplementedException("TransformFinalBlock is not implemented and inputCount is greater than 0");
+				// At least one byte of data is preceeding the auth code
+				int finalBlock = inputCount - ZipAESStream.AUTH_CODE_LENGTH;
+				buffer = new byte[finalBlock];
+				TransformBlock(inputBuffer, inputOffset, finalBlock, buffer, 0);
 			}
-			return Empty.Array<byte>();
+			else if (inputCount < ZipAESStream.AUTH_CODE_LENGTH)
+				throw new Zip.ZipException("Auth code missing from input stream");
+
+			// Read the authcode from the last 10 bytes
+			_authCode = _hmacsha1.GetHashAndReset();
+
+			return buffer;
 		}
 
 		/// <summary>
 		/// Gets the size of the input data blocks in bytes.
 		/// </summary>
-		public int InputBlockSize
-		{
-			get
-			{
-				return _blockSize;
-			}
-		}
+		public int InputBlockSize => _blockSize;
 
 		/// <summary>
 		/// Gets the size of the output data blocks in bytes.
 		/// </summary>
-		public int OutputBlockSize
-		{
-			get
-			{
-				return _blockSize;
-			}
-		}
+		public int OutputBlockSize => _blockSize;
 
 		/// <summary>
 		/// Gets a value indicating whether multiple blocks can be transformed.
 		/// </summary>
-		public bool CanTransformMultipleBlocks
-		{
-			get
-			{
-				return true;
-			}
-		}
+		public bool CanTransformMultipleBlocks => true;
 
 		/// <summary>
 		/// Gets a value indicating whether the current transform can be reused.
 		/// </summary>
-		public bool CanReuseTransform
-		{
-			get
-			{
-				return true;
-			}
-		}
+		public bool CanReuseTransform => true;
 
 		/// <summary>
 		/// Cleanup internal state.
 		/// </summary>
-		public void Dispose()
-		{
-			_encryptor.Dispose();
-		}
+		public void Dispose() => _encryptor.Dispose();
 
 		#endregion ICryptoTransform Members
 	}

--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net45</TargetFrameworks>
-    <SignAssembly>True</SignAssembly>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../assets/ICSharpCode.SharpZipLib.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,8 +13,8 @@
   
   <!-- Nuget specific tags -->
   <PropertyGroup>
-    <Version>1.3.3</Version>
-    <FileVersion>$(Version).11</FileVersion>
+    <Version>1.4.0</Version>
+    <FileVersion>$(Version).12</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <PackageId>SharpZipLib</PackageId>
     <Company>ICSharpCode</Company>
@@ -22,21 +24,16 @@
 		<PackageProjectUrl>http://icsharpcode.github.io/SharpZipLib/</PackageProjectUrl>
 		<PackageIcon>images/sharpziplib-nuget-256x256.png</PackageIcon>
     <RepositoryUrl>https://github.com/icsharpcode/SharpZipLib</RepositoryUrl>
-    <Copyright>Copyright © 2000-2021 SharpZipLib Contributors</Copyright>
+    <Copyright>Copyright © 2000-2022 SharpZipLib Contributors</Copyright>
     <PackageTags>Compression Library Zip GZip BZip2 LZW Tar</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageReleaseNotes>
-Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.3.3 for more information.</PackageReleaseNotes>
+Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.4.0 for more information.</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/icsharpcode/SharpZipLib</PackageProjectUrl> 
   </PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-		<PackageReference Include="System.Memory" Version="4.5.4" />
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -412,7 +412,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 			}
 		}
 
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER
 		/// <summary>
 		/// Calls <see cref="FinishAsync"/> and closes the underlying
 		/// stream when <see cref="IsStreamOwner"></see> is true.

--- a/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
+++ b/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-		<TargetFrameworks>netcoreapp3.1;net46</TargetFrameworks>
+		<TargetFrameworks>net6.0;net462</TargetFrameworks>
     <ApplicationIcon />
     <StartupObject />
     <SignAssembly>true</SignAssembly>
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="nunit.console" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="nunit.console" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
this branch contains changes needed for the upcoming release, mainly related to .NET 6

The new target frameworks will be:
- .NET Standard 2.0 (for .NET framework 4.6.2+)
- .NET Standard 2.1 (general support for all but .NET framework)
- .NET 6.0 (new LTS)

the main issue stems from the fact that the AES auth code reading is handled inside a class inheriting from `CryptoStream`. For that to work correctly, the reads cannot be bypassed by more efficient code (which is what is happening in the .NET 6 version of `CryptoStream`).
In fact, the entire `ZIPAESStream` should probably just be removed altogether, since it seems to just be a work around for having the auth code appended to the input stream. this can be handled much easier in the TransformLastBlock method of ZipAESTransform.

that approach is now used by async reads on .NET 6.0, but others still use the legacy code. this was done to do as little as possible to allow SharpZipLib to work with .NET 6, but it really ought to be replaced for all usages.
