### PR TITLE
fix(zip): fully implement async deflate

### DIFF
--- a/src/ICSharpCode.SharpZipLib/GZip/GzipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipInputStream.cs
@@ -334,7 +334,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 			int crcval = (footer[0] & 0xff) | ((footer[1] & 0xff) << 8) | ((footer[2] & 0xff) << 16) | (footer[3] << 24);
 			if (crcval != (int)crc.Value)
 			{
-				throw new GZipException("GZIP crc sum mismatch, theirs \"" + crcval + "\" and ours \"" + (int)crc.Value);
+				throw new GZipException($"GZIP crc sum mismatch, theirs \"{crcval:x8}\" and ours \"{(int)crc.Value:x8}\"");
 			}
 
 			// NOTE The total here is the original total modulo 2 ^ 32.

--- a/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -153,8 +153,8 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// <param name="buffer">Buffer to write</param>
 		/// <param name="offset">Offset of first byte in buf to write</param>
 		/// <param name="count">Number of bytes to write</param>
-		public override void Write(byte[] buffer, int offset, int count) 
-			=> WriteSyncOrAsync(buffer, offset, count, null).Wait();
+		public override void Write(byte[] buffer, int offset, int count)
+			=> WriteSyncOrAsync(buffer, offset, count, null).GetAwaiter().GetResult();
 
 		private async Task WriteSyncOrAsync(byte[] buffer, int offset, int count, CancellationToken? ct)
 		{

--- a/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -138,6 +138,11 @@ namespace ICSharpCode.SharpZipLib.GZip
 			}
 		}
 
+		/// <summary>
+		/// If defined, will use this time instead of the current for the output header
+		/// </summary>
+		public DateTime? ModifiedTime { get; set; }
+
 		#endregion Public API
 
 		#region Stream overrides
