### PR TITLE
release v1.4.1

### DIFF
--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -13,7 +13,7 @@
   
   <!-- Nuget specific tags -->
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <FileVersion>$(Version).12</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <PackageId>SharpZipLib</PackageId>
@@ -28,7 +28,7 @@
     <PackageTags>Compression Library Zip GZip BZip2 LZW Tar</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageReleaseNotes>
-Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.4.0 for more information.</PackageReleaseNotes>
+Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.4.1 for more information.</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/icsharpcode/SharpZipLib</PackageProjectUrl> 
   </PropertyGroup>
 


### PR DESCRIPTION
New patch release that mainly fixes issues with the changes in v1.4.0.

## ZIP String Encoding

Further iteration on the StringCodec API, since the released version was confusing to use and in some cases could not be used without causing deprecation warnings.

* 🐛 [#778](https://github.com/icsharpcode/SharpZipLib/pull/778) `zip` __cleanup/fix of StringCodec__ by [_nils måsén_](https://github.com/piksel)

## TAR

Two issues that could cause deadlocks was found in v1.4.0, one due to a typo in the async implementation and one due to a buffer not being cleared.

* 🐛 [#791](https://github.com/icsharpcode/SharpZipLib/pull/791) `tar` __use sync codepath on sync methods__ by [_Lars Hanisch_](https://github.com/flensrocker)

* 🐛 [#789](https://github.com/icsharpcode/SharpZipLib/pull/789) `tar` __clear rest of buffer when eof is reached__ by [_nils måsén_](https://github.com/piksel)

## Async:

General async speed improvement, since we now correctly opt out of requiring to continue in the same context (`ConfigureAwait(false)`). 

* 🐛 [#787](https://github.com/icsharpcode/SharpZipLib/pull/787) __use ConfigureAwait(false) on every await__ by [_Lars Hanisch_](https://github.com/flensrocker)


## Other changes (not related to library code):

* 📚 [#775](https://github.com/icsharpcode/SharpZipLib/pull/775) __fix circular refs and target fw__ by [_nils måsén_](https://github.com/piksel)