### PR TITLE
fix(tar): enable async overrides on net6

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -640,7 +640,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					if (isAsync)
 					{
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 						await outputStream.DisposeAsync().ConfigureAwait(false);
 #else
 						outputStream.Dispose();
@@ -660,7 +660,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 				{
 					if (isAsync)
 					{
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 						await inputStream.DisposeAsync().ConfigureAwait(false);
 #else
 						inputStream.Dispose();

--- a/src/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
@@ -869,7 +869,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 					}
 				}
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 				var value = encoding.GetString(header.Slice(0, count));
 #else
 				var value = encoding.GetString(header.ToArray(), 0, count);

--- a/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -232,7 +232,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			return ReadAsync(buffer.AsMemory().Slice(offset, count), cancellationToken, true).AsTask();
 		}
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 		/// <summary>
 		/// Reads bytes from the current tar archive entry.
 		/// 
@@ -372,7 +372,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			}
 		}
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 		/// <summary>
 		/// Closes this stream. Calls the TarBuffer's close() method.
 		/// The underlying stream is closed by the TarBuffer.


### PR DESCRIPTION
Implicitly include async overrides on `NETCOREAPP3_1_OR_GREATER` to include them when targeting .NET 6.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
