### PR TITLE
Make internal & private classes sealed when possible. Avoid double lookup in dictionary

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Core/StringBuilderPool.cs
+++ b/src/ICSharpCode.SharpZipLib/Core/StringBuilderPool.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace ICSharpCode.SharpZipLib.Core
 {
-	internal class StringBuilderPool
+	internal sealed class StringBuilderPool
 	{
 		public static StringBuilderPool Instance { get; } = new StringBuilderPool();
 		private readonly ConcurrentQueue<StringBuilder> pool = new ConcurrentQueue<StringBuilder>();

--- a/src/ICSharpCode.SharpZipLib/Encryption/PkzipClassic.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/PkzipClassic.cs
@@ -130,7 +130,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 	/// <summary>
 	/// PkzipClassic CryptoTransform for encryption.
 	/// </summary>
-	internal class PkzipClassicEncryptCryptoTransform : PkzipClassicCryptoBase, ICryptoTransform
+	internal sealed class PkzipClassicEncryptCryptoTransform : PkzipClassicCryptoBase, ICryptoTransform
 	{
 		/// <summary>
 		/// Initialise a new instance of <see cref="PkzipClassicEncryptCryptoTransform"></see>
@@ -240,7 +240,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 	/// <summary>
 	/// PkzipClassic CryptoTransform for decryption.
 	/// </summary>
-	internal class PkzipClassicDecryptCryptoTransform : PkzipClassicCryptoBase, ICryptoTransform
+	internal sealed class PkzipClassicDecryptCryptoTransform : PkzipClassicCryptoBase, ICryptoTransform
 	{
 		/// <summary>
 		/// Initialise a new instance of <see cref="PkzipClassicDecryptCryptoTransform"></see>.

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -15,7 +15,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 	/// Based on information from http://www.winzip.com/aes_info.htm
 	/// and http://www.gladman.me.uk/cryptography_technology/fileencrypt/
 	/// </remarks>
-	internal class ZipAESStream : CryptoStream
+	internal sealed class ZipAESStream : CryptoStream
 	{
 		/// <summary>
 		/// Constructor

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -6,7 +6,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 	/// <summary>
 	/// Transforms stream using AES in CTR mode
 	/// </summary>
-	internal class ZipAESTransform : ICryptoTransform
+	internal sealed class ZipAESTransform : ICryptoTransform
 	{
 		private const int PWD_VER_LENGTH = 2;
 

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterHuffman.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterHuffman.cs
@@ -60,7 +60,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 		private static short[] staticDCodes;
 		private static byte[] staticDLength;
 
-		private class Tree
+		private sealed class Tree
 		{
 			#region Instance Fields
 

--- a/src/ICSharpCode.SharpZipLib/Zip/Compression/InflaterDynHeader.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/Compression/InflaterDynHeader.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace ICSharpCode.SharpZipLib.Zip.Compression
 {
-	internal class InflaterDynHeader
+	internal sealed class InflaterDynHeader
 	{
 		#region Constants
 

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -2679,9 +2679,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		private int FindExistingUpdate(ZipEntry entry)
 		{
 			int result = -1;
-			if (updateIndex_.ContainsKey(entry.Name))
+			if (updateIndex_.TryGetValue(entry.Name, out int value))
 			{
-				result = (int)updateIndex_[entry.Name];
+				result = value;
 			}
 			/*
 						// This is slow like the coming of the next ice age but takes less storage and may be useful
@@ -2705,9 +2705,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			string convertedName = !isEntryName ? GetTransformedFileName(fileName) : fileName;
 
-			if (updateIndex_.ContainsKey(convertedName))
+			if (updateIndex_.TryGetValue(convertedName, out int value))
 			{
-				result = (int)updateIndex_[convertedName];
+				result = value;
 			}
 
 			/*
@@ -3030,7 +3030,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Class used to sort updates.
 		/// </summary>
-		private class UpdateComparer : IComparer<ZipUpdate>
+		private sealed class UpdateComparer : IComparer<ZipUpdate>
 		{
 			/// <summary>
 			/// Compares two objects and returns a value indicating whether one is
@@ -3252,7 +3252,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Represents a pending update to a Zip file.
 		/// </summary>
-		private class ZipUpdate
+		private sealed class ZipUpdate
 		{
 			#region Constructors
 
@@ -3911,7 +3911,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <summary>
 		/// Represents a string from a <see cref="ZipFile"/> which is stored as an array of bytes.
 		/// </summary>
-		private class ZipString
+		private sealed class ZipString
 		{
 			#region Constructors
 
@@ -4086,7 +4086,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// An <see cref="UncompressedStream"/> is a stream that you can write uncompressed data
 		/// to and flush, but cannot read, seek or do anything else to.
 		/// </summary>
-		private class UncompressedStream : Stream
+		private sealed class UncompressedStream : Stream
 		{
 			#region Constructors
 
@@ -4241,7 +4241,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// A <see cref="PartialInputStream"/> is an <see cref="InflaterInputStream"/>
 		/// whose data is only a part or subsection of a file.
 		/// </summary>
-		private class PartialInputStream : Stream
+		private sealed class PartialInputStream : Stream
 		{
 			#region Constructors
 


### PR DESCRIPTION
I ran the benchmarks, and there are no regressions, results are trending faster.
I ran it on my laptop, so the margin of error could be rather large.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
