### PR TITLE
fix(zip): cleanup/fix of StringCodec

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -205,7 +205,12 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		protected byte[] AESAuthCode;
 
 		/// <inheritdoc cref="StringCodec.ZipCryptoEncoding"/>
-		public Encoding ZipCryptoEncoding { get; set; } = StringCodec.DefaultZipCryptoEncoding;
+		public Encoding ZipCryptoEncoding {
+			get => _stringCodec.ZipCryptoEncoding;
+			set {
+				_stringCodec = _stringCodec.WithZipCryptoEncoding(value);
+			} 
+		}
 
 		/// <summary>
 		/// Encrypt a block of data
@@ -507,6 +512,9 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		protected Stream baseOutputStream_;
 
 		private bool isClosed_;
+
+		/// <inheritdoc cref="StringCodec"/>
+		protected StringCodec _stringCodec = ZipStrings.GetStringCodec();
 
 		#endregion Instance Fields
 	}

--- a/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -358,7 +358,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public int LegacyCodePage
 		{
 			get => _stringCodec.CodePage;
-			set => _stringCodec.CodePage = value;
+			set => _stringCodec = StringCodec.FromCodePage(value);
 		}
 		
 		/// <inheritdoc cref="Zip.StringCodec"/>
@@ -579,7 +579,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			directoryFilter_ = new NameFilter(directoryFilter);
 			restoreDateTimeOnExtract_ = restoreDateTime;
 
-			using (zipFile_ = new ZipFile(inputStream, !isStreamOwner))
+			using (zipFile_ = new ZipFile(inputStream, !isStreamOwner, _stringCodec))
 			{
 				if (password_ != null)
 				{
@@ -994,8 +994,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		private INameTransform extractNameTransform_;
 		private UseZip64 useZip64_ = UseZip64.Dynamic;
 		private CompressionLevel compressionLevel_ = CompressionLevel.DEFAULT_COMPRESSION;
-		private StringCodec _stringCodec = new StringCodec();
-
+		private StringCodec _stringCodec = ZipStrings.GetStringCodec();
 		private string password_;
 
 		#endregion Instance Fields

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFormat.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFormat.cs
@@ -95,7 +95,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 			}
 
-			byte[] name = stringCodec.ZipOutputEncoding.GetBytes(entry.Name);
+			byte[] name = stringCodec.ZipEncoding(entry.IsUnicodeText).GetBytes(entry.Name);
 
 			if (name.Length > 0xFFFF)
 			{

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -5,6 +5,7 @@ using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -102,6 +103,21 @@ namespace ICSharpCode.SharpZipLib.Zip
 			: base(baseInputStream, new Inflater(true), bufferSize)
 		{
 			internalReader = new ReadDataHandler(ReadingNotAvailable);
+		}
+
+		/// <summary>
+		/// Creates a new Zip input stream, for reading a zip archive.
+		/// </summary>
+		/// <param name="baseInputStream">The underlying <see cref="Stream"/> providing data.</param>
+		/// <param name="stringCodec"></param>
+		public ZipInputStream(Stream baseInputStream, StringCodec stringCodec)
+			: base(baseInputStream, new Inflater(true))
+		{
+			internalReader = new ReadDataHandler(ReadingNotAvailable);
+			if (stringCodec != null)
+			{
+				_stringCodec = stringCodec;
+			}
 		}
 
 		#endregion Constructors
@@ -558,7 +574,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				// Generate and set crypto transform...
 				var managed = new PkzipClassicManaged();
+				Console.WriteLine($"Input Encoding: {_stringCodec.ZipCryptoEncoding.EncodingName}");
 				byte[] key = PkzipClassic.GenerateKeys(_stringCodec.ZipCryptoEncoding.GetBytes(password));
+				Console.WriteLine($"Input Bytes: {string.Join(", ", key.Select(b => $"{b:x2}").ToArray())}");
 
 				inputBuffer.CryptoTransform = managed.CreateDecryptor(key, null);
 

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -6,6 +6,7 @@ using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,7 +81,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 		{
 		}
 
-		internal ZipOutputStream(Stream baseOutputStream, StringCodec stringCodec) : this(baseOutputStream)
+		/// <summary>
+		/// Creates a new Zip output stream, writing a zip archive.
+		/// </summary>
+		/// <param name="baseOutputStream">The output stream to which the archive contents are written.</param>
+		/// <param name="stringCodec"></param>
+		public ZipOutputStream(Stream baseOutputStream, StringCodec stringCodec) : this(baseOutputStream)
 		{
 			_stringCodec = stringCodec;
 		}
@@ -160,7 +166,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// Defaults to <see cref="PathTransformer"/>, set to null to disable transforms and use names as supplied.
 		/// </summary>
 		public INameTransform NameTransform { get; set; } = new PathTransformer();
-		
+
 		/// <summary>
 		/// Get/set the password used for encryption.
 		/// </summary>
@@ -742,7 +748,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		private void InitializeZipCryptoPassword(string password)
 		{
 			var pkManaged = new PkzipClassicManaged();
+			Console.WriteLine($"Output Encoding: {ZipCryptoEncoding.EncodingName}");
 			byte[] key = PkzipClassic.GenerateKeys(ZipCryptoEncoding.GetBytes(password));
+			Console.WriteLine($"Output Bytes: {string.Join(", ", key.Select(b => $"{b:x2}").ToArray())}");
 			cryptoTransform_ = pkManaged.CreateEncryptor(key, null);
 		}
 		
@@ -969,8 +977,6 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// The password to use when encrypting archive entries.
 		/// </summary>
 		private string password;
-
-		private readonly StringCodec _stringCodec = ZipStrings.GetStringCodec();
 
 		#endregion Instance Fields
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/GeneralHandling.cs
@@ -85,57 +85,6 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			}
 		}
 
