### PR TITLE
fix(tar): clear rest of buffer when eof is reached

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -402,6 +402,11 @@ namespace ICSharpCode.SharpZipLib.Tar
 				//
 				if (numBytes <= 0)
 				{
+					// Fill the rest of the buffer with 0 to clear any left over data in the shared buffer
+					for (; offset < RecordSize; offset++)
+					{
+						recordBuffer[offset] = 0;
+					}
 					break;
 				}
 

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarInputStreamTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarInputStreamTests.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Buffers;
-using System.Drawing;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Tests.TestSupport;
 using NUnit.Framework;
@@ -106,10 +104,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 
 			Assert.DoesNotThrow(() =>
 			{
-				using var inStream = new MemoryStream(Array.Empty<byte>());
-				// using var gzipStream = new GZipInputStream(inStream);
-				using var tarInputStream = new TarInputStream(inStream, Encoding.UTF8);
-				// using var tarInputStream = new TarInputStream(gzipStream, Encoding.UTF8);
+				using var emptyStream = new MemoryStream(Array.Empty<byte>());
+				using var tarInputStream = new TarInputStream(emptyStream, Encoding.UTF8);
 				while (tarInputStream.GetNextEntry() is { } tarEntry)
 				{
 				}

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Utils.cs
@@ -133,6 +133,15 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 				stream.Write(sizeBytes, 0, 4);
 			}
 		}
+
+		public static void FillArray(byte[] buffer, byte value)
+		{
+#if NET6_0_OR_GREATER
+			Array.Fill(buffer, value);
+#else
+			for(var i = 0; i < buffer.Length; i++) buffer[i] = value;
+#endif
+		}
 	}
 	
 	public class TestTraceListener : TraceListener
@@ -185,7 +194,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 		    _fileInfo = new FileInfo(Path.Combine(dirPath, filename));
 	    }
 
-    	#region IDisposable Support
+#region IDisposable Support
 
     	private bool _disposed; // To detect redundant calls
 
@@ -213,7 +222,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
     		GC.SuppressFinalize(this);
     	}
 
-    	#endregion IDisposable Support
+#endregion IDisposable Support
 	}
   
   
@@ -245,7 +254,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
         public TempFile GetFile(string fileName) => new TempFile(FullPath, fileName);
         
-    	#region IDisposable Support
+#region IDisposable Support
 
     	private bool _disposed; // To detect redundant calls
 
@@ -272,6 +281,6 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
     		GC.SuppressFinalize(this);
     	}
 
-        #endregion IDisposable Support
+#endregion IDisposable Support
     }
 }


### PR DESCRIPTION
When reading a tar file using `TarBuffer` and the EOF was reached before a full record could be read, the `ReadRecordAsync` method still treats it as a successful read, by assuming the rest of the buffer just contained zeros.

This is not necessarily the case with a SharedArray buffer, which it currently uses. This PR makes sure that the rest of the buffer is cleared before returning.

Fixes #782.