@@ -305,7 +310,8 @@ namespace ICSharpCode.SharpZipLib.GZip
 
 		private byte[] GetHeader()
 		{
-			var modTime = (int)((DateTime.Now.Ticks - new DateTime(1970, 1, 1).Ticks) / 10000000L);  // Ticks give back 100ns intervals
+			var modifiedUtc = ModifiedTime?.ToUniversalTime() ?? DateTime.UtcNow;
+			var modTime = (int)((modifiedUtc - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).Ticks / 10000000L);  // Ticks give back 100ns intervals
 			byte[] gzipHeader = {
 				// The two magic bytes
 				GZipConstants.ID1, 

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -241,10 +241,10 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// </summary>
 		protected void Deflate()
 		{
-			Deflate(false);
+			DeflateSyncOrAsync(false, null).Wait();
 		}
 
-		private void Deflate(bool flushing)
+		private async Task DeflateSyncOrAsync(bool flushing, CancellationToken? ct)
 		{
 			while (flushing || !deflater_.IsNeedingInput)
 			{
@@ -257,7 +257,14 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 
 				EncryptBlock(buffer_, 0, deflateCount);
 
-				baseOutputStream_.Write(buffer_, 0, deflateCount);
+				if (ct.HasValue)
+				{
+					await baseOutputStream_.WriteAsync(buffer_, 0, deflateCount, ct.Value).ConfigureAwait(false);
+				}
+				else
+				{
+					baseOutputStream_.Write(buffer_, 0, deflateCount);
+				}
 			}
 
 			if (!deflater_.IsNeedingInput)
@@ -383,8 +390,16 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		public override void Flush()
 		{
 			deflater_.Flush();
-			Deflate(true);
+			DeflateSyncOrAsync(true, null).Wait();
 			baseOutputStream_.Flush();
+		}
+
+		/// <inheritdoc/>
+		public override async Task FlushAsync(CancellationToken cancellationToken)
+		{
+			deflater_.Flush();
+			await DeflateSyncOrAsync(true, cancellationToken).ConfigureAwait(false);
+			await baseOutputStream_.FlushAsync(cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -489,6 +504,13 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		{
 			deflater_.SetInput(buffer, offset, count);
 			Deflate();
+		}
+
+		/// <inheritdoc />
+		public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ct)
+		{
+			deflater_.SetInput(buffer, offset, count);
+			await DeflateSyncOrAsync(false, ct).ConfigureAwait(false);
 		}
 
 		#endregion Stream Overrides

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -240,9 +240,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// are processed.
 		/// </summary>
 		protected void Deflate()
-		{
-			DeflateSyncOrAsync(false, null).Wait();
-		}
+			=> DeflateSyncOrAsync(false, null).GetAwaiter().GetResult();
 
 		private async Task DeflateSyncOrAsync(bool flushing, CancellationToken? ct)
 		{
@@ -390,7 +388,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		public override void Flush()
 		{
 			deflater_.Flush();
-			DeflateSyncOrAsync(true, null).Wait();
+			DeflateSyncOrAsync(true, null).GetAwaiter().GetResult();
 			baseOutputStream_.Flush();
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -552,7 +552,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		public void CloseEntry()
 		{
 			// Note: This method will run synchronously
-			FinishCompression(null).Wait();
+			FinishCompressionSyncOrAsync(null).GetAwaiter().GetResult();
 			WriteEntryFooter(baseOutputStream_);
 
 			// Patch the header if possible
@@ -566,7 +566,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			curEntry = null;
 		}
 
-		private async Task FinishCompression(CancellationToken? ct)
+		private async Task FinishCompressionSyncOrAsync(CancellationToken? ct)
 		{
 			// Compression handled externally
 			if (entryIsPassthrough) return;
@@ -600,7 +600,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <inheritdoc cref="CloseEntry"/>
 		public async Task CloseEntryAsync(CancellationToken ct)
 		{
-			await FinishCompression(ct).ConfigureAwait(false);
+			await FinishCompressionSyncOrAsync(ct).ConfigureAwait(false);
 			await baseOutputStream_.WriteProcToStreamAsync(WriteEntryFooter, ct).ConfigureAwait(false);
 
 			// Patch the header if possible
@@ -780,7 +780,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <exception cref="ZipException">Archive size is invalid</exception>
 		/// <exception cref="System.InvalidOperationException">No entry is active.</exception>
 		public override void Write(byte[] buffer, int offset, int count)
-			=> WriteSyncOrAsync(buffer, offset, count, null).Wait();
+			=> WriteSyncOrAsync(buffer, offset, count, null).GetAwaiter().GetResult();
 
 		/// <inheritdoc />
 		public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ct)

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipStreamAsyncTests.cs
@@ -124,17 +124,19 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 		[Test]
 		[Category("Zip")]
 		[Category("Async")]
-		public async Task WriteZipStreamToAsyncOnlyStream ()
+		[TestCase(12, Description = "Small files")]
+		[TestCase(12000, Description = "Large files")]
+        public async Task WriteZipStreamToAsyncOnlyStream (int fileSize)
 		{
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
 			await using(var ms = new MemoryStreamWithoutSync()){
 				await using(var outStream = new ZipOutputStream(ms) { IsStreamOwner = false })
 				{
 					await outStream.PutNextEntryAsync(new ZipEntry("FirstFile"));
-					await Utils.WriteDummyDataAsync(outStream, 12);
+					await Utils.WriteDummyDataAsync(outStream, fileSize);
 
 					await outStream.PutNextEntryAsync(new ZipEntry("SecondFile"));
-					await Utils.WriteDummyDataAsync(outStream, 12);
+					await Utils.WriteDummyDataAsync(outStream, fileSize);
 
 					await outStream.FinishAsync(CancellationToken.None);
 					await outStream.DisposeAsync();


### PR DESCRIPTION
Using the previously implemented parts of async deflate/ZipOutputStream would only work as long as the compressed size was lower than the internal deflater buffer.
This fix adds async writing to `DeflaterOutputStream` and `GzipOutputStream`, and allows `ZipOutputStream` to empty it's buffer using asynchronous writes.

This also extends the test for `ZipOutputStream` to try with a larger source buffer and adds a test for `GzipOutputStream` for wholly-async IO.

Additionally, `GzipOutputStream.ModifiedTime` can now also be set. This was added to allow the tests to yield a predicable output.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
