### PR TITLE
Add net462 targeting

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,17 +19,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        target: [netstandard2.0, netstandard2.1, net6.0]
+        target: [netstandard2.0, netstandard2.1, net6.0, net462]
     env:
       LIB_PROJ: src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.events.inputs.tag }}
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
         
@@ -51,13 +51,13 @@ jobs:
         os: [ubuntu, macos]
         target: [net6.0]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup .NET Core
       if: matrix.target == 'net6.0'
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
 
@@ -73,44 +73,37 @@ jobs:
       
   CodeCov:
     name: Code Coverage
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
-      DOTCOVER_VER: 2021.1.2
-      DOTCOVER_PKG: jetbrains.dotcover.commandlinetools
+      DOTCOVER_VER: 2024.1.4
+      DOTCOVER_PKG: JetBrains.dotCover.CommandLineTools
       COVER_SNAPSHOT: SharpZipLib.dcvr
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
         
-    # NOTE: This is the temporary fix for https://github.com/actions/virtual-environments/issues/1090
-    - name: Cleanup before restore
-      run: dotnet clean ICSharpCode.SharpZipLib.sln && dotnet nuget locals all --clear
-   
     - name: Install codecov
-      run: nuget install -o tools -version ${{env.DOTCOVER_VER}} ${{env.DOTCOVER_PKG}}
-   
-    - name: Add dotcover to path
-      run: echo "$(pwd)\tools\${{env.DOTCOVER_PKG}}.${{env.DOTCOVER_VER}}\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      run: dotnet tool install ${{env.DOTCOVER_PKG}} --global --version ${{env.DOTCOVER_VER}}
    
     - name: Run tests with code coverage
-      run: dotcover dotnet --output=${{env.COVER_SNAPSHOT}} --filters=-:ICSharpCode.SharpZipLib.Tests -- test -c release
+      run: dotnet-dotCover dotnet --output=${{env.COVER_SNAPSHOT}} --filters=-:ICSharpCode.SharpZipLib.Tests -- test -c Release
    
     - name: Create code coverage report
-      run: dotcover report --source=${{env.COVER_SNAPSHOT}} --reporttype=detailedxml --output=dotcover-report.xml
+      run: dotnet-dotCover report --source=${{env.COVER_SNAPSHOT}} --reporttype=detailedxml --output=dotcover-report.xml
   
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.2.2
+      uses: codecov/codecov-action@v4
       with:
         files: dotcover-report.xml
         
     - name: Upload coverage snapshot artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Code coverage snapshot
         path: ${{env.COVER_SNAPSHOT}}
@@ -124,22 +117,18 @@ jobs:
       PKG_PROPS: '/p:ContinuousIntegrationBuild=true /p:EmbedUntrackedSources=true'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.events.inputs.tag }}
         fetch-depth: 0
       
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
         
-    - name: Build library for .NET Standard 2.0
-      run: dotnet build -c Release -f netstandard2.0 ${{ env.PKG_PROPS }} ${{ env.PKG_PROJ }}
-    - name: Build library for .NET Standard 2.1
-      run: dotnet build -c Release -f netstandard2.1 ${{ env.PKG_PROPS }} ${{ env.PKG_PROJ }}
-    - name: Build library for .NET 6.0
-      run: dotnet build -c Release -f net6.0  ${{ env.PKG_PROPS }} ${{ env.PKG_PROJ }}
+    - name: Build library
+      run: dotnet build -c Release ${{ env.PKG_PROPS }} ${{ env.PKG_PROJ }}
 
     - name: Add PR suffix to package
       if: ${{ github.event_name == 'pull_request' }}
