### PR TITLE
Adding logic to the inflator and deflator streams to use pooled buffers if possible and clear memory on Dispose()

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -432,6 +432,8 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 						baseOutputStream_.Dispose();
 					}
 				}
+
+				buffer_ = null;
 			}
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -236,7 +236,10 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// </param>
 		protected void EncryptBlock(byte[] buffer, int offset, int length)
 		{
-		    if(cryptoTransform_ is null) return;
+			if(cryptoTransform_ is null)
+			{
+				return;
+			}
 			cryptoTransform_.TransformBlock(buffer, 0, length, buffer, 0);
 		}
 

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -11,7 +11,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	/// <remarks>
 	/// The buffer supports decryption of incoming data.
 	/// </remarks>
-	public class InflaterInputBuffer
+	public class InflaterInputBuffer : IDisposable
 	{
 		#region Constructors
 
@@ -267,6 +267,25 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		public long ReadLeLong()
 		{
 			return (uint)ReadLeInt() | ((long)ReadLeInt() << 32);
+		}
+
+		/// <summary>
+		/// Implements the dispose method of the <see cref="IDisposable"/> interface.
+		/// </summary>
+		public void Dispose()
+		{
+			if(rawData != null)
+			{
+				rawData = null;
+			}
+			if(clearText != null)
+			{
+				clearText = null;
+			}
+			if(internalClearText != null)
+			{
+				internalClearText = null;
+			}
 		}
 
 		/// <summary>
@@ -637,6 +656,11 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 				InflaterPool.Instance.Return(inflater);
 			}
 			inf = null;
+
+			if(inputBuffer != null)
+			{
+				inputBuffer.Dispose();
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
This change allows the inflator and deflator streams to use pooled memory buffers, so they don't need to allocate and free buffers every time they are created. The change also frees the buffers on Dispose, so the GC can clean up memory more quickly.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
