### PR TITLE
fix(zip): remove leftover console logging

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -5,7 +5,6 @@ using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -574,9 +573,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				// Generate and set crypto transform...
 				var managed = new PkzipClassicManaged();
-				Console.WriteLine($"Input Encoding: {_stringCodec.ZipCryptoEncoding.EncodingName}");
 				byte[] key = PkzipClassic.GenerateKeys(_stringCodec.ZipCryptoEncoding.GetBytes(password));
-				Console.WriteLine($"Input Bytes: {string.Join(", ", key.Select(b => $"{b:x2}").ToArray())}");
 
 				inputBuffer.CryptoTransform = managed.CreateDecryptor(key, null);
 


### PR DESCRIPTION
When merging #778, some debug logging were left in. This removes it, since it was never meant to be checked in in the first place.

Fixes #807.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
