### PR TITLE
fix(zip): avoid throwing on empty file name

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
@@ -26,7 +26,7 @@ namespace ICSharpCode.SharpZipLib.Core
 			var cleanPath = new string(path.Take(258)
 				.Select( (c, i) => invalidChars.Contains(c) || (i == 2 && cleanRootSep) ? '_' : c).ToArray());
 
-			var stripLength = Path.GetPathRoot(cleanPath).Length;
+			var stripLength = Path.GetPathRoot(cleanPath)?.Length ?? 0;
 			while (path.Length > stripLength && (path[stripLength] == '/' || path[stripLength] == '\\')) stripLength++;
 			return path.Substring(stripLength);
 		}

--- a/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/PathUtils.cs
@@ -16,6 +16,9 @@ namespace ICSharpCode.SharpZipLib.Core
 		/// <returns>The path with the root removed if it was present; path otherwise.</returns>
 		public static string DropPathRoot(string path)
 		{
+			// No need to drop anything
+			if (path == string.Empty) return path;
+
 			var invalidChars = Path.GetInvalidPathChars();
 			// If the first character after the root is a ':', .NET < 4.6.2 throws
 			var cleanRootSep = path.Length >= 3 && path[1] == ':' && path[2] == ':';

--- a/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
+++ b/test/ICSharpCode.SharpZipLib.Tests/Zip/ZipFileHandling.cs
@@ -1817,5 +1817,27 @@ namespace ICSharpCode.SharpZipLib.Tests.Zip
 				}
 			}
 		}
+
+		/// <summary>
+		/// Check that Zip files can be created with an empty file name
+		/// </summary>
+		[Test]
+		[Category("Zip")]
+		public void HandlesEmptyFileName()
+		{
+			using var ms = new MemoryStream();
+			using (var zos = new ZipOutputStream(ms){IsStreamOwner = false})
+			{
+				zos.PutNextEntry(new ZipEntry(String.Empty));
+				Utils.WriteDummyData(zos, 64);
+			}
+			ms.Seek(0, SeekOrigin.Begin);
+			using (var zis = new ZipInputStream(ms){IsStreamOwner = false})
+			{
+				var entry = zis.GetNextEntry();
+				Assert.That(entry.Name, Is.Empty);
+				Assert.That(zis.ReadBytes(64).Length, Is.EqualTo(64));
+			}
+		}
 	}
 }


### PR DESCRIPTION
Since the APPNOTE allows for zip files to contain files without a file name (useful for piping into a zip file), this ought to be allowed for SharpZipLib as well. This will fix the issue by handling a null value being returned by `Path.GetPathRoot`.

Supersedes #687.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
