### PR TITLE
fix: use ConfigureAwait(false) on every await

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1,0 +1,3 @@
+is_global = true
+global_level = 1
+dotnet_diagnostic.CA2007.severity = warning

--- a/benchmark/.globalconfig
+++ b/benchmark/.globalconfig
@@ -1,0 +1,3 @@
+is_global = true
+global_level = 2
+dotnet_diagnostic.CA2007.severity = none

--- a/src/ICSharpCode.SharpZipLib/Core/ByteOrderUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/ByteOrderUtils.cs
@@ -80,7 +80,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <inheritdoc cref="WriteLEShort"/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static async Task WriteLEShortAsync(this Stream stream, int value, CT ct) 
-			=> await stream.WriteAsync(SwappedBytes(value), 0, 2, ct);
+			=> await stream.WriteAsync(SwappedBytes(value), 0, 2, ct).ConfigureAwait(false);
 
 		/// <summary> Write a ushort in little endian byte order. </summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -89,7 +89,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <inheritdoc cref="WriteLEUshort"/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static async Task WriteLEUshortAsync(this Stream stream, ushort value, CT ct) 
-			=> await stream.WriteAsync(SwappedBytes(value), 0, 2, ct);
+			=> await stream.WriteAsync(SwappedBytes(value), 0, 2, ct).ConfigureAwait(false);
 
 		/// <summary> Write an int in little endian byte order. </summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -98,7 +98,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <inheritdoc cref="WriteLEInt"/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static async Task WriteLEIntAsync(this Stream stream, int value, CT ct)
-			=> await stream.WriteAsync(SwappedBytes(value), 0, 4, ct);
+			=> await stream.WriteAsync(SwappedBytes(value), 0, 4, ct).ConfigureAwait(false);
 
 		/// <summary> Write a uint in little endian byte order. </summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -107,7 +107,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <inheritdoc cref="WriteLEUint"/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static async Task WriteLEUintAsync(this Stream stream, uint value, CT ct)
-			=> await stream.WriteAsync(SwappedBytes(value), 0, 4, ct);
+			=> await stream.WriteAsync(SwappedBytes(value), 0, 4, ct).ConfigureAwait(false);
 
 		/// <summary> Write a long in little endian byte order. </summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -116,7 +116,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <inheritdoc cref="WriteLELong"/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static async Task WriteLELongAsync(this Stream stream, long value, CT ct) 
-			=> await stream.WriteAsync(SwappedBytes(value), 0, 8, ct);
+			=> await stream.WriteAsync(SwappedBytes(value), 0, 8, ct).ConfigureAwait(false);
 
 		/// <summary> Write a ulong in little endian byte order. </summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -125,6 +125,6 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <inheritdoc cref="WriteLEUlong"/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static async Task WriteLEUlongAsync(this Stream stream, ulong value, CT ct)
-			=> await stream.WriteAsync(SwappedBytes(value), 0, 8, ct);
+			=> await stream.WriteAsync(SwappedBytes(value), 0, 8, ct).ConfigureAwait(false);
 	}
 }

--- a/src/ICSharpCode.SharpZipLib/Core/StreamUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/StreamUtils.cs
@@ -280,7 +280,7 @@ namespace ICSharpCode.SharpZipLib.Core
 			bufferStream.SetLength(0);
 			writeProc(bufferStream);
 			bufferStream.Position = 0;
-			await bufferStream.CopyToAsync(targetStream, 81920, ct);
+			await bufferStream.CopyToAsync(targetStream, 81920, ct).ConfigureAwait(false);
 			bufferStream.SetLength(0);
 		}
 		
@@ -288,7 +288,7 @@ namespace ICSharpCode.SharpZipLib.Core
 		{
 			using (var ms = new MemoryStream())
 			{
-				await WriteProcToStreamAsync(targetStream, ms, writeProc, ct);
+				await WriteProcToStreamAsync(targetStream, ms, writeProc, ct).ConfigureAwait(false);
 			}
 		}
 	}

--- a/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -186,14 +186,14 @@ namespace ICSharpCode.SharpZipLib.GZip
 				}
 			}
 		}