@@ -159,7 +148,7 @@ jobs:
       run: dotnet pack ${{ env.PKG_PROJ }} -c Release --output dist ${{ env.PKG_PROPS }} /p:Version=${{ env.PKG_VERSION }}
 
     - name: Upload nuget package artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Nuget package
         path: dist/*.nupkg

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: windows-latest
     name: Generate DocFX documentation
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.events.inputs.tag }}
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
         
@@ -35,7 +35,7 @@ jobs:
       run: docfx docs/help/docfx.json --warningsAsErrors
 
     - name: Upload documentation as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: site
         path: docs/help/_site
@@ -46,10 +46,10 @@ jobs:
     name: Update github pages docs 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Artifacts # The built project is downloaded into the 'site' folder.
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: site
 

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -1,51 +1,45 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
-    <IsTrimmable>true</IsTrimmable>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../assets/ICSharpCode.SharpZipLib.snk</AssemblyOriginatorKeyFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net6.0</TargetFrameworks>
+		<IsTrimmable>true</IsTrimmable>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>../../assets/ICSharpCode.SharpZipLib.snk</AssemblyOriginatorKeyFile>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
-  
-  <!-- Nuget specific tags -->
-  <PropertyGroup>
-    <Version>1.4.2</Version>
-    <FileVersion>$(Version).13</FileVersion>
-    <AssemblyVersion>$(FileVersion)</AssemblyVersion>
-    <PackageId>SharpZipLib</PackageId>
-    <Company>ICSharpCode</Company>
-    <Authors>ICSharpCode</Authors>
-    <Description>SharpZipLib (#ziplib, formerly NZipLib) is a compression library for Zip, GZip, BZip2, and Tar written entirely in C# for .NET. It is implemented as an assembly (installable in the GAC), and thus can easily be incorporated into other projects (in any .NET language)</Description>
+	</PropertyGroup>
+
+	<!-- Nuget specific tags -->
+	<PropertyGroup>
+		<Version>1.4.2</Version>
+		<FileVersion>$(Version).13</FileVersion>
+		<AssemblyVersion>$(FileVersion)</AssemblyVersion>
+		<PackageId>SharpZipLib</PackageId>
+		<Company>ICSharpCode</Company>
+		<Authors>ICSharpCode</Authors>
+		<Description>SharpZipLib (#ziplib, formerly NZipLib) is a compression library for Zip, GZip, BZip2, and Tar written entirely in C# for .NET. It is implemented as an assembly (installable in the GAC), and thus can easily be incorporated into other projects (in any .NET language)</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageProjectUrl>http://icsharpcode.github.io/SharpZipLib/</PackageProjectUrl>
 		<PackageIcon>images/sharpziplib-nuget-256x256.png</PackageIcon>
-    <RepositoryUrl>https://github.com/icsharpcode/SharpZipLib</RepositoryUrl>
-    <Copyright>Copyright © 2000-2022 SharpZipLib Contributors</Copyright>
-    <PackageTags>Compression Library Zip GZip BZip2 LZW Tar</PackageTags>
-    <NeutralLanguage>en-US</NeutralLanguage>
-    <PackageReleaseNotes>
-Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.4.2 for more information.</PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/icsharpcode/SharpZipLib</PackageProjectUrl> 
-  </PropertyGroup>
+		<RepositoryUrl>https://github.com/icsharpcode/SharpZipLib</RepositoryUrl>
+		<Copyright>Copyright © 2000-2022 SharpZipLib Contributors</Copyright>
+		<PackageTags>Compression Library Zip GZip BZip2 LZW Tar</PackageTags>
+		<NeutralLanguage>en-US</NeutralLanguage>
+		<PackageReleaseNotes>
+			Please see https://github.com/icsharpcode/SharpZipLib/wiki/Release-1.4.2 for more information.
+		</PackageReleaseNotes>
+		<PackageProjectUrl>https://github.com/icsharpcode/SharpZipLib</PackageProjectUrl>
+	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462' ">
 		<PackageReference Include="System.Memory" Version="4.5.4" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>
-	   <None Include="../../assets/sharpziplib-nuget-256x256.png">
-      <Pack>True</Pack>
-      <PackagePath>images</PackagePath>
-    </None>
-	 </ItemGroup>
-	 
+		<None Include="../../assets/sharpziplib-nuget-256x256.png" Pack="True" PackagePath="images" />
+	</ItemGroup>
+
 </Project>

--- a/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
+++ b/test/ICSharpCode.SharpZipLib.Tests/ICSharpCode.SharpZipLib.Tests.csproj
@@ -1,37 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
 		<TargetFrameworks>net6.0;net462</TargetFrameworks>
-    <ApplicationIcon />
-    <StartupObject />
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\assets\ICSharpCode.SharpZipLib.snk</AssemblyOriginatorKeyFile>
-    <PublicSign>true</PublicSign>
+		<ApplicationIcon />
+		<StartupObject />
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>..\..\assets\ICSharpCode.SharpZipLib.snk</AssemblyOriginatorKeyFile>
+		<PublicSign>true</PublicSign>
 		<LangVersion>8.0</LangVersion>
-  </PropertyGroup>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="nunit.console" Version="3.16.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+		<PackageReference Include="nunit" Version="3.14.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\..\assets\ICSharpCode.SharpZipLib.snk">
-      <Link>ICSharpCode.SharpZipLib.snk</Link>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\assets\ICSharpCode.SharpZipLib.snk" Link="ICSharpCode.SharpZipLib.snk" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
It's not that much of a maintenance burden and will remove some compatibility issues for folks still on full framework. SharpZipLib 2.0 could drop support if deemed so.

Also had to update testing dependencies to get NET 8 support.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._

fixes #853
fixes #863