-		private string DescribeAttributes(FieldAttributes attributes)
-		{
-			string att = string.Empty;
-			if ((FieldAttributes.Public & attributes) != 0)
-			{
-				att = att + "Public,";
-			}
-
-			if ((FieldAttributes.Static & attributes) != 0)
-			{
-				att = att + "Static,";
-			}
-
-			if ((FieldAttributes.Literal & attributes) != 0)
-			{
-				att = att + "Literal,";
-			}
-
-			if ((FieldAttributes.HasDefault & attributes) != 0)
-			{
-				att = att + "HasDefault,";
-			}
-
-			if ((FieldAttributes.InitOnly & attributes) != 0)
-			{
-				att = att + "InitOnly,";
-			}
-
-			if ((FieldAttributes.Assembly & attributes) != 0)
-			{
-				att = att + "Assembly,";
-			}
-
-			if ((FieldAttributes.FamANDAssem & attributes) != 0)
-			{
-				att = att + "FamANDAssembly,";
-			}
-
-			if ((FieldAttributes.FamORAssem & attributes) != 0)
-			{
-				att = att + "FamORAssembly,";
-			}
-
-			if ((FieldAttributes.HasFieldMarshal & attributes) != 0)
-			{
-				att = att + "HasFieldMarshal,";
-			}
-
-			return att;
-		}
-
 		/// <summary>
 		/// Invalid passwords should be detected early if possible, seekable stream
 		/// Note: Have a 1/255 chance of failing due to CRC collision (hence retried once)
