### PR TITLE
Fix compression method for encrypted empty files and directories when updating a ZipFile

### DIFF
--- a/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -398,9 +398,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <exception cref="ZipException">
 		/// The file doesn't contain a valid zip archive.
 		/// </exception>
-		public ZipFile(string name) : 
-			this(name, null) 
-		{ 
+		public ZipFile(string name) :
+			this(name, null)
+		{
 
 		}
 
@@ -534,10 +534,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <exception cref="ArgumentNullException">
 		/// The <see cref="Stream">stream</see> argument is null.
 		/// </exception>
-		public ZipFile(Stream stream, bool leaveOpen) : 
-			this(stream, leaveOpen, null) 
-		{ 
-		
+		public ZipFile(Stream stream, bool leaveOpen) :
+			this(stream, leaveOpen, null)
+		{
+
 		}
 
 		/// <summary>
@@ -789,7 +789,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <inheritdoc cref="Zip.StringCodec"/>
 		public StringCodec StringCodec
 		{
-			set {
+			set
+			{
 				_stringCodec = value;
 				if (!isNewArchive_)
 				{
@@ -1182,7 +1183,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				bool testData = (tests & HeaderTest.Extract) != 0;
 
 				var entryAbsOffset = offsetOfFirstEntry + entry.Offset;
-				
+
 				baseStream_.Seek(entryAbsOffset, SeekOrigin.Begin);
 				var signature = (int)ReadLEUint();
 
@@ -1258,9 +1259,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 							throw new ZipException($"Version required to extract this entry not supported ({extractVersion})");
 						}
 
-						const GeneralBitFlags notSupportedFlags = GeneralBitFlags.Patched 
-																| GeneralBitFlags.StrongEncryption 
-																| GeneralBitFlags.EnhancedCompress 
+						const GeneralBitFlags notSupportedFlags = GeneralBitFlags.Patched
+																| GeneralBitFlags.StrongEncryption
+																| GeneralBitFlags.EnhancedCompress
 																| GeneralBitFlags.HeaderMasked;
 						if (localFlags.HasAny(notSupportedFlags))
 						{
@@ -1677,8 +1678,8 @@ namespace ICSharpCode.SharpZipLib.Zip
 				{
 					// Create an empty archive if none existed originally.
 					if (entries_.Length != 0) return;
-					byte[] theComment = (newComment_ != null) 
-						? newComment_.RawComment 
+					byte[] theComment = (newComment_ != null)
+						? newComment_.RawComment
 						: _stringCodec.ZipArchiveCommentEncoding.GetBytes(comment_);
 					ZipFormat.WriteEndOfCentralDirectory(baseStream_, 0, 0, 0, theComment);
 				}
@@ -2165,7 +2166,12 @@ namespace ICSharpCode.SharpZipLib.Zip
 						// No need to compress - no data.
 						entry.CompressedSize = entry.Size;
 						entry.Crc = 0;
-						entry.CompressionMethod = CompressionMethod.Stored;
+
+						// Crypted files should be deflated, even with no data (such as directories)
+						if (!HaveKeys)
+						{
+							entry.CompressionMethod = CompressionMethod.Stored;
+						}
 					}
 				}
 				else if (entry.CompressionMethod == CompressionMethod.Stored)
@@ -2583,15 +2589,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 		/// <returns>The descriptor size, zero if there isn't one.</returns>
 		private static int GetDescriptorSize(ZipUpdate update, bool includingSignature)
 		{
-			if (!((GeneralBitFlags)update.Entry.Flags).HasAny(GeneralBitFlags.Descriptor)) 
+			if (!((GeneralBitFlags)update.Entry.Flags).HasAny(GeneralBitFlags.Descriptor))
 				return 0;
-			
-			var descriptorWithSignature = update.Entry.LocalHeaderRequiresZip64 
-				? ZipConstants.Zip64DataDescriptorSize 
+
+			var descriptorWithSignature = update.Entry.LocalHeaderRequiresZip64
+				? ZipConstants.Zip64DataDescriptorSize
 				: ZipConstants.DataDescriptorSize;
 
-			return includingSignature 
-				? descriptorWithSignature 
+			return includingSignature
+				? descriptorWithSignature
 				: descriptorWithSignature - sizeof(int);
 		}
 
@@ -2878,7 +2884,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 			// Clumsy way of handling retrieving the original name and extra data length for now.
 			// TODO: Stop re-reading name and data length in CopyEntryDirect.
-			
+
 			uint nameLength = ReadLEUshort();
 			uint extraLength = ReadLEUshort();
 
@@ -3013,7 +3019,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 			finally
 			{
-				if(updateFile != baseStream_)
+				if (updateFile != baseStream_)
 					updateFile.Dispose();
 			}
 
@@ -3178,7 +3184,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				}
 
 				byte[] theComment = newComment_?.RawComment ?? _stringCodec.ZipArchiveCommentEncoding.GetBytes(comment_);
-				ZipFormat.WriteEndOfCentralDirectory(workFile.baseStream_, updateCount_, 
+				ZipFormat.WriteEndOfCentralDirectory(workFile.baseStream_, updateCount_,
 					sizeEntries, centralDirOffset, theComment);
 
 				endOfStream = workFile.baseStream_.Position;
@@ -3520,7 +3526,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		#endregion Reading
 
 		// NOTE this returns the offset of the first byte after the signature.
-		private long LocateBlockWithSignature(int signature, long endLocation, int minimumBlockSize, int maximumVariableData) 
+		private long LocateBlockWithSignature(int signature, long endLocation, int minimumBlockSize, int maximumVariableData)
 			=> ZipFormat.LocateBlockWithSignature(baseStream_, signature, endLocation, minimumBlockSize, maximumVariableData);
 
 		/// <summary>
@@ -3578,14 +3584,14 @@ namespace ICSharpCode.SharpZipLib.Zip
 			}
 
 			bool isZip64 = false;
-			
+
 			// Check if zip64 header information is required.
 			bool requireZip64 = thisDiskNumber == 0xffff ||
-			                    startCentralDirDisk == 0xffff ||
-			                    entriesForThisDisk == 0xffff ||
-			                    entriesForWholeCentralDir == 0xffff ||
-			                    centralDirSize == 0xffffffff ||
-			                    offsetOfCentralDir == 0xffffffff;
+								startCentralDirDisk == 0xffff ||
+								entriesForThisDisk == 0xffff ||
+								entriesForWholeCentralDir == 0xffff ||
+								centralDirSize == 0xffffffff ||
+								offsetOfCentralDir == 0xffffffff;
 
 			// #357 - always check for the existence of the Zip64 central directory.
 			// #403 - Take account of the fixed size of the locator when searching.
@@ -3676,7 +3682,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 				int extraLen = ReadLEUshort();
 				int commentLen = ReadLEUshort();
 
-				
+
 				// ReSharper disable once UnusedVariable, Currently unused but needs to be read to offset the stream
 				int diskStartNo = ReadLEUshort();
 				// ReSharper disable once UnusedVariable, Currently unused but needs to be read to offset the stream
@@ -3773,9 +3779,9 @@ namespace ICSharpCode.SharpZipLib.Zip
 					int saltLen = entry.AESSaltLen;
 					byte[] saltBytes = new byte[saltLen];
 					int saltIn = StreamUtils.ReadRequestedBytes(baseStream, saltBytes, offset: 0, saltLen);
-					
+
 					if (saltIn != saltLen) throw new ZipException($"AES Salt expected {saltLen} git {saltIn}");
-					
+
 					byte[] pwdVerifyRead = new byte[2];
 					StreamUtils.ReadFully(baseStream, pwdVerifyRead);
 					int blockSize = entry.AESKeySize / 8;   // bits to bytes
@@ -3819,7 +3825,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 		private Stream CreateAndInitEncryptionStream(Stream baseStream, ZipEntry entry)
 		{
 			if (entry.Version >= ZipConstants.VersionStrongEncryption &&
-			    entry.HasFlag(GeneralBitFlags.StrongEncryption)) return null;
+				entry.HasFlag(GeneralBitFlags.StrongEncryption)) return null;
 
 			var classicManaged = new PkzipClassicManaged();
 


### PR DESCRIPTION
I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License.

Fixes this issue: https://github.com/icsharpcode/SharpZipLib/issues/885

This PR fixes an issue that is encountered when calling `ZipInputStream.GetNextEntry()` on an encrypted zip that contains a directory which was added using  `ZipFile.AddDirectory()`.

`ZipFile.AddDirectory()` adds an empty file with compression method set to Deflated but when running updates, will set this method to Stored as it is an empty file. `ZipInputStream` will observe that it is stored, crypted, and that the compressed size (0) less a crypto header size is not equal to the file size. This is because `ZipFile` will not write an encryption header for files that are zero length.

When creating a directory with ZipOutputStream, the directory is NOT set to Stored despite being empty


```
if (method == CompressionMethod.Stored && (!isCrypted && csize != size || (isCrypted && csize - ZipConstants.CryptoHeaderSize != size)))
{
	throw new ZipException("Stored, but compressed != uncompressed");
}
```

This PR makes a change so as to not set the compression method to stored for files that are zero length if they are encrypted. It also adds a unit test to ensure that it works, this unit test failed before the fix was implemented. This PR also has formatting/linting changes which were automatically done by my code editor

<!---
Please remember that unless we have a Joint Copyright Agreement on file or the following statement is in your pull request, we cannot accept it.
-->
_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the SharpZipLib open source product (the "Contribution"). My Contribution is licensed under the MIT License._
