### PR TITLE
docs: fix missing async override docs

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -392,7 +392,12 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 			baseOutputStream_.Flush();
 		}
 
-		/// <inheritdoc/>
+		/// <summary>
+		/// Asynchronously clears all buffers for this stream, causes any buffered data to be written to the underlying device, and monitors cancellation requests.
+		/// </summary>
+		/// <param name="cancellationToken">
+		/// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
+		/// </param>
 		public override async Task FlushAsync(CancellationToken cancellationToken)
 		{
 			deflater_.Flush();
@@ -504,7 +509,21 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 			Deflate();
 		}
 
-		/// <inheritdoc />
+		/// <summary>
+		/// Asynchronously writes a sequence of bytes to the current stream, advances the current position within this stream by the number of bytes written, and monitors cancellation requests.
+		/// </summary>
+		/// <param name="buffer">
+		/// The byte array
+		/// </param>
+		/// <param name="offset">
+		/// The offset into the byte array where to start.
+		/// </param>
+		/// <param name="count">
+		/// The number of bytes to write.
+		/// </param>
+		/// <param name="ct">
+		/// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
+		/// </param>
 		public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ct)
 		{
 			deflater_.SetInput(buffer, offset, count);


### PR DESCRIPTION
DocFX is unable to find the docs for the `Stream.WriteAsync` override in `DeflaterOutputStream`. This explicitly sets the doc comments to the upstream docs to re-enable docs generation.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