-		
+
 #if NETSTANDARD2_1_OR_GREATER
 		/// <inheritdoc cref="DeflaterOutputStream.Dispose"/>
 		public override async ValueTask DisposeAsync()
 		{
 			try
 			{
-				await FinishAsync(CancellationToken.None);
+				await FinishAsync(CancellationToken.None).ConfigureAwait(false);
 			}
 			finally
 			{
@@ -202,11 +202,11 @@ namespace ICSharpCode.SharpZipLib.GZip
 					state_ = OutputState.Closed;
 					if (IsStreamOwner)
 					{
-						await baseOutputStream_.DisposeAsync();
+						await baseOutputStream_.DisposeAsync().ConfigureAwait(false);
 					}
 				}
 
-				await base.DisposeAsync();
+				await base.DisposeAsync().ConfigureAwait(false);
 			}
 		}
 #endif
@@ -252,8 +252,8 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// <inheritdoc cref="Flush"/>
 		public override async Task FlushAsync(CancellationToken ct)
 		{
-			await WriteHeaderAsync();
-			await base.FlushAsync(ct);
+			await WriteHeaderAsync().ConfigureAwait(false);
+			await base.FlushAsync(ct).ConfigureAwait(false);
 		}
 		
 		
@@ -263,15 +263,15 @@ namespace ICSharpCode.SharpZipLib.GZip
 			// If no data has been written a header should be added.
 			if (state_ == OutputState.Header)
 			{
-				await WriteHeaderAsync();
+				await WriteHeaderAsync().ConfigureAwait(false);
 			}
 
 			if (state_ == OutputState.Footer)
 			{
 				state_ = OutputState.Finished;
-				await base.FinishAsync(ct);
+				await base.FinishAsync(ct).ConfigureAwait(false);
 				var gzipFooter = GetFooter();
-				await baseOutputStream_.WriteAsync(gzipFooter, 0, gzipFooter.Length, ct);
+				await baseOutputStream_.WriteAsync(gzipFooter, 0, gzipFooter.Length, ct).ConfigureAwait(false);
 			}
 		}
 
@@ -356,7 +356,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 			if (state_ != OutputState.Header) return;
 			state_ = OutputState.Footer;
 			var gzipHeader = GetHeader();
-			await baseOutputStream_.WriteAsync(gzipHeader, 0, gzipHeader.Length);
+			await baseOutputStream_.WriteAsync(gzipHeader, 0, gzipHeader.Length).ConfigureAwait(false);
 		}
 
 		#endregion Support Routines

