### PR TITLE
fix(tar): use sync codepath on sync methods

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -531,7 +531,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <returns>
 		/// The next TarEntry in the archive, or null.
 		/// </returns>
-		public TarEntry GetNextEntry() => GetNextEntryAsync(CancellationToken.None, true).GetAwaiter().GetResult();
+		public TarEntry GetNextEntry() => GetNextEntryAsync(CancellationToken.None, false).GetAwaiter().GetResult();
 
 		private async ValueTask<TarEntry> GetNextEntryAsync(CancellationToken ct, bool isAsync)
 		{

--- a/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -381,7 +381,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// to the output stream before this entry is closed and the
 		/// next entry written.
 		/// </summary>
-		public void CloseEntry() => CloseEntryAsync(CancellationToken.None, true).GetAwaiter().GetResult();
+		public void CloseEntry() => CloseEntryAsync(CancellationToken.None, false).GetAwaiter().GetResult();
 
 		private async Task CloseEntryAsync(CancellationToken cancellationToken, bool isAsync)
 		{


### PR DESCRIPTION
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

Fixes #788 