### PR TITLE
Improve zip file iteration performance

### DIFF
--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
@@ -1,18 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>net462;net6.0</TargetFrameworks>
+	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet">
-			<Version>0.12.1</Version>
-		</PackageReference>
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\src\ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.csproj" />
+		<ProjectReference Include="..\..\src\ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Program.cs
@@ -9,9 +9,8 @@ namespace ICSharpCode.SharpZipLib.Benchmark
 	{
 		public MultipleRuntimes()
 		{
-			AddJob(Job.Default.WithToolchain(CsProjClassicNetToolchain.Net461).AsBaseline()); // NET 4.6.1
-			AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp21)); // .NET Core 2.1
-			AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp31)); // .NET Core 3.1
+			AddJob(Job.Default.WithToolchain(CsProjClassicNetToolchain.Net462).AsBaseline()); // NET 4.6.2
+			AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp60)); // .NET 6.0
 		}
 	}
 

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipFile.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipFile.cs
@@ -17,6 +17,8 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 		[GlobalSetup]
 		public async Task GlobalSetup()
 		{
+			SharpZipLibOptions.InflaterPoolSize = 4;
+
 			// large real-world test file from test262 repository
 			string commitSha = "2e4e0e6b8ebe3348a207144204cb6d7a5571c863";
 			zipFileWithLargeAmountOfEntriesPath = Path.Combine(Path.GetTempPath(), $"{commitSha}.zip");

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipFile.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipFile.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ICSharpCode.SharpZipLib.Zip;
+
+namespace ICSharpCode.SharpZipLib.Benchmark.Zip
+{
+	[MemoryDiagnoser]
+	[Config(typeof(MultipleRuntimes))]
+	public class ZipFile
+	{
+		private readonly byte[] readBuffer = new byte[4096];
+		private string zipFileWithLargeAmountOfEntriesPath;
+
+		[GlobalSetup]
+		public async Task GlobalSetup()
+		{
+			// large real-world test file from test262 repository
+			string commitSha = "2e4e0e6b8ebe3348a207144204cb6d7a5571c863";
+			zipFileWithLargeAmountOfEntriesPath = Path.Combine(Path.GetTempPath(), $"{commitSha}.zip");
+			if (!File.Exists(zipFileWithLargeAmountOfEntriesPath))
+			{
+				var uri = $"https://github.com/tc39/test262/archive/{commitSha}.zip";
+
+				Console.WriteLine("Loading test262 repository archive from {0}", uri);
+
+				using (var client = new HttpClient())
+				{
+					using (var downloadStream = await client.GetStreamAsync(uri))
+					{
+						using (var writeStream = File.OpenWrite(zipFileWithLargeAmountOfEntriesPath))
+						{
+							await downloadStream.CopyToAsync(writeStream);
+							Console.WriteLine("File downloaded and saved to {0}", zipFileWithLargeAmountOfEntriesPath);
+						}
+					}
+				}
+			}
+
+		}
+
+		[Benchmark]
+		public void ReadLargeZipFile()
+		{
+			using (var file = new SharpZipLib.Zip.ZipFile(zipFileWithLargeAmountOfEntriesPath))
+			{
+				foreach (ZipEntry entry in file)
+				{
+					using (var stream = file.GetInputStream(entry))
+					{
+						while (stream.Read(readBuffer, 0, readBuffer.Length) > 0)
+						{
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipInputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipInputStream.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using BenchmarkDotNet.Attributes;
 
 namespace ICSharpCode.SharpZipLib.Benchmark.Zip
@@ -15,7 +14,8 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 		byte[] zippedData;
 		byte[] readBuffer = new byte[4096];
 
-		public ZipInputStream()
+		[GlobalSetup]
+		public void GlobalSetup()
 		{
 			using (var memoryStream = new MemoryStream())
 			{

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
@@ -16,7 +15,8 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 		byte[] outputBuffer;
 		byte[] inputBuffer;
 
-		public ZipOutputStream()
+		[GlobalSetup]
+		public void GlobalSetup()
 		{
 			inputBuffer = new byte[ChunkSize];
 			outputBuffer = new byte[N];

--- a/src/ICSharpCode.SharpZipLib/Core/InflaterPool.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/InflaterPool.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Concurrent;
+using ICSharpCode.SharpZipLib.Zip.Compression;
+
+namespace ICSharpCode.SharpZipLib.Core
+{
+	/// <summary>
+	/// Pool Inflator instances as they can be costly due to byte array allocations.
+	/// </summary>
+	internal sealed class InflaterPool
+	{
+		public static InflaterPool Instance { get; } = new InflaterPool();
+		private readonly ConcurrentQueue<PooledInflater> noHeaderPool = new ConcurrentQueue<PooledInflater>();
+		private readonly ConcurrentQueue<PooledInflater> headerPool = new ConcurrentQueue<PooledInflater>();
+
+		private InflaterPool()
+		{
+		}
+
+		public Inflater Rent(bool noHeader = false)
+		{
+			var pool = GetPool(noHeader);
+			var inf = pool.TryDequeue(out var inflater) ? inflater : new PooledInflater(noHeader);
+			inf.Reset();
+			return inf;
+		}
+
+		public void Return(Inflater inflater)
+		{
+			if (!(inflater is PooledInflater pooledInflater))
+			{
+				throw new ArgumentException("Returned inflater was not a pooled one");
+			}
+
+			var pool = GetPool(inflater.noHeader);
+			if (pool.Count < 10)
+			{
+				pooledInflater.Reset();
+				pool.Enqueue(pooledInflater);
+			}
+		}
+
+		private ConcurrentQueue<PooledInflater> GetPool(bool noHeader) => noHeader ? noHeaderPool : headerPool;
+	}
+}

--- a/src/ICSharpCode.SharpZipLib/Core/InflaterPool.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/InflaterPool.cs
@@ -5,35 +5,56 @@ using ICSharpCode.SharpZipLib.Zip.Compression;
 namespace ICSharpCode.SharpZipLib.Core
 {
 	/// <summary>
-	/// Pool Inflator instances as they can be costly due to byte array allocations.
+	/// Pool for <see cref="Inflater"/> instances as they can be costly due to byte array allocations.
 	/// </summary>
 	internal sealed class InflaterPool
 	{
-		public static InflaterPool Instance { get; } = new InflaterPool();
 		private readonly ConcurrentQueue<PooledInflater> noHeaderPool = new ConcurrentQueue<PooledInflater>();
 		private readonly ConcurrentQueue<PooledInflater> headerPool = new ConcurrentQueue<PooledInflater>();
+
+		internal static InflaterPool Instance { get; } = new InflaterPool();
 
 		private InflaterPool()
 		{
 		}
 
-		public Inflater Rent(bool noHeader = false)
+		internal Inflater Rent(bool noHeader = false)
 		{
+			if (SharpZipLibOptions.InflaterPoolSize <= 0)
+			{
+				return new Inflater(noHeader);
+			}
+
 			var pool = GetPool(noHeader);
-			var inf = pool.TryDequeue(out var inflater) ? inflater : new PooledInflater(noHeader);
-			inf.Reset();
+
+			PooledInflater inf;
+			if (pool.TryDequeue(out var inflater))
+			{
+				inf = inflater;
+				inf.Reset();
+			}
+			else
+			{
+				inf = new PooledInflater(noHeader);
+			}
+
 			return inf;
 		}
 
-		public void Return(Inflater inflater)
+		internal void Return(Inflater inflater)
 		{
+			if (SharpZipLibOptions.InflaterPoolSize <= 0)
+			{
+				return;
+			}
+
 			if (!(inflater is PooledInflater pooledInflater))
 			{
 				throw new ArgumentException("Returned inflater was not a pooled one");
 			}
 
 			var pool = GetPool(inflater.noHeader);
-			if (pool.Count < 10)
+			if (pool.Count < SharpZipLibOptions.InflaterPoolSize)
 			{
 				pooledInflater.Reset();
 				pool.Enqueue(pooledInflater);

--- a/src/ICSharpCode.SharpZipLib/GZip/GzipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/GZip/GzipInputStream.cs
@@ -4,6 +4,7 @@ using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using System;
 using System.IO;
 using System.Text;
+using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.GZip
 {
@@ -82,7 +83,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 		/// Size of the buffer to use
 		/// </param>
 		public GZipInputStream(Stream baseInputStream, int size)
-			: base(baseInputStream, new Inflater(true), size)
+			: base(baseInputStream, InflaterPool.Instance.Rent(true), size)
 		{
 		}
 

--- a/src/ICSharpCode.SharpZipLib/SharpZipLibOptions.cs
+++ b/src/ICSharpCode.SharpZipLib/SharpZipLibOptions.cs
@@ -1,0 +1,15 @@
+﻿using ICSharpCode.SharpZipLib.Zip.Compression;
+
+namespace ICSharpCode.SharpZipLib
+{
+	/// <summary>
+	/// Global options to alter behavior.
+	/// </summary>
+	public static class SharpZipLibOptions
+	{
+		/// <summary>
+		/// The max pool size allowed for reusing <see cref="Inflater"/> instances, defaults to 0 (disabled).
+		/// </summary>
+		public static int InflaterPoolSize { get; set; } = 0;
+	}
+}

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Inflater.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Inflater.cs
@@ -137,7 +137,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 		/// True means, that the inflated stream doesn't contain a Zlib header or
 		/// footer.
 		/// </summary>
-		private bool noHeader;
+		internal bool noHeader;
 
 		private readonly StreamManipulator input;
 		private OutputWindow outputWindow;

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/PooledInflater.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/PooledInflater.cs
@@ -1,0 +1,14 @@
+﻿using ICSharpCode.SharpZipLib.Core;
+
+namespace ICSharpCode.SharpZipLib.Zip.Compression
+{
+	/// <summary>
+	/// A marker type for pooled version of an inflator that we can return back to <see cref="InflaterPool"/>.
+	/// </summary>
+	internal sealed class PooledInflater : Inflater
+	{
+		public PooledInflater(bool noHeader) : base(noHeader)
+		{
+		}
+	}
+}

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
+using ICSharpCode.SharpZipLib.Core;
 
 namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 {
@@ -339,7 +340,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// The InputStream to read bytes from
 		/// </param>
 		public InflaterInputStream(Stream baseInputStream)
-			: this(baseInputStream, new Inflater(), 4096)
+			: this(baseInputStream, InflaterPool.Instance.Rent(), 4096)
 		{
 		}
 
@@ -630,6 +631,12 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 					baseInputStream.Dispose();
 				}
 			}
+
+			if (inf is PooledInflater inflater)
+			{
+				InflaterPool.Instance.Return(inflater);
+			}
+			inf = null;
 		}
 
 		/// <summary>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -1,10 +1,11 @@
 using ICSharpCode.SharpZipLib.Checksum;
 using ICSharpCode.SharpZipLib.Encryption;
-using ICSharpCode.SharpZipLib.Zip.Compression;
 using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using System;
 using System.Diagnostics;
 using System.IO;
+using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.Zip.Compression;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -88,7 +89,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// </summary>
 		/// <param name="baseInputStream">The underlying <see cref="Stream"/> providing data.</param>
 		public ZipInputStream(Stream baseInputStream)
-			: base(baseInputStream, new Inflater(true))
+			: base(baseInputStream, InflaterPool.Instance.Rent(true))
 		{
 			internalReader = new ReadDataHandler(ReadingNotAvailable);
 		}
@@ -99,7 +100,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="baseInputStream">The underlying <see cref="Stream"/> providing data.</param>
 		/// <param name="bufferSize">Size of the buffer.</param>
 		public ZipInputStream(Stream baseInputStream, int bufferSize)
-			: base(baseInputStream, new Inflater(true), bufferSize)
+			: base(baseInputStream, InflaterPool.Instance.Rent(true), bufferSize)
 		{
 			internalReader = new ReadDataHandler(ReadingNotAvailable);
 		}


### PR DESCRIPTION
When traversing large zip files I noticed that SharpZipLib was allocating quite a lot of memory. So I found out that by pooling of costly `Inflator` instances a lot of that can be rectified. There's now new `PooledInflator` type that can be used by the library itself and is known to be safe to pool (it's rented from pool or is otherwise instance created by the library itself).

I also changed ZipFile to follow the common `public struct` enumerator pattern found in BCL data structures that removes unnecessary allocations 

Benchmark test case updated and now targets oldest supported runtimes (.NET 4.6.2 and .NET 6.0). Unsupported runtimes are not installed by default.

# Results

```

BenchmarkDotNet v0.13.7, Windows 11 (10.0.23516.1000)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 7.0.400
  [Host]     : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
  Job-ERDPDJ : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
  Job-HFJNUX : .NET Framework 4.8.1 (4.8.9179.0), X64 RyuJIT VectorSize=256


```

## ICSharpCode.SharpZipLib.Benchmark.Zip.ZipInputStream

| **Diff**|Method|Toolchain|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |ReadZipInputStream|.NET 6.0|151.4 ms|0.60 ms|104.54 KB|
| **New** |	| **.NET 6.0** | **151.7 ms (0%)** | **0.84 ms** | **72.15 KB (-31%)** |
| Old |ReadZipInputStream|.NET Framework 4.6.2|150.2 ms|0.50 ms|106.05 KB|
| **New** |	| **.NET Framework 4.6.2** | **150.8 ms (0%)** | **0.70 ms** | **74 KB (-30%)** |
| Old |ReadLargeZipFile|.NET 6.0|1,337.3 ms|8.18 ms|2412174.27 KB|
| **New** |	| **.NET 6.0** | **1,292.3 ms (-3%)** | **9.08 ms** | **548513.15 KB (-77%)** |
| Old |ReadLargeZipFile|.NET Framework 4.6.2|1,499.4 ms|11.41 ms|2421273.81 KB|
| **New** |	| **.NET Framework 4.6.2** | **1,452.4 ms (-3%)** | **3.35 ms** | **556703.89 KB (-77%)** |





_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._


