### PR TITLE
Fix security weakness for compilation in .NET 7

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -76,7 +76,11 @@ namespace ICSharpCode.SharpZipLib.Encryption
 			_encrPos = ENCRYPT_BLOCK;
 
 			// Performs the equivalent of derive_key in Dr Brian Gladman's pwd2key.c
+#if NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+			var pdb = new Rfc2898DeriveBytes(key, saltBytes, KEY_ROUNDS, HashAlgorithmName.SHA1);
+#else
 			var pdb = new Rfc2898DeriveBytes(key, saltBytes, KEY_ROUNDS);
+#endif
 			var rm = Aes.Create();
 			rm.Mode = CipherMode.ECB;           // No feedback from cipher for CTR mode
 			_counterNonce = new byte[_blockSize];
@@ -160,7 +164,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		/// </summary>
 		public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
 		{
-			if(inputCount > 0)
+			if (inputCount > 0)
 			{
 				throw new NotImplementedException("TransformFinalBlock is not implemented and inputCount is greater than 0");
 			}


### PR DESCRIPTION
The Rfc2898DeriveBytes constructor used is called out as insecure in NET 7, because it’s insecure to use defaults for the number of iterations and hashing algorithm. The fix is to pass those (secure) values in the versions of .NET that support it.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
