### PR TITLE
tests: make test coverage consistent

### DIFF
--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarBufferTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarBufferTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Tar;
+using ICSharpCode.SharpZipLib.Tests.TestSupport;
 using NUnit.Framework;
 
 namespace ICSharpCode.SharpZipLib.Tests.Tar
@@ -18,9 +19,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 			var writer = TarBuffer.CreateOutputTarBuffer(ms, 1);
 			writer.IsStreamOwner = false;
 
-			var block = new byte[TarBuffer.BlockSize];
-			var r = new Random();
-			r.NextBytes(block);
+			var block = Utils.GetDummyBytes(TarBuffer.BlockSize);
 
 			writer.WriteBlock(block);
 			writer.WriteBlock(block);
@@ -46,11 +45,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 			var writer = TarBuffer.CreateOutputTarBuffer(ms, 1);
 			writer.IsStreamOwner = false;
 
-			var block0 = new byte[TarBuffer.BlockSize];
-			var block1 = new byte[TarBuffer.BlockSize];
-			var r = new Random();
-			r.NextBytes(block0);
-			r.NextBytes(block1);
+			var block0 = Utils.GetDummyBytes(TarBuffer.BlockSize);
+			var block1 = Utils.GetDummyBytes(TarBuffer.BlockSize);
 
 			writer.WriteBlock(block0);
 			writer.WriteBlock(block1);
@@ -72,9 +68,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 			var writer = TarBuffer.CreateOutputTarBuffer(ms, 1);
 			writer.IsStreamOwner = false;
 
-			var block = new byte[TarBuffer.BlockSize];
-			var r = new Random();
-			r.NextBytes(block);
+			var block = Utils.GetDummyBytes(TarBuffer.BlockSize);
 
 			await writer.WriteBlockAsync(block, CancellationToken.None);
 			await writer.WriteBlockAsync(block, CancellationToken.None);
@@ -103,11 +97,8 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 			var writer = TarBuffer.CreateOutputTarBuffer(ms, 1);
 			writer.IsStreamOwner = false;
 
-			var block0 = new byte[TarBuffer.BlockSize];
-			var block1 = new byte[TarBuffer.BlockSize];
-			var r = new Random();
-			r.NextBytes(block0);
-			r.NextBytes(block1);
+			var block0 = Utils.GetDummyBytes(TarBuffer.BlockSize);
+			var block1 = Utils.GetDummyBytes(TarBuffer.BlockSize);
 
 			await writer.WriteBlockAsync(block0, CancellationToken.None);
 			await writer.WriteBlockAsync(block1, CancellationToken.None);

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarInputStreamTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarInputStreamTests.cs
@@ -15,9 +15,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 		[Test]
 		public void TestRead()
 		{
-			var entryBytes = new byte[2000];
-			var r = new Random();
-			r.NextBytes(entryBytes);
+			var entryBytes = Utils.GetDummyBytes(2000);
 			using var ms = new MemoryStream();
 			using (var tos = new TarOutputStream(ms, Encoding.UTF8) { IsStreamOwner = false })
 			{
@@ -54,9 +52,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 		[Test]
 		public async Task TestReadAsync()
 		{
-			var entryBytes = new byte[2000];
-			var r = new Random();
-			r.NextBytes(entryBytes);
+			var entryBytes = Utils.GetDummyBytes(2000);
 			using var ms = new MemoryStream();
 			using (var tos = new TarOutputStream(ms, Encoding.UTF8) { IsStreamOwner = false })
 			{

--- a/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Tar/TarTests.cs
@@ -140,10 +140,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Tar
 					}
 					tarOut.PutNextEntry(entry);
 
-					byte[] buffer = new byte[TarBuffer.BlockSize];
-
-					var r = new Random();
-					r.NextBytes(buffer);
+					byte[] buffer = Utils.GetDummyBytes(TarBuffer.BlockSize);
 
 					if (iteration > 0)
 					{

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/RingBuffer.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/RingBuffer.cs
@@ -510,7 +510,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
 		private void Reader()
 		{
-			var r = new Random();
+			var r = new Random(Utils.DefaultSeed);
 			byte nextValue = 0;
 
 			while (readTarget_ > 0)
@@ -541,7 +541,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
 		private void Writer()
 		{
-			var r = new Random();
+			var r = new Random(Utils.DefaultSeed);
 
 			byte nextValue = 0;
 			while (writeTarget_ > 0)

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipTests.cs
@@ -25,8 +25,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			original = new byte[Size];
 			if (random)
 			{
-				var rnd = new Random();
-				rnd.NextBytes(original);
+				original = Utils.GetDummyBytes(Size);
 			}
 			else
 			{
@@ -251,9 +250,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 				if (size > 0)
 				{
-					var rnd = new Random();
-					original = new byte[size];
-					rnd.NextBytes(original);
+					original = Utils.GetDummyBytes(size);
 
 					// Although this could be written in one chunk doing it in lumps
 					// throws up buffering problems including with encryption the original


### PR DESCRIPTION
When dealing with compression, different methods of reducing the size is used depending on the source content. This will cause a different amount of code paths to be used/covered in the tests for every run.

This PR ensures that all uses of `Random` in the tests use a fixed seed, and as such will always cover the same amount of code.

Without this, the code coverage changes for PRs will fluctuate, and sometimes cause the overall coverage to go down even though the added changes have 100% coverage.