### PR TITLE
Fix #337: Enable use of TarArchive.RootPath for files under working directory

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
@@ -857,11 +857,33 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (!String.IsNullOrEmpty(rootPath))
 			{
-				if (entry.Name.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
+				string newRootPath = rootPath;
+
+				// remove CurrentDirectory from RootPath to be consistent with TarEntry behavior
+				var currentDirectory = Directory.GetCurrentDirectory()
+					.ToTarArchivePath();
+				if (rootPath.StartsWith(currentDirectory, StringComparison.OrdinalIgnoreCase))
 				{
-					newName = entry.Name.Substring(rootPath.Length + 1);
+					if (rootPath.Length == currentDirectory.Length)
+					{
+						// if they are the same, rootPath would be empty
+						// and so the entry name is not modified
+						newRootPath = string.Empty;
+					}
+					else
+					{
+						// TarEntry would have removed the current directory from the entry name, and so do the same here
+						newRootPath = rootPath.Substring(currentDirectory.Length + 1);
+					}
+				}
+
+				if (!string.IsNullOrEmpty(newRootPath) && 
+					entry.Name.StartsWith(newRootPath, StringComparison.OrdinalIgnoreCase))
+				{
+					newName = entry.Name.Substring(newRootPath.Length + 1);
 				}
 			}
+
 
 			if (pathPrefix != null)
 			{

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
@@ -4,11 +4,11 @@ using ICSharpCode.SharpZipLib.Tests.TestSupport;
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework.Internal;
-using System.Linq;
 
 namespace ICSharpCode.SharpZipLib.Tests.Tar
 {


### PR DESCRIPTION
This change fixes #337 . I recently encountered this issue, and saw that #392 had been blocked for a while, and so I decided to take a crack at it.

This does not implement this feature using a feature flag as of writing, as suggested in the thread, but does preserve the existing behavior of adding files under the CurrentDirectory in most cases. When the RootPath is set, and is a child path of CurrentDirectory, the CurrentDirectory is removed from the RootPath, to match the behavior of TarEntry.

My main motivation for changing this behavior in TarArchive, instead of TarEntry, is so that the interface of TarEntry remains unchanged.

The existing behavior works like this: (`{workingDirectory}` is not a child of `/absolute/path/`)

| Root Path | File Path | Resulting Tar Entry |
| - | - | - |
| `{workingDirectory}/temp` | `{workingDirectory}/temp/file.txt` | `temp/file.txt` | 
| (unset) | `{workingDirectory}/temp/file.txt` | `temp/file.txt` |
| `temp` | `{workingDirectory}/temp/file.txt` | `file.txt` | 
| `/absolute/path/` | `/absolute/path/file.txt` | `file.txt` |
| (unset) | `/absolute/path/file.txt` | `/absolute/path/file.txt` |

Instead, per #337 the behavior should be:

| Root Path | File Path | Resulting Tar Entry |
| - | - | - |
| `{workingDirectory}/temp` | `{workingDirectory}/temp/file.txt` | **`file.txt`** | 
| (unset) | `{workingDirectory}/temp/file.txt` | `temp/file.txt` |
| `temp` | `{workingDirectory}/temp/file.txt` | `file.txt` | 
| `/absolute/path/` | `/absolute/path/file.txt` | `file.txt` |
| (unset) | `/absolute/path/file.txt` | `/absolute/path/file.txt` |

An attempt was made to implement this change without additional string manipulation. This could be done with a modified IndexOf, that enables searching for a substring of the pattern within the target substring. This may improve performance.

- Implements this change when RootPath is under CurrentDirectory
  - [ ] Consider reworking this change to avoid additional string manipulation  
  - [ ] The first case has changed, do we need a property in TarArchive to preserve existing behavior?
- Adds test coverage for all cases except when RootPath is upset, and File Path is outside working directory

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
