### PR TITLE
docs: fix circular refs and target fw

### DIFF
--- a/docs/help/docfx.json
+++ b/docs/help/docfx.json
@@ -16,7 +16,7 @@
       ],
       "dest": "api",
       "properties": {
-        "TargetFramework": "NETSTANDARD2"
+        "TargetFramework": "netstandard2.0"
       }
     }
   ],
@@ -65,7 +65,7 @@
     ],
 	"globalMetadata": {
       "_appTitle": "SharpZipLib Help",
-      "_appFooter": "Copyright © 2000-2019 SharpZipLib Contributors",
+      "_appFooter": "Copyright © 2000-2022 SharpZipLib Contributors",
       "_gitContribute": {
          "repo": "https://github.com/icsharpcode/SharpZipLib",
          "branch": "master"

--- a/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -188,7 +188,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 		}
 		
 #if NETSTANDARD2_1_OR_GREATER
-		/// <inheritdoc cref="DeflaterOutputStream.DisposeAsync"/>
+		/// <inheritdoc cref="DeflaterOutputStream.Dispose"/>
 		public override async ValueTask DisposeAsync()
 		{
 			try

--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -361,7 +361,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			set => _stringCodec.CodePage = value;
 		}
 		
-		/// <inheritdoc cref="StringCodec"/>
+		/// <inheritdoc cref="Zip.StringCodec"/>
 		public StringCodec StringCodec
 		{
 			get => _stringCodec;

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -739,7 +739,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			set => _stringCodec.ZipCryptoEncoding = value;
 		}
 
-		/// <inheritdoc cref="StringCodec"/>
+		/// <inheritdoc cref="Zip.StringCodec"/>
 		public StringCodec StringCodec
 		{
 			get => _stringCodec;


### PR DESCRIPTION
fix circular references in `inheritdocs` and target framework.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
