### PR TITLE
zip: finish stream async when async

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -417,7 +417,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 			}
 		}
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
 		/// <summary>
 		/// Calls <see cref="FinishAsync"/> and closes the underlying
 		/// stream when <see cref="IsStreamOwner"></see> is true.

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -577,7 +577,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				if (size >= 0)
 				{
 					if (ct.HasValue) {
-						await base.FinishAsync(ct.Value);
+						await base.FinishAsync(ct.Value).ConfigureAwait(false);
 					} else {
 						base.Finish();
 					}
@@ -600,7 +600,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <inheritdoc cref="CloseEntry"/>
 		public async Task CloseEntryAsync(CancellationToken ct)
 		{
-			await FinishCompression(ct);
+			await FinishCompression(ct).ConfigureAwait(false);
 			await baseOutputStream_.WriteProcToStreamAsync(WriteEntryFooter, ct).ConfigureAwait(false);
 
 			// Patch the header if possible

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
@@ -189,6 +189,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
 	}
 
+#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
 	/// <summary>
 	/// A <see cref="Stream"/> that does not support non-async operations.
 	/// </summary>
@@ -210,11 +211,10 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
 		public override void Flush() => throw new NotSupportedException($"Non-async call to {nameof(Flush)}");
 		
-#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
+
 		public override void CopyTo(Stream destination, int bufferSize) => throw new NotSupportedException($"Non-async call to {nameof(CopyTo)}");
 		public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
 		public override int Read(Span<byte> buffer) => throw new NotSupportedException($"Non-async call to {nameof(Read)}");
-#endif
 
 		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
 		public override void WriteByte(byte value) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
@@ -233,11 +233,8 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 		public override Task FlushAsync(CancellationToken cancellationToken) => TaskFromBlocking(() => _inner.Flush());
 		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => TaskFromBlocking(() => _inner.Write(buffer, offset, count));
 		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => Task.FromResult(_inner.Read(buffer, offset, count));
-
-#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
 		public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => ValueTaskFromBlocking(() => _inner.Write(buffer.Span));
 		public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => ValueTask.FromResult(_inner.Read(buffer.Span));
-#endif
 		
 		static Task TaskFromBlocking(Action action)
 		{
@@ -261,6 +258,7 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 			_inner.SetLength(value);
 		}
 	}
+#endif
 
 	/// <summary>
 	/// A <see cref="Stream"/> that cannot be read but supports infinite writes.

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
@@ -208,14 +208,17 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 
 		public byte[] ToArray() => _inner.ToArray();
 
-		public override void CopyTo(Stream destination, int bufferSize) => throw new NotSupportedException($"Non-async call to {nameof(CopyTo)}");
 		public override void Flush() => throw new NotSupportedException($"Non-async call to {nameof(Flush)}");
-
+		
+#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
+		public override void CopyTo(Stream destination, int bufferSize) => throw new NotSupportedException($"Non-async call to {nameof(CopyTo)}");
 		public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
+		public override int Read(Span<byte> buffer) => throw new NotSupportedException($"Non-async call to {nameof(Read)}");
+#endif
+
 		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
 		public override void WriteByte(byte value) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
 
-		public override int Read(Span<byte> buffer) => throw new NotSupportedException($"Non-async call to {nameof(Read)}");
 		public override int Read(byte[] buffer, int offset, int count)  => throw new NotSupportedException($"Non-async call to {nameof(Read)}");
 		public override int ReadByte() => throw new NotSupportedException($"Non-async call to {nameof(ReadByte)}");
 
@@ -229,10 +232,12 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 		}
 		public override Task FlushAsync(CancellationToken cancellationToken) => TaskFromBlocking(() => _inner.Flush());
 		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => TaskFromBlocking(() => _inner.Write(buffer, offset, count));
-		public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => ValueTaskFromBlocking(() => _inner.Write(buffer.Span));
 		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => Task.FromResult(_inner.Read(buffer, offset, count));
-		public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => ValueTask.FromResult(_inner.Read(buffer.Span));
 