@@ -865,7 +814,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[TestCase("a/b/c/d/e/f/g/h/SomethingLikeAnArchiveName.txt")]
 		public void LegacyNameConversion(string name)
 		{
-			var encoding = new StringCodec().ZipEncoding(false);
+			var encoding = StringCodec.Default.ZipEncoding(false);
 			byte[] intermediate = encoding.GetBytes(name);
 			string final = encoding.GetString(intermediate);
 
@@ -878,22 +827,22 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		{
 			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
-			var codec = new StringCodec() {CodePage = 850};
+			var codec = StringCodec.FromCodePage(850);
 			string sample = "Hello world";
 
 			byte[] rawData = Encoding.ASCII.GetBytes(sample);
 
-			var converted = codec.ZipInputEncoding(0).GetString(rawData);
+			var converted = codec.LegacyEncoding.GetString(rawData);
 			Assert.AreEqual(sample, converted);
 
-			converted = codec.ZipInputEncoding((int)GeneralBitFlags.UnicodeText).GetString(rawData);
+			converted = codec.ZipInputEncoding(GeneralBitFlags.UnicodeText).GetString(rawData);
 			Assert.AreEqual(sample, converted);
 
 			// This time use some greek characters
 			sample = "\u03A5\u03d5\u03a3";
 			rawData = Encoding.UTF8.GetBytes(sample);
 
-			converted = codec.ZipInputEncoding((int)GeneralBitFlags.UnicodeText).GetString(rawData);
+			converted = codec.ZipInputEncoding(GeneralBitFlags.UnicodeText).GetString(rawData);
 			Assert.AreEqual(sample, converted);
 		}
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStringsTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStringsTests.cs
@@ -1,0 +1,242 @@
+﻿using ICSharpCode.SharpZipLib.Tests.TestSupport;
+using ICSharpCode.SharpZipLib.Zip;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using static System.Net.WebRequestMethods;
+using Does = NUnit.Framework.Does;
+
+namespace ICSharpCode.SharpZipLib.Tests.Zip
+{
+	[TestFixture]
+	[Order(0)]
+	public class ZipStringsTests
+	{
+		[Test]
+		[Order(0)]
+		// NOTE: This test needs to be run before any test registering CodePagesEncodingProvider.Instance
+		public void TestSystemDefaultEncoding()
+		{
+			Console.WriteLine($"Default encoding before registering provider: {Encoding.GetEncoding(0).EncodingName}");
+			Encoding.RegisterProvider(new TestEncodingProvider());
+			Console.WriteLine($"Default encoding after registering provider: {Encoding.GetEncoding(0).EncodingName}");
+
+			// Initialize a default StringCodec
+			var sc = StringCodec.Default;
+
+			var legacyEncoding = sc.ZipEncoding(false);
+			Assert.That(legacyEncoding.EncodingName, Is.EqualTo(TestEncodingProvider.DefaultEncodingName));
+			Assert.That(legacyEncoding.CodePage, Is.EqualTo(TestEncodingProvider.DefaultEncodingCodePage)); 
+		}
+
+		[Test]
+		[Order(1)]
+		public void TestFastZipRoundTripWithCodePage()
+		{
+			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+			using var ms = new MemoryStream();
+			using var zipFile = new TempFile();
+			using var srcDir = new TempDir();
+			using var dstDir = new TempDir();
+
+			srcDir.CreateDummyFile("file1");
+			srcDir.CreateDummyFile("слово");
+
+			foreach(var f in Directory.EnumerateFiles(srcDir.FullName))
+			{
+				Console.WriteLine(f);
+			}
+
+			var fzCreate = new FastZip() { StringCodec = StringCodec.FromCodePage(866), UseUnicode = false };
+			fzCreate.CreateZip(zipFile, srcDir.FullName, true, null);
+
+			var fzExtract = new FastZip() { StringCodec = StringCodec.FromCodePage(866) };
+			fzExtract.ExtractZip(zipFile, dstDir.FullName, null);
+
+			foreach (var f in Directory.EnumerateFiles(dstDir.FullName))
+			{
+				Console.WriteLine(f);
+			}
+
+			Assert.That(dstDir.GetFile("file1").FullName, Does.Exist);
+			Assert.That(dstDir.GetFile("слово").FullName, Does.Exist);
+		}
+
+
+		[Test]
+		[Order(1)]
+		public void TestZipFileRoundTripWithCodePage()
+		{
+			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+			using var ms = new MemoryStream();
+			using (var zf = ZipFile.Create(ms))
+			{
+				zf.StringCodec = StringCodec.FromCodePage(866);
+				zf.BeginUpdate();
+				zf.Add(MemoryDataSource.Empty, "file1", CompressionMethod.Stored, useUnicodeText: false);
+				zf.Add(MemoryDataSource.Empty, "слово", CompressionMethod.Stored, useUnicodeText: false);
+				zf.CommitUpdate();
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using (var zf = new ZipFile(ms, false, StringCodec.FromCodePage(866)) { IsStreamOwner = false })
+			{
+				Assert.That(zf.GetEntry("file1"), Is.Not.Null);
+				Assert.That(zf.GetEntry("слово"), Is.Not.Null);
+			}
+
+		}
+
+		[Test]
+		[Order(1)]
+		public void TestZipStreamRoundTripWithCodePage()
+		{
+			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+			using var ms = new MemoryStream();
+			using (var zos = new ZipOutputStream(ms, StringCodec.FromCodePage(866)) { IsStreamOwner = false })
+			{
+				zos.PutNextEntry(new ZipEntry("file1") { IsUnicodeText = false });
+				zos.PutNextEntry(new ZipEntry("слово") { IsUnicodeText = false });
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using (var zis = new ZipInputStream(ms, StringCodec.FromCodePage(866)) { IsStreamOwner = false })
+			{
+				Assert.That(zis.GetNextEntry().Name, Is.EqualTo("file1"));
+				Assert.That(zis.GetNextEntry().Name, Is.EqualTo("слово"));
+			}
+
+		}
+
+		[Test]
+		[Order(1)]
+		public void TestZipCryptoPasswordEncodingRoundtrip()
+		{
+			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+			var content = Utils.GetDummyBytes(32);
+
+			using var ms = new MemoryStream();
+			using (var zos = new ZipOutputStream(ms, StringCodec.FromCodePage(866)) { IsStreamOwner = false })
+			{
+				zos.Password = "слово";
+				zos.PutNextEntry(new ZipEntry("file1"));
+				zos.Write(content, 0, content.Length);
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using (var zis = new ZipInputStream(ms, StringCodec.FromCodePage(866)) { IsStreamOwner = false })
+			{
+				zis.Password = "слово";
+				var entry = zis.GetNextEntry();
+				var output = new byte[32];
+				Assert.That(zis.Read(output, 0, 32), Is.EqualTo(32));
+				Assert.That(output, Is.EqualTo(content));
+			}
+
+		}
+
+		[Test]
+		[Order(1)]
+		public void TestZipStreamCommentEncodingRoundtrip()
+		{
+			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+			var content = Utils.GetDummyBytes(32);
+
+			using var ms = new MemoryStream();
+			using (var zos = new ZipOutputStream(ms, StringCodec.FromCodePage(866)) { IsStreamOwner = false })
+			{
+				zos.SetComment("слово");
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using var zf = new ZipFile(ms, false, StringCodec.FromCodePage(866));
+			Assert.That(zf.ZipFileComment, Is.EqualTo("слово"));
+		}
+
+
+		[Test]
+		[Order(1)]
+		public void TestZipFileCommentEncodingRoundtrip()
+		{
+			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+			var content = Utils.GetDummyBytes(32);
+
+			using var ms = new MemoryStream();
+			using (var zf = ZipFile.Create(ms))
+			{
+				zf.StringCodec = StringCodec.FromCodePage(866);
+				zf.BeginUpdate();
+				zf.SetComment("слово");
+				zf.CommitUpdate();
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
+
+			using (var zf = new ZipFile(ms, false, StringCodec.FromCodePage(866)))
+			{
+				Assert.That(zf.ZipFileComment, Is.EqualTo("слово"));
+			}
+		}
+	}
+
+
+	internal class TestEncodingProvider : EncodingProvider
+	{
+		internal static string DefaultEncodingName = "TestDefaultEncoding";
+		internal static int DefaultEncodingCodePage = -37;
+
+		class TestDefaultEncoding : Encoding
+		{
+			public override string EncodingName => DefaultEncodingName;
+			public override int CodePage => DefaultEncodingCodePage;
+
+			public override int GetByteCount(char[] chars, int index, int count) 
+				=> UTF8.GetByteCount(chars, index, count);
+
+			public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) 
+				=> UTF8.GetBytes(chars, charIndex, charCount, bytes, byteIndex);
+
+			public override int GetCharCount(byte[] bytes, int index, int count)
+				=> UTF8.GetCharCount(bytes, index, count);
+
+			public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) 
+				=> UTF8.GetChars(bytes, byteIndex, byteCount, chars, charIndex);
+
+			public override int GetMaxByteCount(int charCount) => UTF8.GetMaxByteCount(charCount);
+
+			public override int GetMaxCharCount(int byteCount) => UTF8.GetMaxCharCount(byteCount);
+		}
+
+		TestDefaultEncoding testDefaultEncoding = new TestDefaultEncoding();
+
+		public override Encoding GetEncoding(int codepage)
+			=> (codepage == 0 || codepage == DefaultEncodingCodePage) ? testDefaultEncoding : null;
+
+		public override Encoding GetEncoding(string name) 
+			=> DefaultEncodingName == name ? testDefaultEncoding : null;
+
+#if NET6_0_OR_GREATER
+		public override IEnumerable<EncodingInfo> GetEncodings()
+		{
+			yield return new EncodingInfo(this, DefaultEncodingCodePage, DefaultEncodingName, DefaultEncodingName);
+		}
+#endif
+	}
+}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStringsTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStringsTests.cs
@@ -1,26 +1,23 @@
 ﻿using ICSharpCode.SharpZipLib.Tests.TestSupport;
+using ICSharpCode.SharpZipLib.Tests.Zip;
 using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
-using static System.Net.WebRequestMethods;
-using Does = NUnit.Framework.Does;
+using Does = ICSharpCode.SharpZipLib.Tests.TestSupport.Does;
 
-namespace ICSharpCode.SharpZipLib.Tests.Zip
+// As there is no way to order the test namespace execution order we use a name that should be alphabetically sorted before any other namespace
+// This is because we have one test that only works when no encoding provider has been loaded which is not reversable once done.
+namespace ICSharpCode.SharpZipLib.Tests._Zip
 {
 	[TestFixture]
-	[Order(0)]
+	[Order(1)]
 	public class ZipStringsTests
 	{
 		[Test]
-		[Order(0)]
+		[Order(1)]
 		// NOTE: This test needs to be run before any test registering CodePagesEncodingProvider.Instance
 		public void TestSystemDefaultEncoding()
 		{
@@ -37,7 +34,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		}
 
 		[Test]
-		[Order(1)]
+		[Order(2)]
 		public void TestFastZipRoundTripWithCodePage()
 		{
 			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -72,7 +69,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 
 		[Test]
-		[Order(1)]
+		[Order(2)]
 		public void TestZipFileRoundTripWithCodePage()
 		{
 			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -98,7 +95,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		}
 
 		[Test]
-		[Order(1)]
+		[Order(2)]
 		public void TestZipStreamRoundTripWithCodePage()
 		{
 			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -121,7 +118,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		}
 
 		[Test]
-		[Order(1)]
+		[Order(2)]
 		public void TestZipCryptoPasswordEncodingRoundtrip()
 		{
 			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -150,7 +147,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		}
 
 		[Test]
-		[Order(1)]
+		[Order(2)]
 		public void TestZipStreamCommentEncodingRoundtrip()
 		{
 			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -171,7 +168,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 
 		[Test]
-		[Order(1)]
+		[Order(2)]
 		public void TestZipFileCommentEncodingRoundtrip()
 		{
 			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
@@ -122,6 +122,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			data_ = data;
 		}
 
+		public static MemoryDataSource Empty => new MemoryDataSource(Array.Empty<byte>());
+
 		#endregion Constructors
 
 		#region IDataSource Members


### PR DESCRIPTION
This PR fixes some issues that were present in #592 but wasn't detected before the release of v1.4.0.

In general, it goes a bit further in trying to make the string encoding easy and predictable to use.
It also has tests for the most common usages of the API to make sure it both works and feels straightforward to use.
The changes in the API are slightly breaking from v1.4.0, but only where the API could be misused in confusing ways. It should not require any minor version bump, but should be released ASAP to limit the effect.


Fixes #777.
Fixes #776.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