--- a/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -302,7 +302,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (currentBlockIndex >= BlockFactor)
 			{
-				if (!await ReadRecordAsync(ct, isAsync))
+				if (!await ReadRecordAsync(ct, isAsync).ConfigureAwait(false))
 				{
 					throw new TarException("Failed to read a record");
 				}
@@ -353,7 +353,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (currentBlockIndex >= BlockFactor)
 			{
-				if (!await ReadRecordAsync(ct, isAsync))
+				if (!await ReadRecordAsync(ct, isAsync).ConfigureAwait(false))
 				{
 					throw new TarException("Failed to read a record");
 				}
@@ -384,7 +384,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			while (bytesNeeded > 0)
 			{
 				long numBytes = isAsync
-					? await inputStream.ReadAsync(recordBuffer, offset, bytesNeeded, ct)
+					? await inputStream.ReadAsync(recordBuffer, offset, bytesNeeded, ct).ConfigureAwait(false)
 					: inputStream.Read(recordBuffer, offset, bytesNeeded);
 
 				//
@@ -551,7 +551,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (currentBlockIndex >= BlockFactor)
 			{
-				await WriteRecordAsync(CancellationToken.None, isAsync);
+				await WriteRecordAsync(CancellationToken.None, isAsync).ConfigureAwait(false);
 			}
 
 			Array.Copy(buffer, offset, recordBuffer, (currentBlockIndex * BlockSize), BlockSize);
@@ -571,8 +571,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (isAsync)
 			{
-				await outputStream.WriteAsync(recordBuffer, 0, RecordSize, ct);
-				await outputStream.FlushAsync(ct);
+				await outputStream.WriteAsync(recordBuffer, 0, RecordSize, ct).ConfigureAwait(false);
+				await outputStream.FlushAsync(ct).ConfigureAwait(false);
 			}
 			else
 			{
@@ -600,12 +600,12 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				int dataBytes = currentBlockIndex * BlockSize;
 				Array.Clear(recordBuffer, dataBytes, RecordSize - dataBytes);
-				await WriteRecordAsync(ct, isAsync);
+				await WriteRecordAsync(ct, isAsync).ConfigureAwait(false);
 			}
 
 			if (isAsync)
 			{
-				await outputStream.FlushAsync(ct);
+				await outputStream.FlushAsync(ct).ConfigureAwait(false);
 			}
 			else
 			{
@@ -629,14 +629,14 @@ namespace ICSharpCode.SharpZipLib.Tar
 		{
 			if (outputStream != null)
 			{
-				await WriteFinalRecordAsync(ct, isAsync);
+				await WriteFinalRecordAsync(ct, isAsync).ConfigureAwait(false);
 
 				if (IsStreamOwner)
 				{
 					if (isAsync)
 					{
 #if NETSTANDARD2_1_OR_GREATER
-						await outputStream.DisposeAsync();
+						await outputStream.DisposeAsync().ConfigureAwait(false);
 #else
 						outputStream.Dispose();
 #endif
@@ -656,7 +656,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 					if (isAsync)
 					{
 #if NETSTANDARD2_1_OR_GREATER
-						await inputStream.DisposeAsync();
+						await inputStream.DisposeAsync().ConfigureAwait(false);
 #else
 						inputStream.Dispose();
 #endif

--- a/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -138,7 +138,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <param name="cancellationToken"></param>
 		public override async Task FlushAsync(CancellationToken cancellationToken)
 		{
-			await inputStream.FlushAsync(cancellationToken);
+			await inputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -330,7 +330,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			while (numToRead > 0)
 			{
-				await tarBuffer.ReadBlockIntAsync(recBuf, ct, isAsync);
+				await tarBuffer.ReadBlockIntAsync(recBuf, ct, isAsync).ConfigureAwait(false);
 
 				var sz = (int)numToRead;
 
@@ -379,7 +379,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public override async ValueTask DisposeAsync()
 		{
-			await tarBuffer.CloseAsync(CancellationToken.None);
+			await tarBuffer.CloseAsync(CancellationToken.None).ConfigureAwait(false);
 		}
 #endif
 
@@ -465,7 +465,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				for (long num = skipCount; num > 0;)
 				{
 					int toRead = num > length ? length : (int)num;
-					int numRead = await ReadAsync(skipBuf.Memory.Slice(0, toRead), ct, isAsync);
+					int numRead = await ReadAsync(skipBuf.Memory.Slice(0, toRead), ct, isAsync).ConfigureAwait(false);
 
 					if (numRead == -1)
 					{
@@ -542,18 +542,18 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (currentEntry != null)
 			{
-				await SkipToNextEntryAsync(ct, isAsync);
+				await SkipToNextEntryAsync(ct, isAsync).ConfigureAwait(false);
 			}
 
 			byte[] headerBuf = ArrayPool<byte>.Shared.Rent(TarBuffer.BlockSize);
-			await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
+			await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync).ConfigureAwait(false);
 
 			if (TarBuffer.IsEndOfArchiveBlock(headerBuf))
 			{
 				hasHitEOF = true;
 
 				// Read the second zero-filled block
-				await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
+				await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync).ConfigureAwait(false);
 			}
 			else
 			{
@@ -592,7 +592,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 							while (numToRead > 0)
 							{
 								var length = (numToRead > TarBuffer.BlockSize ? TarBuffer.BlockSize : (int)numToRead);
-								int numRead = await ReadAsync(nameBuffer.Memory.Slice(0, length), ct, isAsync);
+								int numRead = await ReadAsync(nameBuffer.Memory.Slice(0, length), ct, isAsync).ConfigureAwait(false);
 
 								if (numRead == -1)
 								{
@@ -607,16 +607,16 @@ namespace ICSharpCode.SharpZipLib.Tar
 							longName = longNameBuilder.ToString();
 							StringBuilderPool.Instance.Return(longNameBuilder);
 
-							await SkipToNextEntryAsync(ct, isAsync);
-							await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
+							await SkipToNextEntryAsync(ct, isAsync).ConfigureAwait(false);
+							await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync).ConfigureAwait(false);
 						}
 					}
 					else if (header.TypeFlag == TarHeader.LF_GHDR)
 					{
 						// POSIX global extended header
 						// Ignore things we dont understand completely for now
-						await SkipToNextEntryAsync(ct, isAsync);
-						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
+						await SkipToNextEntryAsync(ct, isAsync).ConfigureAwait(false);
+						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync).ConfigureAwait(false);
 					}
 					else if (header.TypeFlag == TarHeader.LF_XHDR)
 					{
@@ -629,7 +629,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 						while (numToRead > 0)
 						{
 							var length = (numToRead > nameBuffer.Length ? nameBuffer.Length : (int)numToRead);
-							int numRead = await ReadAsync(nameBuffer.AsMemory().Slice(0, length), ct, isAsync);
+							int numRead = await ReadAsync(nameBuffer.AsMemory().Slice(0, length), ct, isAsync).ConfigureAwait(false);
 
 							if (numRead == -1)
 							{
@@ -647,14 +647,14 @@ namespace ICSharpCode.SharpZipLib.Tar
 							longName = name;
 						}
 
-						await SkipToNextEntryAsync(ct, isAsync);
-						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
+						await SkipToNextEntryAsync(ct, isAsync).ConfigureAwait(false);
+						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync).ConfigureAwait(false);
 					}
 					else if (header.TypeFlag == TarHeader.LF_GNU_VOLHDR)
 					{
 						// TODO: could show volume name when verbose
-						await SkipToNextEntryAsync(ct, isAsync);
-						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
+						await SkipToNextEntryAsync(ct, isAsync).ConfigureAwait(false);
+						await this.tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync).ConfigureAwait(false);
 					}
 					else if (header.TypeFlag != TarHeader.LF_NORMAL &&
 					         header.TypeFlag != TarHeader.LF_OLDNORM &&
@@ -663,8 +663,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 					         header.TypeFlag != TarHeader.LF_DIR)
 					{
 						// Ignore things we dont understand completely for now
-						await SkipToNextEntryAsync(ct, isAsync);
-						await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync);
+						await SkipToNextEntryAsync(ct, isAsync).ConfigureAwait(false);
+						await tarBuffer.ReadBlockIntAsync(headerBuf, ct, isAsync).ConfigureAwait(false);
 					}
 
 					if (entryFactory == null)
@@ -736,7 +736,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			while (true)
 			{
-				int numRead = await ReadAsync(tempBuffer, ct, isAsync);
+				int numRead = await ReadAsync(tempBuffer, ct, isAsync).ConfigureAwait(false);
 				if (numRead <= 0)
 				{
 					break;
@@ -744,7 +744,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 				if (isAsync)
 				{
-					await outputStream.WriteAsync(tempBuffer, 0, numRead, ct);
+					await outputStream.WriteAsync(tempBuffer, 0, numRead, ct).ConfigureAwait(false);
 				}
 				else
 				{
@@ -761,7 +761,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 			if (numToSkip > 0)
 			{
-				await SkipAsync(numToSkip, ct, isAsync);
+				await SkipAsync(numToSkip, ct, isAsync).ConfigureAwait(false);
 			}
 
 			readBuffer?.Dispose();

--- a/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -192,7 +192,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
 			CancellationToken cancellationToken)
 		{
-			return await outputStream.ReadAsync(buffer, offset, count, cancellationToken);
+			return await outputStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -208,7 +208,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// </summary>
 		public override async Task FlushAsync(CancellationToken cancellationToken)
 		{
-			await outputStream.FlushAsync(cancellationToken);
+			await outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -227,10 +227,10 @@ namespace ICSharpCode.SharpZipLib.Tar
 		{
 			if (IsEntryOpen)
 			{
-				await CloseEntryAsync(cancellationToken, isAsync);
+				await CloseEntryAsync(cancellationToken, isAsync).ConfigureAwait(false);
 			}
 
-			await WriteEofBlockAsync(cancellationToken, isAsync);
+			await WriteEofBlockAsync(cancellationToken, isAsync).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -336,7 +336,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 
 				longHeader.WriteHeader(blockBuffer, nameEncoding);
 				// Add special long filename header block
-				await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
+				await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync).ConfigureAwait(false);
 
 				int nameCharIndex = 0;
 
@@ -349,12 +349,12 @@ namespace ICSharpCode.SharpZipLib.Tar
 						TarBuffer.BlockSize, nameEncoding); // This func handles OK the extra char out of string length
 					nameCharIndex += TarBuffer.BlockSize;
 
-					await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
+					await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync).ConfigureAwait(false);
 				}
 			}
 
 			entry.WriteEntryHeader(blockBuffer, nameEncoding);
-			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
+			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync).ConfigureAwait(false);
 
 			currBytes = 0;
 
@@ -389,7 +389,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			{
 				Array.Clear(assemblyBuffer, assemblyBufferLength, assemblyBuffer.Length - assemblyBufferLength);
 
-				await buffer.WriteBlockAsync(assemblyBuffer, 0, cancellationToken, isAsync);
+				await buffer.WriteBlockAsync(assemblyBuffer, 0, cancellationToken, isAsync).ConfigureAwait(false);
 
 				currBytes += assemblyBufferLength;
 				assemblyBufferLength = 0;
@@ -507,7 +507,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 					Array.Copy(assemblyBuffer, 0, blockBuffer, 0, assemblyBufferLength);
 					Array.Copy(buffer, offset, blockBuffer, assemblyBufferLength, aLen);
 
-					await this.buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
+					await this.buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync).ConfigureAwait(false);
 
 					currBytes += blockBuffer.Length;
 
@@ -539,7 +539,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 					break;
 				}
 
-				await this.buffer.WriteBlockAsync(buffer, offset, cancellationToken, isAsync);
+				await this.buffer.WriteBlockAsync(buffer, offset, cancellationToken, isAsync).ConfigureAwait(false);
 
 				int bufferLength = blockBuffer.Length;
 				currBytes += bufferLength;
@@ -555,8 +555,8 @@ namespace ICSharpCode.SharpZipLib.Tar
 		private async Task WriteEofBlockAsync(CancellationToken cancellationToken, bool isAsync)
 		{
 			Array.Clear(blockBuffer, 0, blockBuffer.Length);
-			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
-			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync);
+			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync).ConfigureAwait(false);
+			await buffer.WriteBlockAsync(blockBuffer, 0, cancellationToken, isAsync).ConfigureAwait(false);
 		}
 
 		#region Instance Fields

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -151,7 +151,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 
 				EncryptBlock(buffer_, 0, len);
 
-				await baseOutputStream_.WriteAsync(buffer_, 0, len, ct);
+				await baseOutputStream_.WriteAsync(buffer_, 0, len, ct).ConfigureAwait(false);
 			}
 
 			if (!deflater_.IsFinished)
@@ -159,7 +159,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 				throw new SharpZipBaseException("Can't deflate all input?");
 			}
 
-			await baseOutputStream_.FlushAsync(ct);
+			await baseOutputStream_.FlushAsync(ct).ConfigureAwait(false);
 
 			if (cryptoTransform_ != null)
 			{
@@ -425,7 +425,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 
 				try
 				{
-					await FinishAsync(CancellationToken.None);
+					await FinishAsync(CancellationToken.None).ConfigureAwait(false);
 					if (cryptoTransform_ != null)
 					{
 						GetAuthCodeIfAES();
@@ -437,7 +437,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 				{
 					if (IsStreamOwner)
 					{
-						await baseOutputStream_.DisposeAsync();
+						await baseOutputStream_.DisposeAsync().ConfigureAwait(false);
 					}
 				}
 			}

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFormat.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFormat.cs
@@ -195,7 +195,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public static async Task WriteZip64EndOfCentralDirectoryAsync(Stream stream, long noOfEntries, 
 			long sizeEntries, long centralDirOffset, CancellationToken cancellationToken)
 		{
-			await stream.WriteProcToStreamAsync(s => WriteZip64EndOfCentralDirectory(s, noOfEntries, sizeEntries, centralDirOffset), cancellationToken);
+			await stream.WriteProcToStreamAsync(s => WriteZip64EndOfCentralDirectory(s, noOfEntries, sizeEntries, centralDirOffset), cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -237,7 +237,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public static  async Task WriteEndOfCentralDirectoryAsync(Stream stream, long noOfEntries, long sizeEntries, 
 			long start, byte[] comment, CancellationToken cancellationToken) 
 			=> await stream.WriteProcToStreamAsync(s 
-				=> WriteEndOfCentralDirectory(s, noOfEntries, sizeEntries, start, comment), cancellationToken);
+				=> WriteEndOfCentralDirectory(s, noOfEntries, sizeEntries, start, comment), cancellationToken).ConfigureAwait(false);
 		
 		/// <summary>
 		/// Write the required records to end the central directory.
@@ -540,7 +540,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			
 			// Update CRC
 			stream.Seek(patchData.CrcPatchOffset, SeekOrigin.Begin);
-			await stream.WriteLEIntAsync((int)entry.Crc, ct);
+			await stream.WriteLEIntAsync((int)entry.Crc, ct).ConfigureAwait(false);
 
 			// Update Sizes
 			if (entry.LocalHeaderRequiresZip64)
@@ -553,13 +553,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 				stream.Seek(patchData.SizePatchOffset, SeekOrigin.Begin);
 
 				// Note: The order of the size fields is reversed when compared to the local header!
-				await stream.WriteLELongAsync(entry.Size, ct);
-				await stream.WriteLELongAsync(entry.CompressedSize, ct);
+				await stream.WriteLELongAsync(entry.Size, ct).ConfigureAwait(false);
+				await stream.WriteLELongAsync(entry.CompressedSize, ct).ConfigureAwait(false);
 			}
 			else
 			{
-				await stream.WriteLEIntAsync((int)entry.CompressedSize, ct);
-				await stream.WriteLEIntAsync((int)entry.Size, ct);
+				await stream.WriteLEIntAsync((int)entry.CompressedSize, ct).ConfigureAwait(false);
+				await stream.WriteLEIntAsync((int)entry.Size, ct).ConfigureAwait(false);
 			}
 
 			stream.Seek(initialPos, SeekOrigin.Begin);

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -520,15 +520,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </exception>
 		public async Task PutNextEntryAsync(ZipEntry entry, CancellationToken ct = default)
 		{
-			if (curEntry != null) await CloseEntryAsync(ct);
+			if (curEntry != null) await CloseEntryAsync(ct).ConfigureAwait(false);
 			var position = CanPatchEntries ? baseOutputStream_.Position : -1; 
 			await baseOutputStream_.WriteProcToStreamAsync(s =>
 			{
 				PutNextEntry(s, entry, position);
-			}, ct);
+			}, ct).ConfigureAwait(false);
 			
 			if (!entry.IsCrypted) return;
-			await WriteOutputAsync(GetEntryEncryptionHeader(entry));
+			await WriteOutputAsync(GetEntryEncryptionHeader(entry)).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -561,13 +561,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <inheritdoc cref="CloseEntry"/>
 		public async Task CloseEntryAsync(CancellationToken ct)
 		{
-			await baseOutputStream_.WriteProcToStreamAsync(WriteEntryFooter, ct);
+			await baseOutputStream_.WriteProcToStreamAsync(WriteEntryFooter, ct).ConfigureAwait(false);
 
 			// Patch the header if possible
 			if (patchEntryHeader)
 			{
 				patchEntryHeader = false;
-				await ZipFormat.PatchLocalHeaderAsync(baseOutputStream_, curEntry, patchData, ct);
+				await ZipFormat.PatchLocalHeaderAsync(baseOutputStream_, curEntry, patchData, ct).ConfigureAwait(false);
 			}
 
 			entries.Add(curEntry);
@@ -873,7 +873,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				if (curEntry != null)
 				{
-					await CloseEntryAsync(ct);
+					await CloseEntryAsync(ct).ConfigureAwait(false);
 				}
 
 				long numEntries = entries.Count;
@@ -884,12 +884,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 					await baseOutputStream_.WriteProcToStreamAsync(ms, s =>
 					{
 						sizeEntries += ZipFormat.WriteEndEntry(s, entry, _stringCodec);
-					}, ct);
+					}, ct).ConfigureAwait(false);
 				}
 
 				await baseOutputStream_.WriteProcToStreamAsync(ms, s 
 						=> ZipFormat.WriteEndOfCentralDirectory(s, numEntries, sizeEntries, offset, zipComment),
-					ct);
+					ct).ConfigureAwait(false);
 
 				entries = null;
 			}

--- a/test/.globalconfig
+++ b/test/.globalconfig
@@ -1,0 +1,3 @@
+is_global = true
+global_level = 2
+dotnet_diagnostic.CA2007.severity = none


### PR DESCRIPTION
See https://devblogs.microsoft.com/dotnet/configureawait-faq/

General purpose libraries should always use `.CongfigureAwait(false)` to avoid deadlocks. It may not prevent from every deadlock but is after all a "best practice".

I also added a `.globalconfig` to warn if `ConfigureAwait` calls are missing in future changes.

Fixes #786 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