+#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
+		public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => ValueTaskFromBlocking(() => _inner.Write(buffer.Span));
+		public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => ValueTask.FromResult(_inner.Read(buffer.Span));
+#endif
 		
 		static Task TaskFromBlocking(Action action)
 		{

--- a/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/TestSupport/Streams.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 {
@@ -186,6 +187,74 @@ namespace ICSharpCode.SharpZipLib.Tests.TestSupport
 			set => throw new NotSupportedException("Setting position is not supported");
 		}
 
+	}
+
+	/// <summary>
+	/// A <see cref="Stream"/> that does not support non-async operations.
+	/// </summary>
+	/// <remarks>
+	/// This could not be done by extending MemoryStream itself, since other instances of MemoryStream tries to us a faster (non-async) method of copying
+	///  if it detects that it's a (subclass of) MemoryStream.
+	/// </remarks>
+	public class MemoryStreamWithoutSync : Stream
+	{
+		MemoryStream _inner = new MemoryStream();
+
+		public override bool CanRead => _inner.CanRead;
+		public override bool CanSeek => _inner.CanSeek;
+		public override bool CanWrite => _inner.CanWrite;
+		public override long Length => _inner.Length;
+		public override long Position { get => _inner.Position; set => _inner.Position = value; }
+
+		public byte[] ToArray() => _inner.ToArray();
+
+		public override void CopyTo(Stream destination, int bufferSize) => throw new NotSupportedException($"Non-async call to {nameof(CopyTo)}");
+		public override void Flush() => throw new NotSupportedException($"Non-async call to {nameof(Flush)}");
+
+		public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
+		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
+		public override void WriteByte(byte value) => throw new NotSupportedException($"Non-async call to {nameof(Write)}");
+
+		public override int Read(Span<byte> buffer) => throw new NotSupportedException($"Non-async call to {nameof(Read)}");
+		public override int Read(byte[] buffer, int offset, int count)  => throw new NotSupportedException($"Non-async call to {nameof(Read)}");
+		public override int ReadByte() => throw new NotSupportedException($"Non-async call to {nameof(ReadByte)}");
+
+		// Even though our mock stream is writing synchronously, this should not fail the tests
+		public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) 
+		{
+			var buf = new byte[bufferSize];
+			while(_inner.Read(buf, 0, bufferSize) > 0) {
+				await destination.WriteAsync(buf, cancellationToken);
+			}
+		}
+		public override Task FlushAsync(CancellationToken cancellationToken) => TaskFromBlocking(() => _inner.Flush());
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => TaskFromBlocking(() => _inner.Write(buffer, offset, count));
+		public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => ValueTaskFromBlocking(() => _inner.Write(buffer.Span));
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => Task.FromResult(_inner.Read(buffer, offset, count));
+		public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => ValueTask.FromResult(_inner.Read(buffer.Span));
+
+		
+		static Task TaskFromBlocking(Action action)
+		{
+			action();
+			return Task.CompletedTask;
+		}
+
+		static ValueTask ValueTaskFromBlocking(Action action)
+		{
+			action();
+			return ValueTask.CompletedTask;
+		}
+
+		public override long Seek(long offset, SeekOrigin origin)
+		{
+			return _inner.Seek(offset, origin);
+		}
+
+		public override void SetLength(long value)
+		{
+			_inner.SetLength(value);
+		}
 	}
 
 	/// <summary>

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
@@ -15,7 +15,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Category("Async")]
 		public async Task WriteZipStreamUsingAsync()
 		{
-#if NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
 			await using var ms = new MemoryStream();
 			
 			await using (var outStream = new ZipOutputStream(ms){IsStreamOwner = false})
@@ -126,6 +126,7 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Category("Async")]
 		public async Task WriteZipStreamToAsyncOnlyStream ()
 		{
+#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
 			await using(var ms = new MemoryStreamWithoutSync()){
 				await using(var outStream = new ZipOutputStream(ms) { IsStreamOwner = false })
 				{
@@ -141,6 +142,10 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 
 				ZipTesting.AssertValidZip(new MemoryStream(ms.ToArray()));
 			}
+#else
+			await Task.CompletedTask;
+			Assert.Ignore("AsyncDispose is not supported");
+#endif
 		}
 
 	}

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
@@ -121,5 +121,27 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 			ZipTesting.AssertValidZip(new MemoryStream(ms.ToArray()));
 		}
 
+		[Test]
+		[Category("Zip")]
+		[Category("Async")]
+		public async Task WriteZipStreamToAsyncOnlyStream ()
+		{
+			await using(var ms = new MemoryStreamWithoutSync()){
+				await using(var outStream = new ZipOutputStream(ms) { IsStreamOwner = false })
+				{
+					await outStream.PutNextEntryAsync(new ZipEntry("FirstFile"));
+					await Utils.WriteDummyDataAsync(outStream, 12);
+
+					await outStream.PutNextEntryAsync(new ZipEntry("SecondFile"));
+					await Utils.WriteDummyDataAsync(outStream, 12);
+
+					await outStream.FinishAsync(CancellationToken.None);
+					await outStream.DisposeAsync();
+				}
+
+				ZipTesting.AssertValidZip(new MemoryStream(ms.ToArray()));
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
This PR fixes the async finishing of entries in `ZipOutputStream`. The initial problem was that there was a sneaky `base.Finish()` call in `WriteEntryFooter` which in turn wrote synchronously to the output stream when called.
Additionally, `DeflateOutputSteam.AsyncDispose` was not included when targeting .NET 6 due to the preprocessor constants for `NETSTANDARD2_1_OR_GREATER` not being defined.

This also adds tests that ensures that writing zip streams can be done wholly async, without calling any of the output streams synchronous methods.

Fixes #801 

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
