### PR TITLE
Dispose some disposables

### DIFF
--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/ICSharpCode.SharpZipLib.Benchmark.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFrameworks>net462;net6.0</TargetFrameworks>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarInputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Tar/TarInputStream.cs
@@ -27,7 +27,7 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Tar
 					tarEntry.Size = 1024 * 1024;
 					zipOutputStream.PutNextEntry(tarEntry);
 
-					var rng = RandomNumberGenerator.Create();
+					using var rng = RandomNumberGenerator.Create();
 					var inputBuffer = new byte[1024];
 					rng.GetBytes(inputBuffer);
 

--- a/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
+++ b/benchmark/ICSharpCode.SharpZipLib.Benchmark/Zip/ZipOutputStream.cs
@@ -27,7 +27,7 @@ namespace ICSharpCode.SharpZipLib.Benchmark.Zip
 		{
 			using (var memoryStream = new MemoryStream(outputBuffer))
 			{
-				var zipOutputStream = new SharpZipLib.Zip.ZipOutputStream(memoryStream);
+				using var zipOutputStream = new SharpZipLib.Zip.ZipOutputStream(memoryStream);
 				zipOutputStream.PutNextEntry(new SharpZipLib.Zip.ZipEntry("0"));
 
 				for (int i = 0; i < ChunkCount; i++)

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESStream.cs
@@ -48,7 +48,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		// total length of block + auth code
 		private const int BLOCK_AND_AUTH = CRYPTO_BLOCK_SIZE + AUTH_CODE_LENGTH;
 
-		private Stream _stream;
+		private readonly Stream _stream;
 		private ZipAESTransform _transform;
 		private byte[] _slideBuffer;
 		private int _slideBufStartPos;

--- a/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
+++ b/src/ICSharpCode.SharpZipLib/Encryption/ZipAESTransform.cs
@@ -51,11 +51,11 @@ namespace ICSharpCode.SharpZipLib.Encryption
 
 			// Performs the equivalent of derive_key in Dr Brian Gladman's pwd2key.c
 #if NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER
-			var pdb = new Rfc2898DeriveBytes(key, saltBytes, KEY_ROUNDS, HashAlgorithmName.SHA1);
+			using var pdb = new Rfc2898DeriveBytes(key, saltBytes, KEY_ROUNDS, HashAlgorithmName.SHA1);
 #else
-			var pdb = new Rfc2898DeriveBytes(key, saltBytes, KEY_ROUNDS);
+			using var pdb = new Rfc2898DeriveBytes(key, saltBytes, KEY_ROUNDS);
 #endif
-			var rm = Aes.Create();
+			using var rm = Aes.Create();
 			rm.Mode = CipherMode.ECB;           // No feedback from cipher for CTR mode
 			_counterNonce = new byte[_blockSize];
 			byte[] key1bytes = pdb.GetBytes(_blockSize);
@@ -171,7 +171,11 @@ namespace ICSharpCode.SharpZipLib.Encryption
 		/// <summary>
 		/// Cleanup internal state.
 		/// </summary>
-		public void Dispose() => _encryptor.Dispose();
+		public void Dispose()
+		{
+			_encryptor.Dispose();
+			_hmacsha1.Dispose();
+		}
 
 		#endregion ICryptoTransform Members
 	}

--- a/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
+++ b/src/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+		<LangVersion>8.0</LangVersion>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <SignAssembly>true</SignAssembly>

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -863,7 +863,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			// TODO: This will be slow as the next ice age for huge archives!
 			for (int i = 0; i < entries_.Length; i++)
 			{
-				if (string.Compare(name, entries_[i].Name, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) == 0)
+				if (string.Equals(name, entries_[i].Name, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
 				{
 					return i;
 				}
@@ -1208,7 +1208,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				byte[] extraData = new byte[extraDataLength];
 				StreamUtils.ReadFully(baseStream_, extraData);
 
-				var localExtraData = new ZipExtraData(extraData);
+				using var localExtraData = new ZipExtraData(extraData);
 
 				// Extra data / zip64 checks
 				if (localExtraData.Find(headerID: 1))
@@ -2249,7 +2249,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				throw new ZipException("Entry name too long.");
 			}
 
-			var ed = new ZipExtraData(entry.ExtraData);
+			using var ed = new ZipExtraData(entry.ExtraData);
 
 			if (entry.LocalHeaderRequiresZip64)
 			{
@@ -2360,7 +2360,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			WriteLEShort(name.Length);
 
 			// Central header extra data is different to local header version so regenerate.
-			var ed = new ZipExtraData(entry.ExtraData);
+			using var ed = new ZipExtraData(entry.ExtraData);
 
 			if (entry.CentralHeaderRequiresZip64)
 			{
@@ -3795,7 +3795,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			{
 				if (entry.Version < ZipConstants.VersionStrongEncryption || !entry.HasFlag(GeneralBitFlags.StrongEncryption))
 				{
-					var classicManaged = new PkzipClassicManaged();
+					using var classicManaged = new PkzipClassicManaged();
 
 					OnKeysRequired(entry.Name);
 					if (HaveKeys == false)
@@ -3821,7 +3821,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			if (entry.Version >= ZipConstants.VersionStrongEncryption &&
 			    entry.HasFlag(GeneralBitFlags.StrongEncryption)) return null;
 
-			var classicManaged = new PkzipClassicManaged();
+			using var classicManaged = new PkzipClassicManaged();
 
 			OnKeysRequired(entry.Name);
 			if (HaveKeys == false)

--- a/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -766,7 +766,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <param name="password">The password.</param>
 		private void InitializeZipCryptoPassword(string password)
 		{
-			var pkManaged = new PkzipClassicManaged();
+			using var pkManaged = new PkzipClassicManaged();
 			byte[] key = PkzipClassic.GenerateKeys(ZipCryptoEncoding.GetBytes(password));
 			cryptoTransform_ = pkManaged.CreateEncryptor(key, null);
 		}


### PR DESCRIPTION
Added `LangVersion` 8 to be able to use `using` without scope, it could probably be higher, but I do not know the build pipeline and 8 was used elsewhere.

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
